### PR TITLE
Handle models with any number of Aspects in artifact generators

### DIFF
--- a/core/sds-aspect-meta-model-interface/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/AspectMetaModelResourceResolver.java
+++ b/core/sds-aspect-meta-model-interface/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/AspectMetaModelResourceResolver.java
@@ -44,20 +44,6 @@ public interface AspectMetaModelResourceResolver {
    Try<VersionedModel> mergeMetaModelIntoRawModel( final Model rawModel, final VersionNumber version );
 
    /**
-    * Parses an Aspect (meta) model URN into an {@link AspectModelUrn}
-    *
-    * @param uri The Aspect (meta) model URN
-    * @return The {@link AspectModelUrn} if parsing succeeds, an {@link UrnSyntaxException} otherwise
-    */
-   default Try<AspectModelUrn> getAspectModelUrn( final String uri ) {
-      try {
-         return Try.success( AspectModelUrn.fromUrn( uri ) );
-      } catch ( final UrnSyntaxException exception ) {
-         return Try.failure( exception );
-      }
-   }
-
-   /**
     * Retrieves the meta model version an Aspect model uses
     *
     * @param model The RDF model containing an Aspect Model

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/AspectContext.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/AspectContext.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package io.openmanufacturing.sds.metamodel;
+
+import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+
+public record AspectContext(VersionedModel rdfModel, Aspect aspect) {
+}

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/AspectContext.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/AspectContext.java
@@ -15,5 +15,11 @@ package io.openmanufacturing.sds.metamodel;
 
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 
+/**
+ * The AspectContext wraps a loaded/resolved Aspect Model and a single Aspect that was instantiated from this model, i.e.,
+ * which must be defined in the RDF model.
+ * @param rdfModel the RDF model
+ * @param aspect the Aspect
+ */
 public record AspectContext(VersionedModel rdfModel, Aspect aspect) {
 }

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/MetaModelBaseAttributes.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/MetaModelBaseAttributes.java
@@ -203,7 +203,7 @@ public class MetaModelBaseAttributes {
          throw new AspectLoadingException( "At least one anonymous node in the model does not have a parent with a regular name." );
       }
       final String parentModelElementUri = namedParent.getURI();
-      final String parentModelElementName = metaModelResourceResolver.getAspectModelUrn( parentModelElementUri )
+      final String parentModelElementName = AspectModelUrn.from( parentModelElementUri )
             .toJavaOptional()
             .map( AspectModelUrn::getName )
             .map( StringUtils::capitalize )
@@ -211,7 +211,7 @@ public class MetaModelBaseAttributes {
 
       final Resource modelElementType = getModelElementType( modelElement, bamm );
       final String modelElementTypeUri = modelElementType.getURI();
-      final String modelElementTypeName = metaModelResourceResolver.getAspectModelUrn( modelElementTypeUri )
+      final String modelElementTypeName = AspectModelUrn.from( modelElementTypeUri )
             .toJavaOptional()
             .map( AspectModelUrn::getName )
             .orElse( "" );

--- a/core/sds-aspect-meta-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/services/SdsAspectMetaModelResourceResolver.java
+++ b/core/sds-aspect-meta-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/services/SdsAspectMetaModelResourceResolver.java
@@ -220,7 +220,7 @@ public class SdsAspectMetaModelResourceResolver implements AspectMetaModelResour
             .map( RDFNode::asResource )
             .map( Resource::getURI )
             .filter( uri -> uri.startsWith( bammUrnStart ) )
-            .flatMap( uri -> getAspectModelUrn( uri ).toJavaStream() )
+            .flatMap( uri -> AspectModelUrn.from( uri ).toJavaStream() )
             .filter( urn -> (urn.getElementType().equals( ElementType.META_MODEL ) || urn.getElementType().equals( ElementType.CHARACTERISTIC )) )
             .map( AspectModelUrn::getVersion )
             .map( VersionNumber::parse )

--- a/core/sds-aspect-meta-model-resolver/src/test/java/io/openmanufacturing/sds/aspectmodel/resolver/services/SdsAspectMetaModelResourceResolverTest.java
+++ b/core/sds-aspect-meta-model-resolver/src/test/java/io/openmanufacturing/sds/aspectmodel/resolver/services/SdsAspectMetaModelResourceResolverTest.java
@@ -27,8 +27,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.openmanufacturing.sds.aspectmetamodel.KnownVersion;
-import io.openmanufacturing.sds.aspectmodel.VersionNumber;
 import io.openmanufacturing.sds.aspectmodel.MissingMetaModelVersionException;
+import io.openmanufacturing.sds.aspectmodel.VersionNumber;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.test.MetaModelVersions;
 import io.vavr.control.Try;
@@ -82,20 +82,18 @@ public class SdsAspectMetaModelResourceResolverTest extends MetaModelVersions {
    @ParameterizedTest
    @MethodSource( "allVersions" )
    public void testGetAspectModelUrnExpectSuccess( final KnownVersion metaModelVersion ) {
-      final Try<AspectModelUrn> aspectModelUrn = aspectMetaModelResourceResolver.getAspectModelUrn(
+      final Try<AspectModelUrn> aspectModelUrn = AspectModelUrn.from(
             "urn:bamm:io.openmanufacturing:meta-model:" + metaModelVersion.toVersionString() + "#Aspect" );
       assertThat( aspectModelUrn ).isSuccess();
       org.assertj.core.api.Assertions.assertThat( aspectModelUrn.get().getUrn().toString() )
-                                     .isEqualTo( "urn:bamm:io.openmanufacturing:meta-model:" + metaModelVersion
-                                           .toVersionString() + "#Aspect" );
+            .isEqualTo( "urn:bamm:io.openmanufacturing:meta-model:" + metaModelVersion
+                  .toVersionString() + "#Aspect" );
    }
 
    @ParameterizedTest
    @MethodSource( "allVersions" )
    public void testGetAspectModelUrnInvalidUrnExpectFailure( final KnownVersion metaModelVersion ) {
-      final Try<AspectModelUrn> aspectModelUrn = aspectMetaModelResourceResolver
-            .getAspectModelUrn(
-                  "urn:foo:io.openmanufacturing:meta-model:" + metaModelVersion.toVersionString() );
+      final Try<AspectModelUrn> aspectModelUrn = AspectModelUrn.from( "urn:foo:io.openmanufacturing:meta-model:" + metaModelVersion.toVersionString() );
       assertThat( aspectModelUrn ).isFailure();
    }
 
@@ -120,7 +118,7 @@ public class SdsAspectMetaModelResourceResolverTest extends MetaModelVersions {
       final Model model = aspectMetaModelResourceResolver.loadMetaModel( metaModelVersion ).get();
 
       org.assertj.core.api.Assertions.assertThat( model.contains( ResourceFactory.createResource(
-            "urn:bamm:io.openmanufacturing:meta-model:" + metaModelVersion.toVersionString() + "#value" ),
+                  "urn:bamm:io.openmanufacturing:meta-model:" + metaModelVersion.toVersionString() + "#value" ),
             RDF.type, (RDFNode) null ) ).isTrue();
    }
 }

--- a/core/sds-aspect-model-aas-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/aas/AspectModelAASGeneratorTest.java
+++ b/core/sds-aspect-model-aas-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/aas/AspectModelAASGeneratorTest.java
@@ -264,7 +264,7 @@ class AspectModelAASGeneratorTest {
 
    private Aspect loadAspect( final TestAspect testAspect ) {
       final VersionedModel model = TestResources.getModel( testAspect, KnownVersion.getLatest() ).get();
-      return AspectModelLoader.fromVersionedModelUnchecked( model );
+      return AspectModelLoader.getSingleAspectUnchecked( model );
    }
 
    private AssetAdministrationShellEnvironment loadAASX( final ByteArrayOutputStream byteStream ) throws DeserializationException {

--- a/core/sds-aspect-model-document-generators/src/main/java/io/openmanufacturing/sds/aspectmodel/generator/AspectModelHelper.java
+++ b/core/sds-aspect-model-document-generators/src/main/java/io/openmanufacturing/sds/aspectmodel/generator/AspectModelHelper.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.aspectmetamodel.KnownVersion;
 import io.openmanufacturing.sds.metamodel.Aspect;
 import io.openmanufacturing.sds.metamodel.ModelElement;
 import io.openmanufacturing.sds.metamodel.ComplexType;
@@ -35,14 +35,14 @@ import io.openmanufacturing.sds.metamodel.Type;
 import io.openmanufacturing.sds.metamodel.visitor.AspectStreamTraversalVisitor;
 
 public class AspectModelHelper {
-   private final VersionedModel modelVersion;
+   private final KnownVersion metaModelVersion;
 
-   public AspectModelHelper( final VersionedModel modelVersion ) {
-      this.modelVersion = modelVersion;
+   public AspectModelHelper( final KnownVersion metaModelVersion ) {
+      this.metaModelVersion = metaModelVersion;
    }
 
-   public VersionedModel getModelVersion() {
-      return modelVersion;
+   public KnownVersion getMetaModelVersion() {
+      return metaModelVersion;
    }
 
    public static List<Property> sortPropertiesByPreferredName( final List<Property> properties, final Locale locale ) {

--- a/core/sds-aspect-model-document-generators/src/main/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGenerator.java
+++ b/core/sds-aspect-model-document-generators/src/main/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGenerator.java
@@ -58,7 +58,6 @@ import io.openmanufacturing.sds.aspectmodel.generator.AbstractGenerator;
 import io.openmanufacturing.sds.aspectmodel.generator.NumericTypeTraits;
 import io.openmanufacturing.sds.aspectmodel.jackson.AspectModelJacksonModule;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.DataType;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.aspectmodel.vocabulary.BAMM;
 import io.openmanufacturing.sds.characteristic.Collection;
 import io.openmanufacturing.sds.characteristic.Either;
@@ -70,6 +69,7 @@ import io.openmanufacturing.sds.constraint.RangeConstraint;
 import io.openmanufacturing.sds.constraint.RegularExpressionConstraint;
 import io.openmanufacturing.sds.metamodel.AbstractEntity;
 import io.openmanufacturing.sds.metamodel.Aspect;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import io.openmanufacturing.sds.metamodel.Characteristic;
 import io.openmanufacturing.sds.metamodel.ComplexType;
 import io.openmanufacturing.sds.metamodel.Constraint;
@@ -81,7 +81,6 @@ import io.openmanufacturing.sds.metamodel.Type;
 import io.openmanufacturing.sds.metamodel.Value;
 import io.openmanufacturing.sds.metamodel.datatypes.Curie;
 import io.openmanufacturing.sds.metamodel.impl.BoundDefinition;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 
 public class AspectModelJsonPayloadGenerator extends AbstractGenerator {
    /**
@@ -102,8 +101,8 @@ public class AspectModelJsonPayloadGenerator extends AbstractGenerator {
       this( aspect, new BAMM( aspect.getMetaModelVersion() ), new Random() );
    }
 
-   public AspectModelJsonPayloadGenerator( final VersionedModel versionedModel ) {
-      this( AspectModelLoader.fromVersionedModelUnchecked( versionedModel ) );
+   public AspectModelJsonPayloadGenerator( final AspectContext context ) {
+      this( context.aspect() );
    }
 
    public AspectModelJsonPayloadGenerator( final Aspect aspect, final Random randomStrategy ) {

--- a/core/sds-aspect-model-document-generators/src/main/resources/docu/templates/html/characteristic-documentation-lib.vm
+++ b/core/sds-aspect-model-document-generators/src/main/resources/docu/templates/html/characteristic-documentation-lib.vm
@@ -38,7 +38,7 @@
         #if( !$characteristic.getDataType().get().is( $Scalar ) )
             <a href="#$aspectModelHelper.getNameFromURN( $characteristic.getDataType().get().getUrn() )-entity"
         #else
-            <a href="https://openmanufacturingplatform.github.io/sds-bamm-aspect-meta-model/bamm-specification/v$aspectModelHelper.getModelVersion().getMetaModelVersion().toString()/datatypes.html" target="_blank"
+            <a href="https://openmanufacturingplatform.github.io/sds-bamm-aspect-meta-model/bamm-specification/v$aspectModelHelper.getMetaModelVersion().toString()/datatypes.html" target="_blank"
         #end
         class="break-all underline">$characteristic.getDataType().get().getUrn()</a>
     #end

--- a/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/docu/AspectModelDocumentationGeneratorTest.java
+++ b/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/docu/AspectModelDocumentationGeneratorTest.java
@@ -13,7 +13,8 @@
 
 package io.openmanufacturing.sds.aspectmodel.generator.docu;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.BufferedWriter;
@@ -31,6 +32,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.openmanufacturing.sds.aspectmetamodel.KnownVersion;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.metamodel.Aspect;
+import io.openmanufacturing.sds.metamodel.AspectContext;
+import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 import io.openmanufacturing.sds.test.MetaModelVersions;
 import io.openmanufacturing.sds.test.TestAspect;
 import io.openmanufacturing.sds.test.TestResources;
@@ -192,7 +196,9 @@ public class AspectModelDocumentationGeneratorTest extends MetaModelVersions {
 
    private String generateHtmlDocumentation( final TestAspect model, final KnownVersion testedVersion ) throws IOException {
       final VersionedModel versionedModel = TestResources.getModel( model, testedVersion ).get();
-      final AspectModelDocumentationGenerator aspectModelDocumentationGenerator = new AspectModelDocumentationGenerator( versionedModel );
+      final Aspect aspect = AspectModelLoader.getSingleAspect( versionedModel ).getOrElseThrow( () -> new RuntimeException() );
+      final AspectContext context = new AspectContext( versionedModel, aspect );
+      final AspectModelDocumentationGenerator aspectModelDocumentationGenerator = new AspectModelDocumentationGenerator( context );
 
       try ( final ByteArrayOutputStream result = new ByteArrayOutputStream() ) {
          aspectModelDocumentationGenerator.generate( name -> result, Collections.EMPTY_MAP );

--- a/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -94,22 +94,24 @@ import io.openmanufacturing.sds.aspectmodel.resolver.services.DataType;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.aspectmodel.vocabulary.BAMM;
+import io.openmanufacturing.sds.characteristic.Trait;
+import io.openmanufacturing.sds.characteristic.impl.DefaultTrait;
+import io.openmanufacturing.sds.constraint.RangeConstraint;
+import io.openmanufacturing.sds.constraint.impl.DefaultRangeConstraint;
 import io.openmanufacturing.sds.metamodel.Aspect;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import io.openmanufacturing.sds.metamodel.Characteristic;
 import io.openmanufacturing.sds.metamodel.Property;
-import io.openmanufacturing.sds.constraint.RangeConstraint;
 import io.openmanufacturing.sds.metamodel.ScalarValue;
-import io.openmanufacturing.sds.characteristic.Trait;
 import io.openmanufacturing.sds.metamodel.Type;
 import io.openmanufacturing.sds.metamodel.datatypes.LangString;
 import io.openmanufacturing.sds.metamodel.impl.BoundDefinition;
 import io.openmanufacturing.sds.metamodel.impl.DefaultAspect;
 import io.openmanufacturing.sds.metamodel.impl.DefaultCharacteristic;
 import io.openmanufacturing.sds.metamodel.impl.DefaultProperty;
-import io.openmanufacturing.sds.constraint.impl.DefaultRangeConstraint;
 import io.openmanufacturing.sds.metamodel.impl.DefaultScalar;
 import io.openmanufacturing.sds.metamodel.impl.DefaultScalarValue;
-import io.openmanufacturing.sds.characteristic.impl.DefaultTrait;
+import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 import io.openmanufacturing.sds.metamodel.loader.MetaModelBaseAttributes;
 import io.openmanufacturing.sds.test.MetaModelVersions;
 import io.openmanufacturing.sds.test.TestAspect;
@@ -580,7 +582,8 @@ public class AspectModelJsonPayloadGeneratorTest extends MetaModelVersions {
 
    private String generateJsonForModel( final TestAspect model, final KnownVersion testedVersion ) {
       final VersionedModel versionedModel = TestResources.getModel( model, testedVersion ).get();
-      final AspectModelJsonPayloadGenerator jsonGenerator = new AspectModelJsonPayloadGenerator( versionedModel );
+      final Aspect aspect = AspectModelLoader.getSingleAspectUnchecked( versionedModel );
+      final AspectModelJsonPayloadGenerator jsonGenerator = new AspectModelJsonPayloadGenerator( new AspectContext( versionedModel, aspect ) );
       try {
          return jsonGenerator.generateJson();
       } catch ( final IOException e ) {

--- a/core/sds-aspect-model-java-generator/pom.xml
+++ b/core/sds-aspect-model-java-generator/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.soabase.record-builder</groupId>
+            <artifactId>record-builder-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -167,6 +172,11 @@
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
                             <version>${lombok-version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.soabase.record-builder</groupId>
+                            <artifactId>record-builder-processor</artifactId>
+                            <version>${record-builder-version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaUtil.java
@@ -92,7 +92,7 @@ public class AspectModelJavaUtil {
          return "Object";
       }
       final String propertyType = determinePropertyType( property.getCharacteristic(), false, codeGenerationConfig );
-      codeGenerationConfig.getImportTracker().trackPotentiallyParameterizedType( propertyType );
+      codeGenerationConfig.importTracker().trackPotentiallyParameterizedType( propertyType );
       if ( property.isOptional() ) {
          return containerType( Optional.class, propertyType, Optional.empty() );
       }
@@ -156,10 +156,10 @@ public class AspectModelJavaUtil {
       }
 
       if ( characteristic.is( Either.class ) ) {
-         if ( codeGenerationConfig.doEnableJacksonAnnotations() ) {
-            codeGenerationConfig.getImportTracker().importExplicit( "io.openmanufacturing.sds.aspectmodel.jackson.Either" );
+         if ( codeGenerationConfig.enableJacksonAnnotations() ) {
+            codeGenerationConfig.importTracker().importExplicit( "io.openmanufacturing.sds.aspectmodel.jackson.Either" );
          } else {
-            codeGenerationConfig.getImportTracker().importExplicit( io.openmanufacturing.sds.aspectmodel.java.types.Either.class );
+            codeGenerationConfig.importTracker().importExplicit( io.openmanufacturing.sds.aspectmodel.java.types.Either.class );
          }
          final String left = determinePropertyType(
                optionalCharacteristic.map( c -> c.as( Either.class ) ).map( Either::getLeft ), inclValidation, codeGenerationConfig );
@@ -168,18 +168,18 @@ public class AspectModelJavaUtil {
          return String.format( "Either<%s,%s>", left, right );
       }
 
-      return getDataType( dataType, codeGenerationConfig.getImportTracker() );
+      return getDataType( dataType, codeGenerationConfig.importTracker() );
    }
 
    public static String determineCollectionAspectClassDefinition( final StructureElement element, final JavaCodeGenerationConfig codeGenerationConfig ) {
       final Supplier<RuntimeException> error = () -> new CodeGenerationException(
             "Tried to generate a Collection Aspect class definition, but no " + "Property has a Collection Characteristic in " + element.getName() );
-      codeGenerationConfig.getImportTracker().importExplicit( CollectionAspect.class );
+      codeGenerationConfig.importTracker().importExplicit( CollectionAspect.class );
       for ( final Property property : element.getProperties() ) {
          final Characteristic characteristic = property.getEffectiveCharacteristic().orElseThrow( error );
          if ( characteristic instanceof Collection ) {
             final String collectionType = determineCollectionType( (Collection) characteristic, false, codeGenerationConfig );
-            final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.getImportTracker() );
+            final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.importTracker() );
             return String.format( "public class %s implements CollectionAspect<%s,%s>", element.getName(), collectionType, dataType );
          }
       }
@@ -212,8 +212,8 @@ public class AspectModelJavaUtil {
          final Set<ComplexType> extendingEntities ) {
       final StringBuilder classAnnotationBuilder = new StringBuilder();
       if ( element.isAbstractEntity() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( JsonTypeInfo.class );
-         codeGenerationConfig.getImportTracker().importExplicit( JsonSubTypes.class );
+         codeGenerationConfig.importTracker().importExplicit( JsonTypeInfo.class );
+         codeGenerationConfig.importTracker().importExplicit( JsonSubTypes.class );
 
          final AbstractEntity abstractEntity = (AbstractEntity) element;
          classAnnotationBuilder.append( "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)" );
@@ -249,20 +249,20 @@ public class AspectModelJavaUtil {
       final Optional<String> elementConstraint = inclValidation ? buildConstraintForCollectionElements( collection, codeGenerationConfig ) : Optional.empty();
 
       if ( collection.isAllowDuplicates() && collection.isOrdered() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( List.class );
-         return containerType( List.class, getDataType( dataType, codeGenerationConfig.getImportTracker() ), elementConstraint );
+         codeGenerationConfig.importTracker().importExplicit( List.class );
+         return containerType( List.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && collection.isOrdered() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( LinkedHashSet.class );
-         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.getImportTracker() ), elementConstraint );
+         codeGenerationConfig.importTracker().importExplicit( LinkedHashSet.class );
+         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
       }
       if ( collection.isAllowDuplicates() && !collection.isOrdered() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( java.util.Collection.class );
-         return containerType( java.util.Collection.class, getDataType( dataType, codeGenerationConfig.getImportTracker() ), elementConstraint );
+         codeGenerationConfig.importTracker().importExplicit( java.util.Collection.class );
+         return containerType( java.util.Collection.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && !collection.isOrdered() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( Set.class );
-         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.getImportTracker() ), elementConstraint );
+         codeGenerationConfig.importTracker().importExplicit( Set.class );
+         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
       }
       throw new CodeGenerationException( "Could not determine Java collection type for " + collection.getName() );
    }
@@ -353,7 +353,7 @@ public class AspectModelJavaUtil {
     */
    public static String applyImports( final String body, final JavaCodeGenerationConfig codeGenerationConfig ) {
       String importsApplied = body;
-      for ( final String oneImport : codeGenerationConfig.getImportTracker().getUsedImports() ) {
+      for ( final String oneImport : codeGenerationConfig.importTracker().getUsedImports() ) {
          final String className = oneImport.substring( oneImport.lastIndexOf( '.' ) + 1 );
          importsApplied = importsApplied.replaceAll( oneImport, className );
       }
@@ -362,7 +362,7 @@ public class AspectModelJavaUtil {
 
    public static boolean isPropertyNotInPayload( final Property property, final JavaCodeGenerationConfig codeGenerationConfig ) {
       if ( property.isNotInPayload() ) {
-         codeGenerationConfig.getImportTracker().importExplicit( "com.fasterxml.jackson.annotation.JsonIgnore" );
+         codeGenerationConfig.importTracker().importExplicit( "com.fasterxml.jackson.annotation.JsonIgnore" );
          return true;
       }
       return false;
@@ -370,7 +370,7 @@ public class AspectModelJavaUtil {
 
    public static String buildConstraintsForCharacteristic( final Trait trait, final JavaCodeGenerationConfig codeGenerationConfig ) {
       return trait.getConstraints().stream()
-            .map( constraint -> new ConstraintAnnotationBuilder().setConstraintClass( constraint ).setImportTracker( codeGenerationConfig.getImportTracker() )
+            .map( constraint -> new ConstraintAnnotationBuilder().setConstraintClass( constraint ).setImportTracker( codeGenerationConfig.importTracker() )
                   .build() ).collect( Collectors.joining() );
    }
 
@@ -410,7 +410,7 @@ public class AspectModelJavaUtil {
          final Resource typeResource = ResourceFactory.createResource( type.getUrn() );
          final KnownVersion metaModelVersion = property.getMetaModelVersion();
          final Class<?> result = DataType.getJavaTypeForMetaModelType( typeResource, metaModelVersion );
-         codeGenerationConfig.getImportTracker().importExplicit( result );
+         codeGenerationConfig.importTracker().importExplicit( result );
          return valueInitializer.apply( typeResource, value, metaModelVersion );
       } ).orElseThrow( () -> new CodeGenerationException( "The Either Characteristic is not allowed for Properties used as elements in a StructuredValue" ) );
    }
@@ -442,7 +442,7 @@ public class AspectModelJavaUtil {
    public static String getCharacteristicJavaType( final Property property, final JavaCodeGenerationConfig codeGenerationConfig ) {
       final Supplier<RuntimeException> error = () -> new CodeGenerationException( "No data type found for Property " + property.getName() );
       if ( hasContainerType( property ) ) {
-         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.getImportTracker() );
+         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.importTracker() );
       }
 
       return property.getEffectiveCharacteristic().flatMap( Characteristic::getDataType ).map( type -> {

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -17,69 +17,31 @@ import java.io.File;
 
 import io.openmanufacturing.sds.aspectmodel.generator.GenerationConfig;
 import io.openmanufacturing.sds.aspectmodel.java.exception.CodeGenerationException;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
 /**
  * A {@link GenerationConfig} for Java code
  */
-public class JavaCodeGenerationConfig implements GenerationConfig {
-   private final boolean enableJacksonAnnotations;
-   private final String packageName;
-   private final ImportTracker importTracker;
-   private final boolean executeLibraryMacros;
-   private final File templateLibFile;
-
-   public JavaCodeGenerationConfig( final boolean enableJacksonAnnotations, final String packageName, final boolean executeLibraryMacros,
-         final File templateLibFile ) {
-      this.enableJacksonAnnotations = enableJacksonAnnotations;
-      this.packageName = packageName;
-      importTracker = new ImportTracker();
-
-      validateTemplateLibConfig( executeLibraryMacros, templateLibFile );
-      this.executeLibraryMacros = executeLibraryMacros;
-      this.templateLibFile = templateLibFile;
-   }
-
-   private void validateTemplateLibConfig( final boolean executeLibraryMacros, final File templateLibFile ) {
-      if ( executeLibraryMacros && ( templateLibFile == null || templateLibFile.toString().isEmpty() ) ) {
+@RecordBuilder
+public record JavaCodeGenerationConfig (
+      boolean enableJacksonAnnotations,
+      String packageName,
+      ImportTracker importTracker,
+      boolean executeLibraryMacros,
+      File templateLibFile
+) implements GenerationConfig {
+   public JavaCodeGenerationConfig {
+      if ( packageName == null ) {
+         packageName = "";
+      }
+      if ( importTracker == null ) {
+         importTracker = new ImportTracker();
+      }
+      if ( executeLibraryMacros && (templateLibFile == null || templateLibFile.toString().isEmpty()) ) {
          throw new CodeGenerationException( "Missing configuration. Please provide path to velocity template library file." );
       }
       if ( executeLibraryMacros && !templateLibFile.exists() ) {
          throw new CodeGenerationException( "Incorrect configuration. Please provide a valid path to the velocity template library file." );
       }
-   }
-
-   /**
-    * @return a boolean indicating whether Jackson annotations are included in the generated source code or not.
-    */
-   public boolean doEnableJacksonAnnotations() {
-      return enableJacksonAnnotations;
-   }
-
-   /**
-    * @return the package name to be used for the generated source code.
-    */
-   public String getPackageName() {
-      return packageName;
-   }
-
-   /**
-    * @return an instance of the {@link ImportTracker}.
-    */
-   public ImportTracker getImportTracker() {
-      return importTracker;
-   }
-
-   /**
-    * @return a boolean indicating whether the library macros defined in the {@link #templateLibFile} file will be executed during the code generation.
-    */
-   public boolean doExecuteLibraryMacros() {
-      return executeLibraryMacros;
-   }
-
-   /**
-    * @return the path from where the file containing the library macros is to be retrieved.
-    */
-   public File getTemplateLibFile() {
-      return templateLibFile;
    }
 }

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/ValueExpressionVisitor.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/ValueExpressionVisitor.java
@@ -69,8 +69,8 @@ public class ValueExpressionVisitor implements AspectVisitor<String, ValueExpres
    private String generateValueExpression( final ScalarValue value, final Context context ) {
       final String typeUri = value.getType().as( Scalar.class ).getUrn();
       if ( typeUri.equals( RDF.langString.getURI() ) ) {
-         context.getCodeGenerationConfig().getImportTracker().importExplicit( LangString.class );
-         context.getCodeGenerationConfig().getImportTracker().importExplicit( Locale.class );
+         context.getCodeGenerationConfig().importTracker().importExplicit( LangString.class );
+         context.getCodeGenerationConfig().importTracker().importExplicit( Locale.class );
          final LangString langStringValue = (LangString) value.as( ScalarValue.class ).getValue();
          return String.format( "new LangString(\"%s\", Locale.forLanguageTag(\"%s\"))", StringEscapeUtils.escapeJava( langStringValue.getValue() ),
                langStringValue.getLanguageTag().toLanguageTag() );
@@ -78,7 +78,7 @@ public class ValueExpressionVisitor implements AspectVisitor<String, ValueExpres
 
       final Resource typeResource = ResourceFactory.createResource( typeUri );
       final Class<?> javaType = DataType.getJavaTypeForMetaModelType( typeResource, value.getMetaModelVersion() );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( javaType );
+      context.getCodeGenerationConfig().importTracker().importExplicit( javaType );
       return valueInitializer.apply( typeResource, javaType, "\"" + StringEscapeUtils.escapeJava( value.getValue().toString() ) + "\"",
             value.getMetaModelVersion() );
    }
@@ -86,7 +86,7 @@ public class ValueExpressionVisitor implements AspectVisitor<String, ValueExpres
    @Override
    public String visitCollectionValue( final CollectionValue collection, final Context context ) {
       final Class<?> collectionClass = collection.getValues().getClass();
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( collectionClass );
+      context.getCodeGenerationConfig().importTracker().importExplicit( collectionClass );
       final StringBuilder result = new StringBuilder();
       result.append( "new " );
       result.append( collectionClass.getSimpleName() );

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
@@ -118,7 +118,7 @@ import io.openmanufacturing.sds.staticmetamodel.constraint.StaticConstraintUnitP
 public class StaticMetaModelJavaArtifactGenerator<E extends StructureElement> implements JavaArtifactGenerator<E> {
    @Override
    public JavaArtifact apply( final E element, final JavaCodeGenerationConfig config ) {
-      final ImportTracker importTracker = config.getImportTracker();
+      final ImportTracker importTracker = config.importTracker();
       importTracker.importExplicit( java.util.Optional.class );
       importTracker.importExplicit( java.util.List.class );
       importTracker.importExplicit( PropertyContainer.class );
@@ -222,15 +222,15 @@ public class StaticMetaModelJavaArtifactGenerator<E extends StructureElement> im
             .build();
 
       final Properties engineConfiguration = new Properties();
-      if ( config.doExecuteLibraryMacros() ) {
-         engineConfiguration.put( "velocimacro.library", config.getTemplateLibFile().getName() );
-         engineConfiguration.put( "file.resource.loader.path", config.getTemplateLibFile().getParent() );
+      if ( config.executeLibraryMacros() ) {
+         engineConfiguration.put( "velocimacro.library", config.templateLibFile().getName() );
+         engineConfiguration.put( "file.resource.loader.path", config.templateLibFile().getParent() );
       }
 
       final String generatedSource = new TemplateEngine( context, engineConfiguration ).apply( "java-static-class" );
       try {
          return new JavaArtifact( Roaster.format( generatedSource ), "Meta" + element.getName(),
-               config.getPackageName() );
+               config.packageName() );
       } catch ( final Exception exception ) {
          throw new CodeGenerationException( generatedSource, exception );
       }

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelJavaGenerator.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelJavaGenerator.java
@@ -12,49 +12,22 @@
  */
 package io.openmanufacturing.sds.aspectmodel.java.metamodel;
 
-import java.io.File;
 import java.util.stream.Stream;
 
 import io.openmanufacturing.sds.aspectmodel.generator.Artifact;
 import io.openmanufacturing.sds.aspectmodel.java.JavaCodeGenerationConfig;
 import io.openmanufacturing.sds.aspectmodel.java.JavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.java.QualifiedName;
-import io.openmanufacturing.sds.aspectmodel.java.exception.CodeGenerationException;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
-import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.metamodel.Aspect;
 import io.openmanufacturing.sds.metamodel.StructureElement;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 
 /**
  * Generates Java classes representing the static meta model for an Aspect.
  */
 public class StaticMetaModelJavaGenerator extends JavaGenerator {
-   public StaticMetaModelJavaGenerator( final Aspect aspect ) {
-      this( aspect, aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace )
-            .orElseThrow( () -> new CodeGenerationException(
-                  "An Aspect may not be defined as an anonymous node" ) ), false, null );
+   public StaticMetaModelJavaGenerator( final Aspect aspect, final JavaCodeGenerationConfig config ) {
+      super( aspect, config );
    }
-
-   public StaticMetaModelJavaGenerator( final Aspect aspect, final boolean executeLibraryMacros, final File templateLibFile ) {
-      this( aspect, aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace )
-            .orElseThrow( () -> new CodeGenerationException(
-                  "An Aspect may not be defined as an anonymous node" ) ), executeLibraryMacros, templateLibFile );
-   }
-
-   public StaticMetaModelJavaGenerator( final Aspect aspect, final String javaPackageName, final boolean executeLibraryMacros, final File templateLibFile ) {
-      super( aspect, new JavaCodeGenerationConfig( true, javaPackageName, executeLibraryMacros, templateLibFile ) );
-   }
-
-   public StaticMetaModelJavaGenerator( final VersionedModel versionedModel, final boolean executeLibraryMacros, final File templateLibFile ) {
-      this( AspectModelLoader.fromVersionedModelUnchecked( versionedModel ), executeLibraryMacros, templateLibFile );
-   }
-
-   public StaticMetaModelJavaGenerator( final VersionedModel versionedModel, final String javaPackageName, final boolean executeLibraryMacros,
-         final File templateLibFile ) {
-      this( AspectModelLoader.fromVersionedModelUnchecked( versionedModel ), javaPackageName, executeLibraryMacros, templateLibFile );
-   }
-
    @Override
    protected Stream<Artifact<QualifiedName, String>> generateArtifacts() {
       final StaticMetaModelJavaArtifactGenerator<StructureElement> template = new StaticMetaModelJavaArtifactGenerator<>();

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelVisitor.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/metamodel/StaticMetaModelVisitor.java
@@ -109,7 +109,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitScalarValue( final ScalarValue value, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultScalarValue.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultScalarValue.class );
       final ValueExpressionVisitor.Context valueContext = new ValueExpressionVisitor.Context( context.getCodeGenerationConfig(), false );
       return "new DefaultScalarValue("
             // Object value
@@ -121,8 +121,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
    @Override
    public String visitCollectionValue( final CollectionValue collection, final StaticCodeGenerationContext context ) {
       final Class<?> collectionClass = collection.getValues().getClass();
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultCollectionValue.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( collectionClass );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultCollectionValue.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( collectionClass );
       final StringBuilder result = new StringBuilder();
       result.append( "new DefaultCollectionValue(" );
       // Collection<Value> values
@@ -147,11 +147,11 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitEntityInstance( final EntityInstance instance, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultEntityInstance.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Map.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( HashMap.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Property.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Value.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultEntityInstance.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Map.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( HashMap.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Property.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Value.class );
       final Entity entity = instance.getEntityType();
       final StringBuilder builder = new StringBuilder();
       builder.append( "new DefaultEntityInstance(" );
@@ -182,7 +182,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitSingleEntity( final SingleEntity singleEntity, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultSingleEntity.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultSingleEntity.class );
       return "new DefaultSingleEntity("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( singleEntity, context ) + ", "
@@ -208,7 +208,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
          break;
       }
 
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( implementationClass );
+      context.getCodeGenerationConfig().importTracker().importExplicit( implementationClass );
       final String optionalType = collection.getDataType().map( type -> type.accept( this, context ) ).map( type -> "Optional.of(" + type + ")" )
             .orElse( "Optional.empty()" );
       final String optionalElementCharacteristic = collection.getElementCharacteristic().map( characteristic -> characteristic.accept( this, context ) )
@@ -219,7 +219,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitCode( final Code code, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultCode.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultCode.class );
       return "new DefaultCode("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( code, context ) + ","
@@ -243,8 +243,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
    }
 
    private <T extends Quantifiable> String generateForQuantifiable( final T quantifiable, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( quantifiable.getClass() );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Units.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( quantifiable.getClass() );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Units.class );
       return "new " + quantifiable.getClass().getSimpleName() + "("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( quantifiable, context ) + ","
@@ -262,13 +262,13 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
    public String visitUnit( final Unit unit, final StaticCodeGenerationContext context ) {
       final Optional<Unit> unitFromCatalog = Units.fromName( unit.getName(), unit.getMetaModelVersion() );
       if ( unitFromCatalog.isPresent() ) {
-         context.getCodeGenerationConfig().getImportTracker().importExplicit( Units.class );
+         context.getCodeGenerationConfig().importTracker().importExplicit( Units.class );
          return "Units.fromName(\"" + unit.getName() + "\", KnownVersion." + unit.getMetaModelVersion() + ")";
       }
 
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultUnit.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( HashSet.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Optional.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultUnit.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( HashSet.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Optional.class );
       return "Optional.of(new DefaultUnit("
             + getMetaModelBaseAttributes( unit, context ) + ","
             + optionalString( unit.getSymbol() ) + ","
@@ -286,15 +286,15 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitQuantityKind( final QuantityKind quantityKind, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( QuantityKinds.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( QuantityKinds.class );
       return "QuantityKinds." + AspectModelJavaUtil.toConstant( quantityKind.getName() );
    }
 
    @Override
    public String visitState( final State state, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultState.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( ArrayList.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Value.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultState.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( ArrayList.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Value.class );
       return "new DefaultState("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( state, context ) + ","
@@ -309,9 +309,9 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitEnumeration( final Enumeration enumeration, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultEnumeration.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( ArrayList.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Value.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultEnumeration.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( ArrayList.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Value.class );
       return "new DefaultEnumeration("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( enumeration, context ) + ","
@@ -324,8 +324,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitStructuredValue( final StructuredValue structuredValue, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultStructuredValue.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( ArrayList.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultStructuredValue.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( ArrayList.class );
       return "new DefaultStructuredValue("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( structuredValue, context ) + ","
@@ -340,8 +340,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitTrait( final Trait trait, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultTrait.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( ArrayList.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultTrait.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( ArrayList.class );
       return "new DefaultTrait("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( trait, context ) + ","
@@ -355,7 +355,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitCharacteristic( final Characteristic characteristic, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultCharacteristic.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultCharacteristic.class );
       return "new DefaultCharacteristic("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( characteristic, context ) + ","
@@ -365,7 +365,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitLengthConstraint( final LengthConstraint lengthConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultLengthConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultLengthConstraint.class );
       final Scalar nonNegativeInteger = new DefaultScalar( XSD.nonNegativeInteger.getURI(), lengthConstraint.getMetaModelVersion() );
       return "new DefaultLengthConstraint("
             // MetaModelBaseAttributes
@@ -378,8 +378,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitRangeConstraint( final RangeConstraint rangeConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultRangeConstraint.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( BoundDefinition.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultRangeConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( BoundDefinition.class );
       final Type characteristicType = context.getCurrentCharacteristic().getDataType().orElseThrow( noTypeException );
       return "new DefaultRangeConstraint("
             // MetaModelBaseAttributes
@@ -396,7 +396,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitRegularExpressionConstraint( final RegularExpressionConstraint regularExpressionConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultRegularExpressionConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultRegularExpressionConstraint.class );
       return "new DefaultRegularExpressionConstraint("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( regularExpressionConstraint, context ) + ","
@@ -406,8 +406,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitEncodingConstraint( final EncodingConstraint encodingConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultEncodingConstraint.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Charset.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultEncodingConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Charset.class );
       return "new DefaultEncodingConstraint("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( encodingConstraint, context ) + ","
@@ -417,8 +417,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitLanguageConstraint( final LanguageConstraint languageConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultLanguageConstraint.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Locale.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultLanguageConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Locale.class );
       return "new DefaultLanguageConstraint("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( languageConstraint, context ) + ","
@@ -428,8 +428,8 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitLocaleConstraint( final LocaleConstraint localeConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultLocaleConstraint.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( Locale.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultLocaleConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( Locale.class );
       return "new DefaultLanguageConstraint("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( localeConstraint, context ) + ","
@@ -439,7 +439,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitFixedPointConstraint( final FixedPointConstraint fixedPointConstraint, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultFixedPointConstraint.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultFixedPointConstraint.class );
       return "new DefaultFixedPointConstraint("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( fixedPointConstraint, context ) + ","
@@ -456,7 +456,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitEntity( final Entity entity, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultEntity.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultEntity.class );
       return "DefaultEntity.createDefaultEntity("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( entity, context ) + ","
@@ -468,7 +468,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitAbstractEntity( final AbstractEntity abstractEntity, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultAbstractEntity.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultAbstractEntity.class );
       return "DefaultAbstractEntity.createDefaultAbstractEntity("
             // MetaModelBaseAttributes
             + getMetaModelBaseAttributes( abstractEntity, context ) + ","
@@ -483,7 +483,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
 
    @Override
    public String visitScalar( final Scalar scalar, final StaticCodeGenerationContext context ) {
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultScalar.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultScalar.class );
       return "new DefaultScalar(\"" + scalar.getUrn() + "\", KnownVersion." + scalar.getMetaModelVersion() + ")";
    }
 
@@ -495,13 +495,13 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
       final ComplexType type = complexType.getExtends().get();
       if ( type.is( Entity.class ) ) {
          final Entity entity = type.as( Entity.class );
-         context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultEntity.class );
+         context.getCodeGenerationConfig().importTracker().importExplicit( DefaultEntity.class );
          return "Optional.of(DefaultEntity.createDefaultEntity(" + getMetaModelBaseAttributes( complexType, context ) + "," + "Meta" + entity.getName()
                + ".INSTANCE.getProperties()," + extendsComplexType( entity, context ) + "))";
       }
       // AbstractEntity
       final AbstractEntity abstractEntity = type.as( AbstractEntity.class );
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( DefaultAbstractEntity.class );
+      context.getCodeGenerationConfig().importTracker().importExplicit( DefaultAbstractEntity.class );
       return "Optional.of(DefaultAbstractEntity.createDefaultAbstractEntity(" + getMetaModelBaseAttributes( abstractEntity, context ) + "," + "Meta"
             + abstractEntity.getName() + ".INSTANCE.getProperties()," + extendsComplexType( abstractEntity, context ) + "," + "List.of("
             + abstractEntity.getExtendingElements().stream().sorted()
@@ -518,7 +518,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
          return "Optional.of(" + ((ScalarValue) optionalValue.get()).accept( this, context ) + ")";
       }
 
-      context.getCodeGenerationConfig().getImportTracker().importExplicit( AspectModelJavaUtil.getDataTypeClass( type ) );
+      context.getCodeGenerationConfig().importTracker().importExplicit( AspectModelJavaUtil.getDataTypeClass( type ) );
       final Resource xsdType = ResourceFactory.createResource( type.getUrn() );
       String valueExpression = optionalValue.get().toString();
       if ( type.getUrn().endsWith( "#float" ) ) {

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/AspectModelJavaGenerator.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/AspectModelJavaGenerator.java
@@ -12,7 +12,6 @@
  */
 package io.openmanufacturing.sds.aspectmodel.java.pojo;
 
-import java.io.File;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,39 +20,16 @@ import io.openmanufacturing.sds.aspectmodel.generator.Artifact;
 import io.openmanufacturing.sds.aspectmodel.java.JavaCodeGenerationConfig;
 import io.openmanufacturing.sds.aspectmodel.java.JavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.java.QualifiedName;
-import io.openmanufacturing.sds.aspectmodel.java.exception.CodeGenerationException;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
-import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.characteristic.Enumeration;
 import io.openmanufacturing.sds.metamodel.Aspect;
 import io.openmanufacturing.sds.metamodel.ComplexType;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 
 /**
  * Generates Java Domain classes for an Aspect model and all its contained elements.
  */
 public class AspectModelJavaGenerator extends JavaGenerator {
-   public AspectModelJavaGenerator( final Aspect aspect, final boolean enableJacksonAnnotations, final boolean executeLibraryMacros,
-         final File templateLibFile ) {
-      this( aspect, aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace )
-            .orElseThrow( () -> new CodeGenerationException(
-                  "An Aspect may not be defined as an anonymous node" ) ), enableJacksonAnnotations, executeLibraryMacros, templateLibFile );
-   }
-
-   public AspectModelJavaGenerator( final Aspect aspect, final String javaPackagename, final boolean enableJacksonAnnotations,
-         final boolean executeLibraryMacros,
-         final File templateLibFile ) {
-      super( aspect, new JavaCodeGenerationConfig( enableJacksonAnnotations, javaPackagename, executeLibraryMacros, templateLibFile ) );
-   }
-
-   public AspectModelJavaGenerator( final VersionedModel versionedModel, final boolean enableJacksonAnnotations, final boolean executeLibraryMacros,
-         final File templateLibFile ) {
-      this( AspectModelLoader.fromVersionedModelUnchecked( versionedModel ), enableJacksonAnnotations, executeLibraryMacros, templateLibFile );
-   }
-
-   public AspectModelJavaGenerator( final VersionedModel versionedModel, final String javaPackageName, final boolean enableJacksonAnnotations,
-         final boolean executeLibraryMacros, final File templateLibFile ) {
-      this( AspectModelLoader.fromVersionedModelUnchecked( versionedModel ), javaPackageName, enableJacksonAnnotations, executeLibraryMacros, templateLibFile );
+   public AspectModelJavaGenerator( final Aspect aspect, final JavaCodeGenerationConfig config ) {
+      super( aspect, config );
    }
 
    @Override

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/EnumerationJavaArtifactGenerator.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/EnumerationJavaArtifactGenerator.java
@@ -47,7 +47,7 @@ import io.openmanufacturing.sds.characteristic.State;
 public class EnumerationJavaArtifactGenerator<E extends Enumeration> implements JavaArtifactGenerator<E> {
    @Override
    public JavaArtifact apply( final E element, final JavaCodeGenerationConfig config ) {
-      final ImportTracker importTracker = config.getImportTracker();
+      final ImportTracker importTracker = config.importTracker();
       importTracker.importExplicit( EnumAttributeNotFoundException.class );
 
       final Map<String, Object> context = ImmutableMap.<String, Object> builder()
@@ -55,7 +55,7 @@ public class EnumerationJavaArtifactGenerator<E extends Enumeration> implements 
             .put( "className", element.getName() )
             .put( "codeGenerationConfig", config )
             .put( "currentYear", Year.now() )
-            .put( "dataType", AspectModelJavaUtil.getDataType( element.getDataType(), config.getImportTracker() ) )
+            .put( "dataType", AspectModelJavaUtil.getDataType( element.getDataType(), config.importTracker() ) )
             .put( "Entity", Entity.class )
             .put( "enumeration", element )
             .put( "importTracker", importTracker )
@@ -70,14 +70,14 @@ public class EnumerationJavaArtifactGenerator<E extends Enumeration> implements 
 
       try {
          final Properties engineConfiguration = new Properties();
-         if ( config.doExecuteLibraryMacros() ) {
-            engineConfiguration.put( "velocimacro.library", config.getTemplateLibFile().getName() );
-            engineConfiguration.put( "file.resource.loader.path", config.getTemplateLibFile().getParent() );
+         if ( config.executeLibraryMacros() ) {
+            engineConfiguration.put( "velocimacro.library", config.templateLibFile().getName() );
+            engineConfiguration.put( "file.resource.loader.path", config.templateLibFile().getParent() );
          }
 
          final String generatedSource = new TemplateEngine( context, engineConfiguration ).apply( "java-enumeration" );
          return new JavaArtifact( Roaster.format( generatedSource ), element.getName(),
-               config.getPackageName() );
+               config.packageName() );
       } catch ( final Exception e ) {
          throw new CodeGenerationException( e );
       }

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
@@ -49,6 +49,7 @@ import io.openmanufacturing.sds.aspectmodel.java.StructuredValuePropertiesDecons
 import io.openmanufacturing.sds.aspectmodel.java.ValueInitializer;
 import io.openmanufacturing.sds.aspectmodel.java.exception.CodeGenerationException;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.DataType;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.characteristic.Trait;
 import io.openmanufacturing.sds.metamodel.ComplexType;
 import io.openmanufacturing.sds.metamodel.Constraint;
@@ -79,7 +80,7 @@ public class StructureElementJavaArtifactGenerator<E extends StructureElement> i
    @SuppressWarnings( { "squid:S2440", "InstantiationOfUtilityClass" } )
    @Override
    public JavaArtifact apply( final E element, final JavaCodeGenerationConfig config ) {
-      final ImportTracker importTracker = config.getImportTracker();
+      final ImportTracker importTracker = config.importTracker();
       importTracker.importExplicit( java.util.Optional.class );
       importTracker.importExplicit( java.util.List.class );
       importTracker.importExplicit( java.util.Locale.class );
@@ -125,15 +126,15 @@ public class StructureElementJavaArtifactGenerator<E extends StructureElement> i
             .build();
 
       final Properties engineConfiguration = new Properties();
-      if ( config.doExecuteLibraryMacros() ) {
-         engineConfiguration.put( "velocimacro.library", config.getTemplateLibFile().getName() );
-         engineConfiguration.put( "file.resource.loader.path", config.getTemplateLibFile().getParent() );
+      if ( config.executeLibraryMacros() ) {
+         engineConfiguration.put( "velocimacro.library", config.templateLibFile().getName() );
+         engineConfiguration.put( "file.resource.loader.path", config.templateLibFile().getParent() );
       }
 
       final String generatedSource = new TemplateEngine( context, engineConfiguration ).apply( "java-pojo" );
       try {
          return new JavaArtifact( Roaster.format( generatedSource ), element.getName(),
-               config.getPackageName() );
+               config.packageName() );
       } catch ( final Exception exception ) {
          throw new CodeGenerationException( generatedSource, exception );
       }

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
@@ -11,18 +11,18 @@
  ~ SPDX-License-Identifier: MPL-2.0
  *#
 #macro( javaEnumerationClassBody )
-$codeGenerationConfig.importTracker.importExplicit( $Optional )
-$codeGenerationConfig.importTracker.importExplicit( $Arrays )
-#if( $codeGenerationConfig.doEnableJacksonAnnotations() )
-    $codeGenerationConfig.importTracker.importExplicit( $JsonValue )
-    $codeGenerationConfig.importTracker.importExplicit( $JsonFormat )
-    $codeGenerationConfig.importTracker.importExplicit( $JsonCreator )
+$codeGenerationConfig.importTracker().importExplicit( $Optional )
+$codeGenerationConfig.importTracker().importExplicit( $Arrays )
+#if( $codeGenerationConfig.enableJacksonAnnotations() )
+    $codeGenerationConfig.importTracker().importExplicit( $JsonValue )
+    $codeGenerationConfig.importTracker().importExplicit( $JsonFormat )
+    $codeGenerationConfig.importTracker().importExplicit( $JsonCreator )
 #end
 
 /**
 * Generated class {@link ${enumeration.name}}.
 */
-#if( $codeGenerationConfig.doEnableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
+#if( $codeGenerationConfig.enableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
 public enum ${enumeration.name} {
 #foreach( $value in $enumeration.values )
     $util.generateEnumKey($value)($util.generateEnumValue($value, $codeGenerationConfig))
@@ -35,12 +35,12 @@ $className($dataType value) {
     this.value = value;
 }
 
-#if( $codeGenerationConfig.doEnableJacksonAnnotations() )@JsonCreator #end
+#if( $codeGenerationConfig.enableJacksonAnnotations() )@JsonCreator #end
 static ${className} enumDeserializationConstructor($dataType value) {
     return fromValue(value).orElseThrow(() -> new EnumAttributeNotFoundException("Tried to parse value \"" + value + "\", but there is no enum field like that in ${className}"));
 }
 
-#if( $codeGenerationConfig.doEnableJacksonAnnotations() )@JsonValue #end
+#if( $codeGenerationConfig.enableJacksonAnnotations() )@JsonValue #end
 public $dataType getValue() {
     return value;
 }

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-enumeration.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-enumeration.vm
@@ -12,12 +12,12 @@
  *#
 #parse( "java-enumeration-class-body-lib.vm" )
 #set( $classBody = $util.applyImports( "#javaEnumerationClassBody()", $codeGenerationConfig ) )
-#if( $codeGenerationConfig.doExecuteLibraryMacros() )
+#if( $codeGenerationConfig.executeLibraryMacros() )
 #fileHeader
 #end
-package $codeGenerationConfig.packageName;
+package $codeGenerationConfig.packageName();
 
-#foreach( $import in $codeGenerationConfig.getImportTracker().getUsedImportsWithoutJavaLang() )
+#foreach( $import in $codeGenerationConfig.importTracker().getUsedImportsWithoutJavaLang() )
 import $import;
 #end
 

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
@@ -14,8 +14,8 @@
 #* Note that in this macro $enableJacksonAnnotations overrides the value given in $codeGenerationConfig *#
 #macro( constructorContent $deconstructionSets $needInitializer $allProperties $codeGenerationConfig $enableJacksonAnnotations $elementProperties )
     #if( $enableJacksonAnnotations )
-        $codeGenerationConfig.getImportTracker().importExplicit( $JsonProperty )
-        $codeGenerationConfig.getImportTracker().importExplicit( $JsonCreator )
+        $codeGenerationConfig.importTracker().importExplicit( $JsonProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $JsonCreator )
         @JsonCreator
     #end
     public ${element.name}(
@@ -49,15 +49,15 @@
 
 #macro( javaPojoConstructor )
 #if ( $deconstructor.isApplicable() )
-    $codeGenerationConfig.getImportTracker().importExplicit( $Matcher )
-    $codeGenerationConfig.getImportTracker().importExplicit( $Pattern )
+    $codeGenerationConfig.importTracker().importExplicit( $Matcher )
+    $codeGenerationConfig.importTracker().importExplicit( $Pattern )
 #end
 #set( $deconstructionSets = $deconstructor.getDeconstructionSets() )
 #set( $needInitializer = $valueInitializer.needInitializationToConstructor( $deconstructionSets ) )
 #if ( $needInitializer )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeConfigurationException )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeConstants )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeFactory )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeConfigurationException )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeConstants )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeFactory )
 #end
 #if ( $element.is( $ComplexType ) && $element.getExtends().isPresent() )
 	#set( $allPropertiesInPayload = $util.getAllPropertiesInPayload( $element ) )
@@ -72,8 +72,8 @@
 #end
 #if ( $util.anyPropertyNotInPayload( $element ) )
     #constructorContent( $deconstructionSets $needInitializer $allProperties $codeGenerationConfig false $elementProperties )
-    #constructorContent( $deconstructionSets $needInitializer $allPropertiesInPayload $codeGenerationConfig $codeGenerationConfig.doEnableJacksonAnnotations() $elementPropertiesInPayload )
+    #constructorContent( $deconstructionSets $needInitializer $allPropertiesInPayload $codeGenerationConfig $codeGenerationConfig.enableJacksonAnnotations() $elementPropertiesInPayload )
 #else
-    #constructorContent( $deconstructionSets $needInitializer $allProperties $codeGenerationConfig $codeGenerationConfig.doEnableJacksonAnnotations() $elementProperties )
+    #constructorContent( $deconstructionSets $needInitializer $allProperties $codeGenerationConfig $codeGenerationConfig.enableJacksonAnnotations() $elementProperties )
 #end
 #end

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
@@ -14,20 +14,20 @@
 #if( !$property.isAbstract() )
     #set( $propertyType = $util.getPropertyType( $property, true, $codeGenerationConfig ) )
     #if( !$property.isOptional() && !$property.isNotInPayload() )
-        $codeGenerationConfig.getImportTracker().importExplicit( $NotNull )
+        $codeGenerationConfig.importTracker().importExplicit( $NotNull )
     @NotNull
     #end
     #if( $propertyType == 'byte[]' )
-        $codeGenerationConfig.getImportTracker().importExplicit( $JsonSerialize )
-        $codeGenerationConfig.getImportTracker().importExplicit( $JsonDeserialize )
+        $codeGenerationConfig.importTracker().importExplicit( $JsonSerialize )
+        $codeGenerationConfig.importTracker().importExplicit( $JsonDeserialize )
         #if( $property.dataType.get().urn == $XSD.hexBinary.URI )
-            $codeGenerationConfig.getImportTracker().importExplicit( $HexBinarySerializer  )
-            $codeGenerationConfig.getImportTracker().importExplicit( $HexBinaryDeserializer )
+            $codeGenerationConfig.importTracker().importExplicit( $HexBinarySerializer  )
+            $codeGenerationConfig.importTracker().importExplicit( $HexBinaryDeserializer )
         @JsonSerialize( using = HexBinarySerializer.class )
         @JsonDeserialize( using = HexBinaryDeserializer.class )
         #else
-            $codeGenerationConfig.getImportTracker().importExplicit( $Base64BinarySerializer  )
-            $codeGenerationConfig.getImportTracker().importExplicit( $Base64BinaryDeserializer )
+            $codeGenerationConfig.importTracker().importExplicit( $Base64BinarySerializer  )
+            $codeGenerationConfig.importTracker().importExplicit( $Base64BinaryDeserializer )
         @JsonSerialize( using = Base64BinarySerializer.class )
         @JsonDeserialize( using = Base64BinaryDeserializer.class )
         #end

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo.vm
@@ -12,15 +12,15 @@
  *#
 #parse( "java-pojo-class-body-lib.vm" )
 #set( $classBody = $util.applyImports( "#javaPojoClassBody()", $codeGenerationConfig ) )
-#if( $codeGenerationConfig.doExecuteLibraryMacros() )
+#if( $codeGenerationConfig.executeLibraryMacros() )
 #fileHeader
 #end
-package $codeGenerationConfig.getPackageName();
+package $codeGenerationConfig.packageName();
 
-#foreach( $import in $codeGenerationConfig.getImportTracker().getUsedImportsWithoutJavaLang() )
+#foreach( $import in $codeGenerationConfig.importTracker().getUsedImportsWithoutJavaLang() )
 import $import;
 #end
-#foreach( $import in $codeGenerationConfig.getImportTracker().getUsedStaticImports() )
+#foreach( $import in $codeGenerationConfig.importTracker().getUsedStaticImports() )
 import $import;
 #end
 

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
@@ -13,7 +13,7 @@
 #parse( "java-static-class-property-lib.vm" )
 
 #macro( javaStaticClassBody )
-$codeGenerationConfig.getImportTracker().importExplicit( "${codeGenerationConfig.getPackageName()}.${element.getName()}" )
+$codeGenerationConfig.importTracker().importExplicit( "${codeGenerationConfig.packageName()}.${element.getName()}" )
 /**
 * Generated class {@link Meta${element.getName()}}.
 */
@@ -26,9 +26,9 @@ private static String CHARACTERISTIC_NAMESPACE = "${characteristicBaseUrn}";
 #propertyDeclaration() Meta${element.getName()} INSTANCE = new Meta${element.getName()}();
 
 #if( $util.isXmlDatatypeFactoryRequired( $element ) )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeConfigurationException )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeConstants )
-    $codeGenerationConfig.getImportTracker().importExplicit( $DatatypeFactory )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeConfigurationException )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeConstants )
+    $codeGenerationConfig.importTracker().importExplicit( $DatatypeFactory )
 private static DatatypeFactory _datatypeFactory;
 
 static {
@@ -79,10 +79,10 @@ static {
     public List<StaticProperty<?>> getAllProperties() {
     #if( $element.getExtends().isPresent() )
         #set( $extendedElement = $element.getExtends().get() )
-        $codeGenerationConfig.getImportTracker().importExplicit( "java.util.stream.Stream" )
-        $codeGenerationConfig.getImportTracker().importExplicit( "java.util.stream.Collectors" )
-        $codeGenerationConfig.getImportTracker().importExplicit( "java.util.Collection" )
-        $codeGenerationConfig.getImportTracker().importExplicit( "${codeGenerationConfig.getPackageName()}.Meta${extendedElement.getName()}" )
+        $codeGenerationConfig.importTracker().importExplicit( "java.util.stream.Stream" )
+        $codeGenerationConfig.importTracker().importExplicit( "java.util.stream.Collectors" )
+        $codeGenerationConfig.importTracker().importExplicit( "java.util.Collection" )
+        $codeGenerationConfig.importTracker().importExplicit( "${codeGenerationConfig.packageName()}.Meta${extendedElement.getName()}" )
         return Stream.of( getProperties(), Meta${extendedElement.getName()}.INSTANCE.getAllProperties() ).flatMap( Collection::stream ).collect( Collectors.toList() );
     #else
         return getProperties();
@@ -90,9 +90,9 @@ static {
     }
 
 #if( !$element.getPreferredNames().isEmpty() )
-    $codeGenerationConfig.getImportTracker().importExplicit( $LangString )
-    $codeGenerationConfig.getImportTracker().importExplicit( $HashSet )
-    $codeGenerationConfig.getImportTracker().importExplicit( $Locale )
+    $codeGenerationConfig.importTracker().importExplicit( $LangString )
+    $codeGenerationConfig.importTracker().importExplicit( $HashSet )
+    $codeGenerationConfig.importTracker().importExplicit( $Locale )
     @Override
     public java.util.Set<LangString> getPreferredNames() {
        return new HashSet<>() {{
@@ -104,9 +104,9 @@ static {
 #end
 
 #if( !$element.descriptions.isEmpty() )
-    $codeGenerationConfig.getImportTracker().importExplicit( $LangString )
-    $codeGenerationConfig.getImportTracker().importExplicit( $HashSet )
-    $codeGenerationConfig.getImportTracker().importExplicit( $Locale )
+    $codeGenerationConfig.importTracker().importExplicit( $LangString )
+    $codeGenerationConfig.importTracker().importExplicit( $HashSet )
+    $codeGenerationConfig.importTracker().importExplicit( $Locale )
     @Override
     public java.util.Set<LangString> getDescriptions() {
        return new HashSet<>() {{

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
@@ -26,7 +26,7 @@
         #set( $extendedComplexType = $complexType.getExtends().get() )
         #if ( $Entity.isAssignableFrom( $extendedComplexType.class ) )
             #set( $entityType = $Entity.cast( $extendedComplexType ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $DefaultEntity )
+            $codeGenerationConfig.importTracker().importExplicit( $DefaultEntity )
             Optional.of(DefaultEntity.createDefaultEntity(MetaModelBaseAttributes.from(KnownVersion.$characteristic.getMetaModelVersion(),
                 $modelVisitor.elementUrn( $entityType, $context ), "$entityType.getName()" ),
             Meta${entityType.getName()}.INSTANCE.getProperties(),
@@ -35,7 +35,7 @@
         )
         #else
             #set( $abstractEntityType = $AbstractEntity.cast( $extendedComplexType ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $DefaultAbstractEntity )
+            $codeGenerationConfig.importTracker().importExplicit( $DefaultAbstractEntity )
             Optional.of(DefaultAbstractEntity.createDefaultAbstractEntity(MetaModelBaseAttributes.from(KnownVersion.$characteristic.getMetaModelVersion(),
                 $modelVisitor.elementUrn( $abstractEntityType, $context ), "$abstractEntityType.getName()" ),
             Meta${abstractEntityType.name}.INSTANCE.getProperties(),
@@ -63,15 +63,15 @@
 
 ## public static final $type $property = (definition)
 #if( $Trait.isAssignableFrom( $property.getCharacteristic().get().getClass() ) )
-    $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintProperty )
+    $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintProperty )
     #if( $util.hasContainerType( $property ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintContainerProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintContainerProperty )
         #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
         #propertyDeclaration() StaticConstraintContainerProperty<$containedType, $propertyType, #getCharacteristicClassName()>
           $util.toConstant( $property.getName() ) = #staticProperty( $property $codeGenerationConfig );
     #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintUnitProperty )
-        $codeGenerationConfig.getImportTracker().importExplicit( $Unit )
+        $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintUnitProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $Unit )
         #propertyDeclaration() StaticConstraintUnitProperty<$propertyType, #getCharacteristicClassName()>
           $util.toConstant( $property.getName() ) = #staticProperty( $property $codeGenerationConfig );
     #else
@@ -80,13 +80,13 @@
     #end
 #else
     #if( $util.hasContainerType( $property ) && !$propertyType.startsWith( "Map" ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $StaticContainerProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $StaticContainerProperty )
         #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
         #propertyDeclaration() StaticContainerProperty<$containedType, java.util.$propertyType> $util.toConstant( $property.getName() ) =
           #staticProperty( $property $codeGenerationConfig );
     #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $StaticUnitProperty )
-        $codeGenerationConfig.getImportTracker().importExplicit( $Unit )
+        $codeGenerationConfig.importTracker().importExplicit( $StaticUnitProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $Unit )
         #propertyDeclaration() StaticUnitProperty<$propertyType> $util.toConstant( $property.getName() ) =
           #staticProperty( $property $codeGenerationConfig );
     #else
@@ -104,26 +104,26 @@
 
     ## new $type(
     #if( $Trait.isAssignableFrom( $property.getCharacteristic().get().getClass() ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintProperty )
+        $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintProperty )
         #if( $util.hasContainerType( $property ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintContainerProperty )
+            $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintContainerProperty )
             #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
             new StaticConstraintContainerProperty<$containedType, $propertyType, #getCharacteristicClassName()>(
         #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $StaticConstraintUnitProperty )
-            $codeGenerationConfig.getImportTracker().importExplicit( $Unit )
+            $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintUnitProperty )
+            $codeGenerationConfig.importTracker().importExplicit( $Unit )
             new StaticConstraintUnitProperty<$propertyType, #getCharacteristicClassName()>(
         #else
             new StaticConstraintProperty<$propertyType, #getCharacteristicClassName()>(
         #end
     #else
         #if( $util.hasContainerType( $property ) && !$propertyType.startsWith( "Map" ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $StaticContainerProperty )
+            $codeGenerationConfig.importTracker().importExplicit( $StaticContainerProperty )
             #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
         new StaticContainerProperty<$containedType, $propertyType> (
         #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
-            $codeGenerationConfig.getImportTracker().importExplicit( $StaticUnitProperty )
-            $codeGenerationConfig.getImportTracker().importExplicit( $Unit )
+            $codeGenerationConfig.importTracker().importExplicit( $StaticUnitProperty )
+            $codeGenerationConfig.importTracker().importExplicit( $Unit )
         new StaticUnitProperty<$propertyType>(
         #else
         new StaticProperty<$propertyType>(
@@ -165,7 +165,7 @@ Optional.of("$property.getPayloadName()"),
     #set( $propertyType = $util.getPropertyType( $property, $codeGenerationConfig ) )
 public Class<$propertyType> getPropertyType() {
     #if( $util.hasContainerType( $property ) )
-    return (Class)${codeGenerationConfig.getImportTracker().getRawContainerType( $propertyType )}.class;
+    return (Class)${codeGenerationConfig.importTracker().getRawContainerType( $propertyType )}.class;
     #else
         #if( ${propertyType.contains( "Either" )} )
         return (Class)Either.class;
@@ -183,8 +183,8 @@ public Class<$propertyType> getPropertyType() {
     #end
 
     #if( $util.hasUnit( $property.getCharacteristic().get() ) )
-        $codeGenerationConfig.getImportTracker().importExplicit( $Unit )
-        $codeGenerationConfig.getImportTracker().importExplicit( $Units )
+        $codeGenerationConfig.importTracker().importExplicit( $Unit )
+        $codeGenerationConfig.importTracker().importExplicit( $Units )
     public Unit getUnit() {
     return Units.fromName("$Quantifiable.cast( $property.getCharacteristic().get() ).unit.get().getName()")
     .orElseThrow(() -> new RuntimeException("Unknown unit: $Quantifiable.cast( $property.getCharacteristic().get() ).getUnit().get().getName()"));

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-static-class.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-static-class.vm
@@ -12,15 +12,15 @@
  *#
 #parse( "java-static-class-body-lib.vm" )
 #set( $classBody = $util.applyImports( "#javaStaticClassBody()", $codeGenerationConfig ) )
-#if( $codeGenerationConfig.doExecuteLibraryMacros() )
+#if( $codeGenerationConfig.executeLibraryMacros() )
 #fileHeader
 #end
-package $codeGenerationConfig.getPackageName();
+package $codeGenerationConfig.packageName();
 
-#foreach( $import in $codeGenerationConfig.getImportTracker().getUsedImportsWithoutJavaLang() )
+#foreach( $import in $codeGenerationConfig.importTracker().getUsedImportsWithoutJavaLang() )
 import $import;
 #end
-#foreach( $import in $codeGenerationConfig.getImportTracker().getUsedStaticImports() )
+#foreach( $import in $codeGenerationConfig.importTracker().getUsedStaticImports() )
 import $import;
 #end
 

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import io.openmanufacturing.sds.aspectmodel.java.exception.CodeGenerationException;
 
 public class JavaCodeGenerationConfigurationTest {
-
    final String currentWorkingDirectory = System.getProperty( "user.dir" );
    private final File templateLibFile = Path.of( currentWorkingDirectory, "/templates", "/test-macro-lib.vm" ).toFile();
    private final File emptyTemplateLibFile = Path.of( "" ).toFile();
@@ -32,25 +31,45 @@ public class JavaCodeGenerationConfigurationTest {
    @Test
    public void testValidTemplateLibConfig() {
       assertThatCode( () ->
-            new JavaCodeGenerationConfig( true, "", true, templateLibFile )
+            JavaCodeGenerationConfigBuilder.builder()
+                  .enableJacksonAnnotations( true )
+                  .packageName( "" )
+                  .executeLibraryMacros( true )
+                  .templateLibFile( templateLibFile )
+                  .build()
       ).doesNotThrowAnyException();
 
       assertThatCode( () ->
-            new JavaCodeGenerationConfig( true, "", false, emptyTemplateLibFile )
+            JavaCodeGenerationConfigBuilder.builder()
+                  .enableJacksonAnnotations( true )
+                  .packageName( "" )
+                  .executeLibraryMacros( false )
+                  .templateLibFile( emptyTemplateLibFile )
+                  .build()
       ).doesNotThrowAnyException();
    }
 
    @Test
    public void testTemplateLibConfigMissingFile() {
       assertThatCode( () ->
-            new JavaCodeGenerationConfig( true, "", true, emptyTemplateLibFile )
+            JavaCodeGenerationConfigBuilder.builder()
+                  .enableJacksonAnnotations( true )
+                  .packageName( "" )
+                  .executeLibraryMacros( true )
+                  .templateLibFile( emptyTemplateLibFile )
+                  .build()
       ).isExactlyInstanceOf( CodeGenerationException.class ).hasMessage( "Missing configuration. Please provide path to velocity template library file." );
    }
 
    @Test
    public void testTemplateLibConfigNonExistingFile() {
       assertThatCode( () ->
-            new JavaCodeGenerationConfig( true, "", true, nonExistingTemplateLibPath )
+            JavaCodeGenerationConfigBuilder.builder()
+                  .enableJacksonAnnotations( true )
+                  .packageName( "" )
+                  .executeLibraryMacros( true )
+                  .templateLibFile( nonExistingTemplateLibPath )
+                  .build()
       ).isExactlyInstanceOf( CodeGenerationException.class )
             .hasMessage( "Incorrect configuration. Please provide a valid path to the velocity template library file." );
    }

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/StaticMetaModelGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/StaticMetaModelGeneratorTest.java
@@ -21,31 +21,53 @@ import io.openmanufacturing.sds.aspectmetamodel.KnownVersion;
 import io.openmanufacturing.sds.aspectmodel.java.metamodel.StaticMetaModelJavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.java.pojo.AspectModelJavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
+import io.openmanufacturing.sds.metamodel.Aspect;
+import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 import io.openmanufacturing.sds.test.MetaModelVersions;
 import io.openmanufacturing.sds.test.TestAspect;
 import io.openmanufacturing.sds.test.TestResources;
 import io.openmanufacturing.sds.test.TestSharedAspect;
 
 abstract class StaticMetaModelGeneratorTest extends MetaModelVersions {
-
-   Collection<JavaGenerator> getGenerators( final TestAspect aspect, final KnownVersion version, final boolean executeLibraryMacros,
+   Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final KnownVersion version, final boolean executeLibraryMacros,
          final File templateLibFile ) {
-      final VersionedModel model = TestResources.getModel( aspect, version ).get();
-      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( model, false, executeLibraryMacros, templateLibFile );
-      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( model, executeLibraryMacros, templateLibFile );
+      final VersionedModel model = TestResources.getModel( testAspect, version ).get();
+      final Aspect aspect = AspectModelLoader.getSingleAspectUnchecked( model );
+      final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
+            .enableJacksonAnnotations( false )
+            .executeLibraryMacros( executeLibraryMacros )
+            .templateLibFile( templateLibFile )
+            .packageName( aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace ).get() )
+            .build();
+      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( aspect, config );
+      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( aspect, config );
       return List.of( pojoGenerator, staticGenerator );
    }
 
-   Collection<JavaGenerator> getGenerators( final TestAspect aspect, final KnownVersion version ) {
-      final VersionedModel model = TestResources.getModel( aspect, version ).get();
-      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( model, false, false, null );
-      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( model, false, null );
+   Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final KnownVersion version ) {
+      final VersionedModel model = TestResources.getModel( testAspect, version ).get();
+      final Aspect aspect = AspectModelLoader.getSingleAspectUnchecked( model );
+      final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
+            .enableJacksonAnnotations( false )
+            .executeLibraryMacros( false )
+            .packageName( aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace ).get() )
+            .build();
+      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( aspect, config );
+      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( aspect, config );
       return List.of( pojoGenerator, staticGenerator );
    }
-   Collection<JavaGenerator> getGenerators( final TestSharedAspect aspect, final KnownVersion version ) {
-      final VersionedModel model = TestResources.getModel( aspect, version ).get();
-      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( model, false, false, null );
-      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( model, false, null );
+
+   Collection<JavaGenerator> getGenerators( final TestSharedAspect testAspect, final KnownVersion version ) {
+      final VersionedModel model = TestResources.getModel( testAspect, version ).get();
+      final Aspect aspect = AspectModelLoader.getSingleAspectUnchecked( model );
+      final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
+            .enableJacksonAnnotations( false )
+            .executeLibraryMacros( false )
+            .packageName( aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace ).get() )
+            .build();
+      final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( aspect, config );
+      final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( aspect, config );
       return List.of( pojoGenerator, staticGenerator );
    }
 }

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/TestContext.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/TestContext.java
@@ -51,7 +51,7 @@ public class TestContext {
 
    private static Map<QualifiedName, Class<?>> generateJavaCode( final File tempDirectory, final Collection<JavaGenerator> generators ) throws IOException {
       final File subFolder = new File(
-            tempDirectory.getAbsolutePath() + File.separator + generators.iterator().next().getConfig().getPackageName()
+            tempDirectory.getAbsolutePath() + File.separator + generators.iterator().next().getConfig().packageName()
                   .replace( '.', File.separatorChar ) );
       if ( !subFolder.mkdirs() ) {
          throw new IOException( "Could not create directory: " + subFolder );
@@ -73,8 +73,8 @@ public class TestContext {
       }
 
       final List<String> referencedClasses = generators.stream().flatMap( generator ->
-                  Stream.concat( generator.getConfig().getImportTracker().getUsedImports().stream(),
-                        generator.getConfig().getImportTracker().getUsedStaticImports().stream() ) )
+                  Stream.concat( generator.getConfig().importTracker().getUsedImports().stream(),
+                        generator.getConfig().importTracker().getUsedStaticImports().stream() ) )
             .collect( Collectors.toList() );
 
       return JavaCompiler.compile( loadOrder, sources, referencedClasses );

--- a/core/sds-aspect-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/CommandExecutor.java
+++ b/core/sds-aspect-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/CommandExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -11,18 +11,17 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-package io.openmanufacturing.sds;
+package io.openmanufacturing.sds.aspectmodel.resolver;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
 import java.util.StringTokenizer;
 
-import io.openmanufacturing.sds.exception.CommandException;
-
-// Executes an external resolver via the underlying OS command and returns the stdout from the command as result.
+/**
+ * Executes an external resolver via the underlying OS command and returns the stdout from the command as result.
+ */
 public class CommandExecutor {
-
    public static String executeCommand( String command ) {
       // convenience: if just the name of the jar is given, expand to the proper java invocation command
       if ( isJarInvocation( command ) ) {
@@ -33,11 +32,11 @@ public class CommandExecutor {
          final Process p = Runtime.getRuntime().exec( command );
          final int result = p.waitFor();
          if ( result != 0 ) {
-            throw new CommandException( getOutputFrom( p.getErrorStream() ) );
+            throw new ModelResolutionException( getOutputFrom( p.getErrorStream() ) );
          }
          return getOutputFrom( p.getInputStream() );
       } catch ( final IOException | InterruptedException e ) {
-         throw new CommandException( "The attempt to execute external resolver failed with the error:", e );
+         throw new ModelResolutionException( "The attempt to execute external resolver failed with the error:", e );
       }
    }
 

--- a/core/sds-aspect-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/ExternalResolverStrategy.java
+++ b/core/sds-aspect-model-resolver/src/main/java/io/openmanufacturing/sds/aspectmodel/resolver/ExternalResolverStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -11,26 +11,24 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-package io.openmanufacturing.sds;
+package io.openmanufacturing.sds.aspectmodel.resolver;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.jena.rdf.model.Model;
 
-import io.openmanufacturing.sds.aspectmodel.resolver.ResolutionStrategy;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.TurtleLoader;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.vavr.control.Try;
 
 /**
- * Specialized resolution strategy: use external resolver to resolve the URNs passed as argument into models.
+ * A ResolutionStrategy that executes an external command, which will be executed using a {@link CommandExecutor}.
  */
-class ExternalResolverStrategy implements ResolutionStrategy {
-
+public class ExternalResolverStrategy implements ResolutionStrategy {
    private final String command;
 
-   ExternalResolverStrategy( final String command ) {
+   public ExternalResolverStrategy( final String command ) {
       this.command = command;
    }
 

--- a/core/sds-aspect-model-urn/pom.xml
+++ b/core/sds-aspect-model-urn/pom.xml
@@ -42,6 +42,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/core/sds-aspect-model-urn/src/main/java/io/openmanufacturing/sds/aspectmodel/urn/AspectModelUrn.java
+++ b/core/sds-aspect-model-urn/src/main/java/io/openmanufacturing/sds/aspectmodel/urn/AspectModelUrn.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
- * information regarding authorship. 
+ * information regarding authorship.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
+
+import io.vavr.control.Try;
 
 /**
  * Represents the identifier URN of an Aspect Model.
@@ -131,6 +133,32 @@ public class AspectModelUrn implements Comparable<AspectModelUrn> {
       final String version = getVersion( isBammUrn, urnParts, elementType );
       final String elementName = getName( isBammUrn, urnParts, elementType );
       return new AspectModelUrn( urn, elementName, namespace, elementType, version, isBammUrn );
+   }
+
+   /**
+    * Checked version of {@link #fromUrn(String)}
+    * @param urn the lexical representation of the Aspect Model URN
+    * @return the Aspect Model URN, a {@link URISyntaxException} or a {@link UrnSyntaxException}
+    */
+   public static Try<AspectModelUrn> from( final String urn ) {
+      try {
+         return from( new URI( urn ) );
+      } catch ( final URISyntaxException e ) {
+         throw new UrnSyntaxException( UrnSyntaxException.URN_IS_NO_URI );
+      }
+   }
+
+   /**
+    * Checked version of {@link #fromUrn(URI)}
+    * @param urn the lexical representation of the Aspect Model URN
+    * @return the Aspect Model URN or a {@link UrnSyntaxException}
+    */
+   public static Try<AspectModelUrn> from( final URI uri ) {
+      try {
+         return Try.success( fromUrn( uri ) );
+      } catch ( final UrnSyntaxException exception ) {
+         return Try.failure( exception );
+      }
    }
 
    /**
@@ -353,7 +381,7 @@ public class AspectModelUrn implements Comparable<AspectModelUrn> {
    }
 
    @Override
-   public int compareTo( AspectModelUrn o ) {
+   public int compareTo( final AspectModelUrn o ) {
       return urn.compareTo( o.urn );
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
       <maven-plugin-flatten-version>1.2.7</maven-plugin-flatten-version>
       <maven-plugin-plugin-version>3.6.4</maven-plugin-plugin-version>
       <maven-plugin-testing-harness-version>3.3.0</maven-plugin-testing-harness-version>
+      <record-builder-version>35</record-builder-version>
       <rgxgen-version>1.3</rgxgen-version>
       <rhino-version>1.7.14</rhino-version>
       <roaster-version>2.24.0.Final</roaster-version>
@@ -412,6 +413,11 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${json-path-version}</version>
+         </dependency>
+         <dependency>
+            <groupId>io.soabase.record-builder</groupId>
+            <artifactId>record-builder-processor</artifactId>
+            <version>${record-builder-version}</version>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/AbstractCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/AbstractCommand.java
@@ -13,106 +13,59 @@
 
 package io.openmanufacturing.sds;
 
+import static io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver.fileToUrn;
+
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.openmanufacturing.sds.aspectmodel.generator.LanguageCollector;
 import io.openmanufacturing.sds.aspectmodel.generator.diagram.AspectModelDiagramGenerator;
 import io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver;
-import io.openmanufacturing.sds.aspectmodel.resolver.FileSystemStrategy;
+import io.openmanufacturing.sds.aspectmodel.resolver.ExternalResolverStrategy;
 import io.openmanufacturing.sds.aspectmodel.resolver.ModelResolutionException;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.SdsAspectMetaModelResourceResolver;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.TurtleLoader;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.aspectmodel.shacl.violation.Violation;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.aspectmodel.validation.services.AspectModelValidator;
 import io.openmanufacturing.sds.aspectmodel.validation.services.ViolationFormatter;
 import io.openmanufacturing.sds.exception.CommandException;
-import io.vavr.CheckedFunction1;
-import io.vavr.control.Option;
+import io.openmanufacturing.sds.metamodel.AspectContext;
+import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 import io.vavr.control.Try;
 
 public abstract class AbstractCommand implements Runnable {
-
    protected static final Logger LOG = LoggerFactory.getLogger( AbstractCommand.class );
 
-   protected Try<VersionedModel> loadAndResolveModel( final File input ) {
-      final File inputFile = input.getAbsoluteFile();
-      final AspectModelUrn urn = fileToUrn( inputFile );
-      return getModelRoot( inputFile ).flatMap( modelsRoot ->
-            new AspectModelResolver().resolveAspectModel( new FileSystemStrategy( modelsRoot ), urn ) );
-   }
-
-   protected Try<VersionedModel> loadAndResolveModel( final File input, final ExternalResolverMixin resolverConfig ) {
+   protected Try<AspectContext> loadAndResolveModel( final File input, final ExternalResolverMixin resolverConfig ) {
+      final Try<VersionedModel> versionedModel;
       if ( resolverConfig.commandLine.isBlank() ) {
-         return loadAndResolveModel( input );
+         versionedModel = AspectModelResolver.loadAndResolveModel( input );
+      } else {
+         final AspectModelUrn urn = fileToUrn( input.getAbsoluteFile() );
+         versionedModel = new AspectModelResolver().resolveAspectModel( new ExternalResolverStrategy( resolverConfig.commandLine ), urn );
       }
-      final File inputFile = input.getAbsoluteFile();
-      final AspectModelUrn urn = fileToUrn( inputFile );
-      return new AspectModelResolver().resolveAspectModel( new ExternalResolverStrategy( resolverConfig.commandLine ), urn );
-   }
-
-   protected Try<Path> getModelRoot( final File inputFile ) {
-      return Option.of( Paths.get( inputFile.getParent(), "..", ".." ) )
-            .map( Path::toFile )
-            .flatMap( file -> CheckedFunction1.lift( File::getCanonicalFile ).apply( file ) )
-            .map( File::toPath )
-            .filter( path -> path.toFile().exists() && path.toFile().isDirectory() )
-            .toTry( () -> new ModelResolutionException( "Could not locate models root directory" ) );
-   }
-
-   protected AspectModelUrn fileToUrn( final File inputFile ) {
-      final File versionDirectory = inputFile.getParentFile();
-      if ( versionDirectory == null ) {
-         throw new CommandException( "Could not determine parent directory of " + inputFile );
-      }
-
-      final String version = versionDirectory.getName();
-      final File namespaceDirectory = versionDirectory.getParentFile();
-      if ( namespaceDirectory == null ) {
-         throw new CommandException( "Could not determine parent directory of " + versionDirectory );
-      }
-
-      final String namespace = namespaceDirectory.getName();
-      final String aspectName = FilenameUtils.removeExtension( inputFile.getName() );
-      final String urn = String.format( "urn:bamm:%s:%s#%s", namespace, version, aspectName );
-      return new SdsAspectMetaModelResourceResolver().getAspectModelUrn( urn ).getOrElse( () -> {
-         throw new CommandException( "The URN constructed from the input file path is invalid: " + urn );
+      return versionedModel.flatMap( model -> {
+         final AspectModelUrn urn = fileToUrn( input.getAbsoluteFile() );
+         return AspectModelLoader.getSingleAspect( model, aspect -> aspect.getName().equals( urn.getName() ) )
+               .map( aspect -> new AspectContext( model, aspect ) );
       } );
    }
 
-   protected Try<VersionedModel> loadButNotResolveModel( final File inputFile ) {
-      try ( final InputStream inputStream = new FileInputStream( inputFile ) ) {
-         final SdsAspectMetaModelResourceResolver metaModelResourceResolver = new SdsAspectMetaModelResourceResolver();
-         return TurtleLoader.loadTurtle( inputStream ).flatMap( model ->
-               metaModelResourceResolver.getBammVersion( model ).flatMap( metaModelVersion ->
-                     metaModelResourceResolver.mergeMetaModelIntoRawModel( model, metaModelVersion ) ) );
-      } catch ( final IOException exception ) {
-         return Try.failure( exception );
-      }
-   }
-
-   protected VersionedModel loadModelOrFail( final String modelFileName, final ExternalResolverMixin resolverConfig ) {
+   protected AspectContext loadModelOrFail( final String modelFileName, final ExternalResolverMixin resolverConfig ) {
       final File inputFile = new File( modelFileName );
-      final Try<VersionedModel> versionedModel = loadAndResolveModel( inputFile, resolverConfig );
-      return versionedModel.recover( throwable -> {
+      final Try<AspectContext> context = loadAndResolveModel( inputFile, resolverConfig );
+      return context.recover( throwable -> {
          // Model can not be loaded, root cause e.g. File not found
          if ( throwable instanceof IllegalArgumentException ) {
             throw new CommandException( "Can not open file for reading: " + modelFileName, throwable );
@@ -123,7 +76,7 @@ public abstract class AbstractCommand implements Runnable {
          }
 
          // Another exception, e.g. syntax error. Let the validator handle this
-         final List<Violation> violations = new AspectModelValidator().validateModel( versionedModel );
+         final List<Violation> violations = new AspectModelValidator().validateModel( context.map( AspectContext::rdfModel ) );
          System.out.println( new ViolationFormatter().apply( violations ) );
 
          System.exit( 1 );
@@ -133,11 +86,11 @@ public abstract class AbstractCommand implements Runnable {
 
    protected void generateDiagram( final String inputFileName, final AspectModelDiagramGenerator.Format targetFormat, final String outputFileName,
          final String languageTag, final ExternalResolverMixin resolverConfig ) throws IOException {
-      final VersionedModel model = loadModelOrFail( inputFileName, resolverConfig );
-      final AspectModelDiagramGenerator generator = new AspectModelDiagramGenerator( model );
+      final AspectContext context = loadModelOrFail( inputFileName, resolverConfig );
+      final AspectModelDiagramGenerator generator = new AspectModelDiagramGenerator( context.rdfModel() );
       final Set<AspectModelDiagramGenerator.Format> targetFormats = new HashSet<>();
       targetFormats.add( targetFormat );
-      final Set<Locale> languagesUsedInModel = LanguageCollector.collectUsedLanguages( model.getModel() );
+      final Set<Locale> languagesUsedInModel = LanguageCollector.collectUsedLanguages( context.rdfModel().getModel() );
       if ( !languagesUsedInModel.contains( Locale.forLanguageTag( languageTag ) ) ) {
          throw new CommandException( String.format( "The model does not contain the desired language: %s.", languageTag ) );
       }

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectMigrateCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectMigrateCommand.java
@@ -13,6 +13,9 @@
 
 package io.openmanufacturing.sds.aspect;
 
+import static io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver.fileToUrn;
+import static io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver.loadButNotResolveModel;
+
 import java.io.File;
 import java.io.PrintWriter;
 

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectPrettyPrintCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectPrettyPrintCommand.java
@@ -13,6 +13,9 @@
 
 package io.openmanufacturing.sds.aspect;
 
+import static io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver.fileToUrn;
+import static io.openmanufacturing.sds.aspectmodel.resolver.AspectModelResolver.loadButNotResolveModel;
+
 import java.io.File;
 import java.io.PrintWriter;
 

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectValidateCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/AspectValidateCommand.java
@@ -23,6 +23,7 @@ import io.openmanufacturing.sds.aspectmodel.shacl.violation.Violation;
 import io.openmanufacturing.sds.aspectmodel.validation.services.AspectModelValidator;
 import io.openmanufacturing.sds.aspectmodel.validation.services.DetailedViolationFormatter;
 import io.openmanufacturing.sds.aspectmodel.validation.services.ViolationFormatter;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import io.vavr.control.Try;
 import picocli.CommandLine;
 
@@ -49,7 +50,7 @@ public class AspectValidateCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      final Try<VersionedModel> versionedModel = loadAndResolveModel( new File( parentCommand.getInput() ), customResolver );
+      final Try<VersionedModel> versionedModel = loadAndResolveModel( new File( parentCommand.getInput() ), customResolver ).map( AspectContext::rdfModel );
       final AspectModelValidator validator = new AspectModelValidator();
 
       final List<Violation> violations = validator.validateModel( versionedModel );

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToAasCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToAasCommand.java
@@ -21,7 +21,6 @@ import io.openmanufacturing.sds.aspect.AspectToCommand;
 import io.openmanufacturing.sds.aspectmodel.aas.AspectModelAASGenerator;
 import io.openmanufacturing.sds.exception.CommandException;
 import io.openmanufacturing.sds.metamodel.Aspect;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -44,14 +43,7 @@ public class AspectToAasCommand extends AbstractCommand {
 
    @CommandLine.Option(
          names = { "--format", "-f" },
-         description =
-               "The file format the AAS is to be generated. Valid options are \""
-                     + AASX
-                     + "\" and \""
-                     + XML
-                     + "\". Default is \""
-                     + XML
-                     + "\"." )
+         description = "The file format the AAS is to be generated. Valid options are \"" + AASX + "\" and \"" + XML + "\". Default is \"" + XML + "\"." )
    private String format = XML;
 
    @CommandLine.ParentCommand
@@ -63,9 +55,7 @@ public class AspectToAasCommand extends AbstractCommand {
    @Override
    public void run() {
       final AspectModelAASGenerator generator = new AspectModelAASGenerator();
-      final Aspect aspect =
-            AspectModelLoader.fromVersionedModelUnchecked(
-                  loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ) );
+      final Aspect aspect = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ).aspect();
       try {
          // we intentionally override the name of the generated artifact here to the name explicitly
          // desired by the user (outputFilePath), as opposed to what the model thinks it should be

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToHtmlCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToHtmlCommand.java
@@ -25,6 +25,7 @@ import io.openmanufacturing.sds.ExternalResolverMixin;
 import io.openmanufacturing.sds.aspect.AspectToCommand;
 import io.openmanufacturing.sds.aspectmodel.generator.docu.AspectModelDocumentationGenerator;
 import io.openmanufacturing.sds.exception.CommandException;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import picocli.CommandLine;
 
 @CommandLine.Command( name = AspectToHtmlCommand.COMMAND_NAME,
@@ -35,7 +36,6 @@ import picocli.CommandLine;
       mixinStandardHelpOptions = true
 )
 public class AspectToHtmlCommand extends AbstractCommand {
-
    public static final String COMMAND_NAME = "html";
 
    @CommandLine.Option( names = { "--output", "-o" }, description = "Output file path (default: stdout)" )
@@ -56,8 +56,8 @@ public class AspectToHtmlCommand extends AbstractCommand {
    @Override
    public void run() {
       try {
-         final AspectModelDocumentationGenerator generator = new AspectModelDocumentationGenerator(
-               loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ) );
+         final AspectContext context = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver );
+         final AspectModelDocumentationGenerator generator = new AspectModelDocumentationGenerator( context );
          final Map<AspectModelDocumentationGenerator.HtmlGenerationOption, String> generationArgs = new HashMap<>();
          generationArgs.put( AspectModelDocumentationGenerator.HtmlGenerationOption.STYLESHEET, "" );
          if ( customCSSFile != null ) {

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToJavaCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToJavaCommand.java
@@ -15,14 +15,20 @@ package io.openmanufacturing.sds.aspect.to;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import io.openmanufacturing.sds.AbstractCommand;
 import io.openmanufacturing.sds.ExternalResolverMixin;
 import io.openmanufacturing.sds.aspect.AspectToCommand;
+import io.openmanufacturing.sds.aspectmodel.java.JavaCodeGenerationConfig;
+import io.openmanufacturing.sds.aspectmodel.java.JavaCodeGenerationConfigBuilder;
 import io.openmanufacturing.sds.aspectmodel.java.JavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.java.metamodel.StaticMetaModelJavaGenerator;
 import io.openmanufacturing.sds.aspectmodel.java.pojo.AspectModelJavaGenerator;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
+import io.openmanufacturing.sds.exception.CommandException;
+import io.openmanufacturing.sds.metamodel.Aspect;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import picocli.CommandLine;
 
 @CommandLine.Command( name = AspectToJavaCommand.COMMAND_NAME,
@@ -63,8 +69,8 @@ public class AspectToJavaCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      final VersionedModel model = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver );
-      final JavaGenerator javaGenerator = generateStaticMetaModelJavaClasses ? getStaticModelGenerator( model ) : getModelGenerator( model );
+      final AspectContext context = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver );
+      final JavaGenerator javaGenerator = generateStaticMetaModelJavaClasses ? getStaticModelGenerator( context ) : getModelGenerator( context );
       javaGenerator.generate( artifact -> {
          final String path = artifact.getPackageName();
          final String fileName = artifact.getClassName();
@@ -72,18 +78,25 @@ public class AspectToJavaCommand extends AbstractCommand {
       } );
    }
 
-   private JavaGenerator getStaticModelGenerator( final VersionedModel model ) {
+   private JavaCodeGenerationConfig buildConfig( final Aspect aspect ) {
       final File templateLibFile = Path.of( templateLib ).toFile();
-      return packageName.isEmpty() ?
-            new StaticMetaModelJavaGenerator( model, executeLibraryMacros, templateLibFile ) :
-            new StaticMetaModelJavaGenerator( model, packageName, executeLibraryMacros, templateLibFile );
+      final String pkgName = Optional.ofNullable( packageName )
+            .flatMap( pkg -> pkg.isBlank() ? Optional.empty() : Optional.of( pkg ) )
+            .or( () -> aspect.getAspectModelUrn().map( AspectModelUrn::getNamespace ) )
+            .orElseThrow( () -> new CommandException( "Could not determine Aspect's namespace" ) );
+      return JavaCodeGenerationConfigBuilder.builder()
+            .executeLibraryMacros( executeLibraryMacros )
+            .templateLibFile( templateLibFile )
+            .enableJacksonAnnotations( !disableJacksonAnnotations )
+            .packageName( pkgName )
+            .build();
    }
 
-   private JavaGenerator getModelGenerator( final VersionedModel model ) {
-      final boolean enableJacksonAnnotations = !disableJacksonAnnotations;
-      final File templateLibFile = Path.of( templateLib ).toFile();
-      return packageName.isEmpty() ?
-            new AspectModelJavaGenerator( model, enableJacksonAnnotations, executeLibraryMacros, templateLibFile ) :
-            new AspectModelJavaGenerator( model, packageName, enableJacksonAnnotations, executeLibraryMacros, templateLibFile );
+   private JavaGenerator getStaticModelGenerator( final AspectContext context ) {
+      return new StaticMetaModelJavaGenerator( context.aspect(), buildConfig( context.aspect() ) );
+   }
+
+   private JavaGenerator getModelGenerator( final AspectContext context ) {
+      return new AspectModelJavaGenerator( context.aspect(), buildConfig( context.aspect() ) );
    }
 }

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToJsonSchemaCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToJsonSchemaCommand.java
@@ -14,6 +14,8 @@
 package io.openmanufacturing.sds.aspect.to;
 
 import java.io.IOException;
+import java.util.Locale;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,9 +26,6 @@ import io.openmanufacturing.sds.aspect.AspectToCommand;
 import io.openmanufacturing.sds.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
 import io.openmanufacturing.sds.exception.CommandException;
 import io.openmanufacturing.sds.metamodel.Aspect;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
-import java.util.Locale;
-import java.util.Optional;
 import picocli.CommandLine;
 
 @CommandLine.Command( name = AspectToJsonSchemaCommand.COMMAND_NAME,
@@ -37,7 +36,6 @@ import picocli.CommandLine;
       mixinStandardHelpOptions = true
 )
 public class AspectToJsonSchemaCommand extends AbstractCommand {
-
    public static final String COMMAND_NAME = "schema";
 
    @CommandLine.Option( names = { "--output", "-o" }, description = "Output file path (default: stdout)" )
@@ -56,7 +54,7 @@ public class AspectToJsonSchemaCommand extends AbstractCommand {
    @Override
    public void run() {
       final AspectModelJsonSchemaGenerator generator = new AspectModelJsonSchemaGenerator();
-      final Aspect aspect = AspectModelLoader.fromVersionedModelUnchecked( loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ) );
+      final Aspect aspect = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ).aspect();
       final Locale locale = Optional.ofNullable( language ).map( Locale::forLanguageTag ).orElse( Locale.ENGLISH );
       final JsonNode schema = generator.apply( aspect, locale );
 

--- a/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToOpenapiCommand.java
+++ b/tools/bamm-cli/src/main/java/io/openmanufacturing/sds/aspect/to/AspectToOpenapiCommand.java
@@ -105,7 +105,7 @@ public class AspectToOpenapiCommand extends AbstractCommand {
    public void run() {
       final Locale locale = Optional.ofNullable( language ).map( Locale::forLanguageTag ).orElse( Locale.ENGLISH );
       final AspectModelOpenApiGenerator generator = new AspectModelOpenApiGenerator();
-      final Aspect aspect = AspectModelLoader.fromVersionedModelUnchecked( loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ) );
+      final Aspect aspect = loadModelOrFail( parentCommand.parentCommand.getInput(), customResolver ).aspect();
       if ( generateJsonOpenApiSpec ) {
          generateJson( generator, aspect, locale );
       } else {

--- a/tools/bamm-cli/src/test/java/io/openmanufacturing/sds/TestCommandExecutor.java
+++ b/tools/bamm-cli/src/test/java/io/openmanufacturing/sds/TestCommandExecutor.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import io.openmanufacturing.sds.aspectmodel.resolver.CommandExecutor;
+
 public class TestCommandExecutor {
 
    @EnabledOnOs( OS.WINDOWS )

--- a/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateDiagram.java
+++ b/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateDiagram.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import io.openmanufacturing.sds.aspectmodel.generator.diagram.AspectModelDiagramGenerator;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 
 @Mojo( name = "generateDiagram", defaultPhase =  LifecyclePhase.GENERATE_RESOURCES )
 public class GenerateDiagram extends AspectModelMojo {
@@ -39,14 +40,14 @@ public class GenerateDiagram extends AspectModelMojo {
    public void execute() throws MojoExecutionException {
       validateParameters();
 
-      final Set<VersionedModel> aspectModels = loadModelsOrFail();
+      final Set<AspectContext> aspectModels = loadModelsOrFail();
       try {
          final Set<AspectModelDiagramGenerator.Format> formats = targetFormats.stream()
                .map( targetFormat -> AspectModelDiagramGenerator.Format.valueOf( targetFormat.toUpperCase() ) )
                .collect( Collectors.toSet() );
 
-         for ( final VersionedModel aspectModel : aspectModels ) {
-            final AspectModelDiagramGenerator generator = new AspectModelDiagramGenerator( aspectModel );
+         for ( final AspectContext aspectModel : aspectModels ) {
+            final AspectModelDiagramGenerator generator = new AspectModelDiagramGenerator( aspectModel.rdfModel() );
             generator.generateDiagrams( formats, name -> getStreamForFile( name, outputDirectory ) );
          }
       } catch ( final IOException exception ) {

--- a/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateDocumentation.java
+++ b/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateDocumentation.java
@@ -28,24 +28,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.openmanufacturing.sds.aspectmodel.generator.docu.AspectModelDocumentationGenerator;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 
-@Mojo( name = "generateDocumentation", defaultPhase =  LifecyclePhase.GENERATE_RESOURCES )
+@Mojo( name = "generateDocumentation", defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class GenerateDocumentation extends AspectModelMojo {
 
    private final Logger logger = LoggerFactory.getLogger( GenerateDocumentation.class );
 
    @Parameter
-   private String htmlCustomCSSFilePath = "";
+   private final String htmlCustomCSSFilePath = "";
 
    @Override
    public void execute() throws MojoExecutionException {
       validateParameters();
 
       try {
-         final Set<VersionedModel> aspectModels = loadModelsOrFail();
-         for ( final VersionedModel aspectModel : aspectModels ) {
-            final AspectModelDocumentationGenerator generator = new AspectModelDocumentationGenerator( aspectModel );
+         final Set<AspectContext> aspectModels = loadModelsOrFail();
+         for ( final AspectContext context : aspectModels ) {
+            final AspectModelDocumentationGenerator generator = new AspectModelDocumentationGenerator( context );
             final Map<AspectModelDocumentationGenerator.HtmlGenerationOption, String> generationArgs = new HashMap<>();
             generationArgs.put( AspectModelDocumentationGenerator.HtmlGenerationOption.STYLESHEET, "" );
             if ( !htmlCustomCSSFilePath.isEmpty() ) {

--- a/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateJsonPayload.java
+++ b/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateJsonPayload.java
@@ -14,6 +14,7 @@
 package io.openmanufacturing.sds.aspectmodel;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -25,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import io.openmanufacturing.sds.aspectmodel.generator.json.AspectModelJsonPayloadGenerator;
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 
 @Mojo( name = "generateJsonPayload", defaultPhase =  LifecyclePhase.GENERATE_RESOURCES )
 public class GenerateJsonPayload extends AspectModelMojo {
@@ -35,10 +38,10 @@ public class GenerateJsonPayload extends AspectModelMojo {
    public void execute() throws MojoExecutionException, MojoFailureException {
       validateParameters();
 
-      final Set<VersionedModel> aspectModels = loadModelsOrFail();
+      final Set<AspectContext> aspectModels = loadModelsOrFail();
       try {
-         for ( VersionedModel aspectModel : aspectModels ) {
-            final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator( aspectModel );
+         for ( AspectContext context : aspectModels ) {
+            final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator( context );
             generator.generateJsonPretty( name -> getStreamForFile( name + ".json", outputDirectory ) );
          }
       } catch ( final IOException exception ) {

--- a/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateOpenApiSpec.java
+++ b/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/GenerateOpenApiSpec.java
@@ -39,11 +39,10 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import io.openmanufacturing.sds.aspectmodel.generator.openapi.AspectModelOpenApiGenerator;
 import io.openmanufacturing.sds.aspectmodel.generator.openapi.PagingOption;
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.metamodel.Aspect;
-import io.openmanufacturing.sds.metamodel.loader.AspectModelLoader;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 
-@Mojo( name = "generateOpenApiSpec", defaultPhase =  LifecyclePhase.GENERATE_RESOURCES )
+@Mojo( name = "generateOpenApiSpec", defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class GenerateOpenApiSpec extends AspectModelMojo {
 
    private final Logger logger = LoggerFactory.getLogger( GenerateOpenApiSpec.class );
@@ -88,7 +87,7 @@ public class GenerateOpenApiSpec extends AspectModelMojo {
    public void execute() throws MojoExecutionException, MojoFailureException {
       validateParameters();
 
-      final Set<VersionedModel> aspectModels = loadModelsOrFail();
+      final Set<AspectContext> aspectModels = loadModelsOrFail();
       final Locale locale = Optional.ofNullable( language ).map( Locale::forLanguageTag ).orElse( Locale.ENGLISH );
       try {
          final OpenApiFormat format = OpenApiFormat.valueOf( outputFormat.toUpperCase() );
@@ -114,9 +113,9 @@ public class GenerateOpenApiSpec extends AspectModelMojo {
       super.validateParameters();
    }
 
-   private void generateOpenApiSpecJson( final Set<VersionedModel> aspectModels, final Locale locale ) throws MojoExecutionException {
-      for ( final VersionedModel aspectModel : aspectModels ) {
-         final Aspect aspect = AspectModelLoader.fromVersionedModelUnchecked( aspectModel );
+   private void generateOpenApiSpecJson( final Set<AspectContext> aspectModels, final Locale locale ) throws MojoExecutionException {
+      for ( final AspectContext context : aspectModels ) {
+         final Aspect aspect = context.aspect();
          JsonNode result = JsonNodeFactory.instance.objectNode();
          final Optional<String> aspectParameterDefinitionFile = getFileAsString( aspectParameterFile );
          if ( aspectParameterDefinitionFile.isPresent() ) {
@@ -139,9 +138,9 @@ public class GenerateOpenApiSpec extends AspectModelMojo {
       }
    }
 
-   private void generateOpenApiSpecYaml( final Set<VersionedModel> aspectModels, final Locale locale ) throws MojoExecutionException {
-      for ( final VersionedModel aspectModel : aspectModels ) {
-         final Aspect aspect = AspectModelLoader.fromVersionedModelUnchecked( aspectModel );
+   private void generateOpenApiSpecYaml( final Set<AspectContext> aspectModels, final Locale locale ) throws MojoExecutionException {
+      for ( final AspectContext context : aspectModels ) {
+         final Aspect aspect = context.aspect();
          try {
             final String yamlSpec = generator.applyForYaml( aspect, useSemanticApiVersion, aspectApiBaseUrl, Optional.ofNullable( aspectResourcePath ),
                   getFileAsString( aspectParameterFile ), includeQueryApi, getPagingFromArgs(), locale );

--- a/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/Validate.java
+++ b/tools/sds-aspect-model-maven-plugin/src/main/java/io/openmanufacturing/sds/aspectmodel/Validate.java
@@ -14,6 +14,7 @@
 package io.openmanufacturing.sds.aspectmodel;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -23,10 +24,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.aspectmodel.shacl.violation.Violation;
+import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
 import io.openmanufacturing.sds.aspectmodel.validation.services.AspectModelValidator;
 import io.openmanufacturing.sds.aspectmodel.validation.services.ViolationFormatter;
+import io.openmanufacturing.sds.metamodel.AspectContext;
 import io.vavr.control.Try;
 
 @Mojo( name = "validate", defaultPhase = LifecyclePhase.VALIDATE )
@@ -39,9 +41,9 @@ public class Validate extends AspectModelMojo {
    public void execute() throws MojoExecutionException, MojoFailureException {
       validateParameters();
 
-      final Set<Try<VersionedModel>> resolvedModels = loadAndResolveModels();
-      for ( final Try<VersionedModel> versionedModel : resolvedModels ) {
-         final List<Violation> violations = validator.validateModel( versionedModel );
+      final Set<Try<AspectContext>> resolvedModels = loadAndResolveModels();
+      for ( final Try<AspectContext> context : resolvedModels ) {
+         final List<Violation> violations = validator.validateModel( context.map( AspectContext::rdfModel ) );
          if ( !violations.isEmpty() ) {
             throw new MojoFailureException( new ViolationFormatter().apply( violations ) );
          }


### PR DESCRIPTION
Fixes #278.

This adjusts the constructors of the document and code generators so that the
Aspect they intend to work on must be passed as an explicit argument. For that
the `AspectContext` is introduced which wraps a `VersionedModel` and a single
`Aspect` that is contained in the model. The task to determine the Aspect from
the loaded model is delegated to the caller (here bamm-cli and Maven plugin).