### PR TITLE
Explicitly set git-auto-commit file pattern

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -261,6 +261,7 @@ jobs:
            commit_user_name: github-actions
            commit_user_email: github-actions@github.com
            commit_author: Author <actions@github.com>
+           file_pattern: 'documentation/developer-guide/antora.yml pom.xml */*/pom.xml'
 
       # Full release: Github
       - name: "Create Github release (full)"


### PR DESCRIPTION
This should prevent API timeouts since nexus-staging and the binaries are
excluded from the commit.