### PR TITLE
Extend migrator to also consider the "curie" literals.

### DIFF
--- a/core/esmf-aspect-meta-model-version-migrator/src/main/java/org/eclipse/esmf/aspectmodel/versionupdate/migrator/AbstractUriRewriter.java
+++ b/core/esmf-aspect-meta-model-version-migrator/src/main/java/org/eclipse/esmf/aspectmodel/versionupdate/migrator/AbstractUriRewriter.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.jena.datatypes.BaseDatatype;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -57,9 +59,17 @@ public abstract class AbstractUriRewriter extends AbstractSammMigrator {
       return rewriteUri( property.getURI(), oldToNewNamespaces ).map( ResourceFactory::createProperty ).orElse( property );
    }
 
+   protected Literal updateLiteral( final Literal literal, final Map<String, String> oldToNewNamespaces ) {
+      return rewriteUri( literal.getDatatypeURI(), oldToNewNamespaces )
+            .map( uri -> ResourceFactory.createTypedLiteral( literal.getLexicalForm(), new BaseDatatype( uri ) ) )
+            .orElse( literal );
+   }
+
    protected RDFNode updateRdfNode( final RDFNode rdfNode, final Map<String, String> oldToNewNamespaces ) {
       if ( rdfNode.isResource() ) {
          return updateResource( rdfNode.asResource(), oldToNewNamespaces );
+      } else if ( rdfNode.isLiteral() ) { // needed especially for "curie" literals, which are versioned: "unit:day"^^samm:curie
+         return updateLiteral( rdfNode.asLiteral(), oldToNewNamespaces );
       }
       return rdfNode;
    }
@@ -88,7 +98,8 @@ public abstract class AbstractUriRewriter extends AbstractSammMigrator {
     * @param oldToNewNamespaces the map of old RDF namespaces to their new counterparts
     * @return the prefix map
     */
-   protected Map<String, String> buildPrefixMap( final Model sourceModel, final Map<String, String> targetPrefixes, final Map<String, String> oldToNewNamespaces ) {
+   protected Map<String, String> buildPrefixMap( final Model sourceModel, final Map<String, String> targetPrefixes,
+         final Map<String, String> oldToNewNamespaces ) {
       return sourceModel.getNsPrefixMap().keySet().stream()
             .map( prefix -> Map.<String, String> entry( prefix, targetPrefixes.getOrDefault( prefix, sourceModel.getNsPrefixURI( prefix ) ) ) )
             .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );

--- a/core/esmf-aspect-meta-model-version-migrator/src/test/java/org/eclipse/esmf/aspectmodel/versionupdate/MigratorTest.java
+++ b/core/esmf-aspect-meta-model-version-migrator/src/test/java/org/eclipse/esmf/aspectmodel/versionupdate/MigratorTest.java
@@ -22,22 +22,22 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDF;
+import org.assertj.core.api.Assertions;
 import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.resolver.services.VersionedModel;
 import org.eclipse.esmf.aspectmodel.vocabulary.SAMM;
 import org.eclipse.esmf.samm.KnownVersion;
 import org.eclipse.esmf.test.MetaModelVersions;
 import org.eclipse.esmf.test.TestAspect;
-
-import com.google.common.collect.Streams;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.vocabulary.RDF;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.Streams;
 
 public class MigratorTest extends MetaModelVersions {
 
@@ -116,6 +116,16 @@ public class MigratorTest extends MetaModelVersions {
             .filter( statement -> statement.getPredicate().getURI().equals( sammNameUrn ) )
             .collect( Collectors.toList() );
       assertThat( sammNameStatements ).isEmpty();
+   }
+
+   @ParameterizedTest
+   @MethodSource( "allVersions" )
+   public void testCurieMigration( final KnownVersion metaModelVersion ) {
+      final VersionedModel versionedModel = TestResources.getModelWithoutResolution( TestAspect.ASPECT_WITH_CURIE, metaModelVersion );
+      final VersionedModel rewrittenModel = migratorService.updateMetaModelVersion( versionedModel ).get();
+      final SAMM latestSamm = new SAMM( KnownVersion.getLatest() );
+      assertThat( rewrittenModel.getRawModel().listStatements( null, latestSamm.exampleValue(), (RDFNode) null ).nextStatement().getObject().asLiteral()
+            .getDatatypeURI() ).isEqualTo( latestSamm.curie().getURI() );
    }
 
    private Set<String> getAllUris( final Model model ) {


### PR DESCRIPTION
Fixes #382 