### PR TITLE
Fix documentation configuration for release build

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
       - name: Publish to OSSRH
         if: ${{ !contains( github.event.inputs.release_version, '-M' ) }}
-        run: mvn -B clean -pl '!sds-sdk-test-report,!tools/bamm-cli' deploy -DskipTests -Prelease-build
+        run: mvn -B clean -pl '!sds-sdk-test-report,!sds-documentation,!tools/bamm-cli' deploy -DskipTests -Prelease-build
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
           write-mode: overwrite
       - name: Publish to Github
         if: contains( github.event.inputs.release_version, '-M' )
-        run: mvn -s ./settings.xml -B clean -pl '!sds-sdk-test-report,!tools/bamm-cli' deploy -DskipTests -Pmilestone-build
+        run: mvn -s ./settings.xml -B clean -pl '!sds-sdk-test-report,!sds-documentation,!tools/bamm-cli' deploy -DskipTests -Pmilestone-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
           PGP_KEY_PASSWORD: ${{ secrets.PGP_KEY_PASSWORD }}

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -19,6 +19,7 @@
       <artifactId>sds-sdk-parent</artifactId>
       <groupId>io.openmanufacturing</groupId>
       <version>DEV-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
The Maven setup for the sds-documentation module is currently broken, see failed
release build: https://github.com/eclipse-esmf/esmf-sdk/actions/runs/4051189413/jobs/6969261232