### PR TITLE
Allow starting samm.exe from explorer/desktop

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -195,8 +195,6 @@ jobs:
           unset JAVA_TOOL_OPTIONS
           mvn -B clean verify -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
           mvn -B verify -Pnative -Dmaven.wagon.httpconnectionManager.ttlSeconds=60
-
-          echo "start cmd /k samm.exe help" > tools/samm-cli/target/start-samm-cli.bat
         shell: bash
 
       - name: Upload Windows binary
@@ -205,7 +203,6 @@ jobs:
           name: windows-artifacts
           path: |
             tools/samm-cli/target/samm.exe
-            tools/samm-cli/target/*.bat
             tools/samm-cli/target/*.dll
             tools/samm-cli/target/lib/
 
@@ -254,7 +251,7 @@ jobs:
       - name: Prepare release
         run: |
           # Create Windows CLI zip
-          zip -9 -r samm-cli-${{ github.event.inputs.release_version }}-windows-x86_64.zip samm.exe *.bat *.dll
+          zip -9 -r samm-cli-${{ github.event.inputs.release_version }}-windows-x86_64.zip samm.exe *.dll
 
       # Full release: Maven Central
       # The (apparently) only way to retrieve the staging profile id

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -35,7 +35,7 @@ alias samm='java -jar /location/to/samm-cli-{esmf-sdk-version}.jar'
 . *For the Windows native executable:*
 * *Download*: Download via above link or visit the repository of the Java SDK which contains the SAMM CLI at the Github https://github.com/eclipse-esmf/esmf-sdk/releases[releases page] and download executable file for Windows.
 * *Extract*: extract it to a location of your choice.
-* *Open* the provided `start-samm-cli.bat`: This will open a command prompt in this directory, where you can enter further `samm` commands.
+* *Open* `samm.exe`: This will open a command prompt in this directory, where you can enter further `samm` commands.
 * *Input*: Make sure to read the below documentation and provide model files in the correct xref:models-directory-structure[directory structure].
 
 . *For the Linux native executable:*

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -89,9 +89,9 @@ public class SammCli extends AbstractCommand {
    }
 
    public static void main( final String[] argv ) {
-      // Check if the .exe was started from the desktop/explorer.
+      // Check if the .exe was started on Windows without arguments: Most likely opened from Explorer or Desktop.
       // If yes, open a command prompt to continue working instead.
-      if ( new IsWindows().getAsBoolean() && System.console() == null && argv.length == 0 ) {
+      if ( new IsWindows().getAsBoolean() && argv.length == 0 ) {
          ProcessHandle.current().info().command().ifPresent( executable -> {
             // Only spawn terminals for native executable
             if ( !executable.endsWith( "java.exe" ) ) {

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.esmf;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -92,11 +93,17 @@ public class SammCli extends AbstractCommand {
       // If yes, open a command prompt to continue working instead.
       if ( new IsWindows().getAsBoolean() && System.console() == null && argv.length == 0 ) {
          ProcessHandle.current().info().command().ifPresent( executable -> {
-            try {
-               Runtime.getRuntime().exec( "cmd /k start cmd /k " + executable + " help" );
-               System.exit( 0 );
-            } catch ( final IOException e ) {
-               // Ignore, continue as usual
+            // Only spawn terminals for native executable
+            if ( !executable.endsWith( "java.exe" ) ) {
+               try {
+                  final File exeFile = new File( executable );
+                  final String directory = exeFile.getParent();
+                  final String exeFileName = exeFile.getName();
+                  Runtime.getRuntime().exec( "cmd /k cd /d \"" + directory + "\" & start cmd /k " + exeFileName + " help" );
+                  System.exit( 0 );
+               } catch ( final Exception e ) {
+                  // Ignore, continue as usual
+               }
             }
          } );
       }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -161,10 +161,4 @@ public class SammCli extends AbstractCommand {
       System.out.println( commandLine.getHelp().fullSynopsis() );
       System.out.println( format( "Run @|bold " + commandLine.getCommandName() + " help|@ for help." ) );
    }
-
-   void testProgrammaticConfiguration() {
-      final CommandLine.Model.CommandSpec spec = CommandLine.Model.CommandSpec.create();
-      spec.usageMessage().footer( "asdf" ).description( "asdf" );
-      spec.addOption( CommandLine.Model.OptionSpec.builder( "-c" ).type( int.class ).build() );
-   }
 }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -93,7 +93,7 @@ public class SammCli extends AbstractCommand {
       if ( new IsWindows().getAsBoolean() && System.console() == null && argv.length == 0 ) {
          ProcessHandle.current().info().command().ifPresent( executable -> {
             try {
-               Runtime.getRuntime().exec( "cmd /k " + executable + " help" );
+               Runtime.getRuntime().exec( "cmd /k start cmd /k " + executable + " help" );
                System.exit( 0 );
             } catch ( final IOException e ) {
                // Ignore, continue as usual

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -90,7 +90,7 @@ public class SammCli extends AbstractCommand {
    public static void main( final String[] argv ) {
       // Check if the .exe was started from the desktop/explorer.
       // If yes, open a command prompt to continue working instead.
-      if ( new IsWindows().getAsBoolean() && System.console() == null ) {
+      if ( new IsWindows().getAsBoolean() && System.console() == null && argv.length == 0 ) {
          ProcessHandle.current().info().command().ifPresent( executable -> {
             try {
                Runtime.getRuntime().exec( "cmd /k " + executable + " help" );

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 
 import org.eclipse.esmf.aas.AasCommand;
 import org.eclipse.esmf.aspect.AspectCommand;
+import org.eclipse.esmf.substitution.IsWindows;
 
 import org.fusesource.jansi.AnsiConsole;
 import picocli.CommandLine;
@@ -87,6 +88,19 @@ public class SammCli extends AbstractCommand {
    }
 
    public static void main( final String[] argv ) {
+      // Check if the .exe was started from the desktop/explorer.
+      // If yes, open a command prompt to continue working instead.
+      if ( new IsWindows().getAsBoolean() && System.console() == null ) {
+         ProcessHandle.current().info().command().ifPresent( executable -> {
+            try {
+               Runtime.getRuntime().exec( "cmd /k " + executable + " help" );
+               System.exit( 0 );
+            } catch ( final IOException e ) {
+               // Ignore, continue as usual
+            }
+         } );
+      }
+
       NativeImageHelpers.ensureRequiredEnvironment();
 
       // The disabling color switch needs to be checked before PicoCLI initialization


### PR DESCRIPTION
This removes the need for a separate .bat file. Instead, samm.exe can be opened directly.