### PR TITLE
Modify build step in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -60,7 +60,7 @@ jobs:
           git commit -m "Add version ${{ github.event.inputs.release_version }}"
           git push origin ${{ env.release_branch_name }}
       - name: Run tests and build
-        run: mvn clean package
+        run: mvn clean install
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         id: sds_sdk_release


### PR DESCRIPTION
This PR adjusts the build step of the Maven release workflow to install the artifacts instead of just packaging them.