### PR TITLE
Run mvn install before setting the version in release pipeline

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -54,6 +54,7 @@ jobs:
           git checkout -b $release_branch_name
       - name: Set Maven version
         run: |
+          mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true
           mvn versions:set -DnewVersion=${{ github.event.inputs.release_version }}
           mvn versions:commit
       - name: Set Antora version


### PR DESCRIPTION
This is necessary for the release to work if there are new modules because maven
is able to resolve modules from the working directory but only from the local
repository