### PR TITLE
SAMM-CLI aas generation: ConceptDescription idShort based on property name

### DIFF
--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAASVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAASVisitor.java
@@ -358,13 +358,12 @@ public class AspectModelAASVisitor implements AspectVisitor<Environment, Context
       if ( property.getCharacteristic().isEmpty() ) {
          return;
       }
-      final Characteristic characteristic = property.getCharacteristic().get();
       // check if the concept description is already created. If not create a new one.
       if ( !context.hasEnvironmentConceptDescription( property.getAspectModelUrn().toString() ) ) {
          final ConceptDescription conceptDescription =
                new DefaultConceptDescription.Builder()
-                     .idShort( characteristic.getName() )
-                     .displayName( LangStringMapper.NAME.map( characteristic.getPreferredNames() ) )
+                     .idShort( property.getName() )
+                     .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
                      .embeddedDataSpecifications( extractEmbeddedDataSpecification( property ) )
                      .id( DEFAULT_MAPPER.determineIdentifierFor( property ) )
                      .build();

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAASGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAASGeneratorTest.java
@@ -290,7 +290,7 @@ class AspectModelAASGeneratorTest {
       assertEquals( 2, env.getConceptDescriptions().size() );
 
       final DataSpecificationIec61360 dataSpecificationContent = (DataSpecificationIec61360) env.getConceptDescriptions().stream()
-            .filter( conceptDescription -> conceptDescription.getIdShort().equals( "TestEnumeration" ) )
+            .filter( conceptDescription -> conceptDescription.getIdShort().equals( "testProperty" ) )
             .findFirst()
             .get()
             .getEmbeddedDataSpecifications()


### PR DESCRIPTION
Changes:

- Provide id_short of Property name to ConceptDescription;
- Provide Property displayName to ConceptDescription;
- Fix tests.

Fixes #457