### PR TITLE
Fix committing of updated documentation version on release

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -276,7 +276,7 @@ jobs:
            commit_user_name: github-actions
            commit_user_email: github-actions@github.com
            commit_author: Author <actions@github.com>
-           file_pattern: 'documentation/developer-guide/antora.yml pom.xml */*/pom.xml'
+           file_pattern: 'documentation/developer-guide/antora.yml pom.xml */pom.xml */*/pom.xml'
 
       # Full release: Github
       - name: "Create Github release (full)"


### PR DESCRIPTION
Since the file pattern for the automatic commit accidentally excluded the
documentation/pom.xml, the documentation version was not automatically updated.