### PR TITLE
set version for documentation in main

### DIFF
--- a/documentation/developer-guide/antora.yml
+++ b/documentation/developer-guide/antora.yml
@@ -1,6 +1,6 @@
 name: sds-developer-guide
 title: SDS SDK Developer Guide
-version: '1.0.0'
+version: 'dev-snapshot'
 start_page: ROOT:index.adoc
 nav:
   - modules/getting-started-guide/nav.adoc


### PR DESCRIPTION
Set the version in the antora.yml to dev-snapshot to avoid version number collisions with already released versions of the SDS-SDK.