### PR TITLE
Generate correct names for SubmodelElementCollections

### DIFF
--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
@@ -299,9 +299,9 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
    }
 
    private SubmodelElement decideOnMapping( final Type type, final Property property, final Context context ) {
-      return type instanceof Entity ?
-            mapToAasSubModelElementCollection( (Entity) type, property, context ) :
-            findPropertyMapper( property ).mapToAasProperty( type, property, context );
+      return type instanceof Entity
+            ? mapToAasSubModelElementCollection( (Entity) type, property, context )
+            : findPropertyMapper( property ).mapToAasProperty( type, property, context );
    }
 
    private SubmodelElementCollection mapToAasSubModelElementCollection( final Entity entity, final Property property,

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
@@ -176,8 +176,7 @@ public class Context {
     * @return the property value at the current property path
     */
    public String getPropertyValue( final String defaultValue ) {
-      return getRawPropertyValue().map( valueNode -> valueNode.asText( defaultValue ) )
-            .orElse( defaultValue );
+      return getRawPropertyValue().flatMap( valueNode -> Optional.ofNullable( valueNode.asText() ) ).orElse( defaultValue );
    }
 
    /**

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -227,7 +227,7 @@ class AspectModelAasGeneratorTest {
       assertThat( env.getSubmodels() ).hasSize( 1 );
       assertThat( env.getSubmodels().get( 0 ).getSubmodelElements() ).hasSize( 1 );
       final SubmodelElementList elementCollection = ((SubmodelElementList) env.getSubmodels().get( 0 ).getSubmodelElements().get( 0 ));
-      final Set<String> testValues = Set.of( "RightEntity", "LeftEntity" );
+      final Set<String> testValues = Set.of( "testProperty", "result" );
       assertThat( elementCollection.getValue() ).as( "Neither left nor right entity contained." )
             .anyMatch( x -> testValues.contains( x.getIdShort() ) );
 

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
-
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
+
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -144,6 +145,8 @@ class AspectModelAasGeneratorTest {
       assertThat( env.getSubmodels().get( 0 ).getSubmodelElements() ).hasSize( 1 );
       final Submodel submodel = env.getSubmodels().get( 0 );
       assertThat( submodel.getSubmodelElements().get( 0 ) ).isInstanceOfSatisfying( SubmodelElementCollection.class, collection -> {
+         assertThat( collection.getIdShort() ).isEqualTo( "testProperty" );
+
          final SubmodelElement property = collection.getValue().stream().findFirst().get();
          assertThat( property.getIdShort() ).isEqualTo( "entityProperty" );
          assertThat( submodel.getSupplementalSemanticIds() ).anySatisfy( ref -> {
@@ -382,14 +385,13 @@ class AspectModelAasGeneratorTest {
    }
 
    private void checkDataSpecificationIec61360( final Set<String> semanticIds, final Environment env ) {
-      semanticIds.forEach( x -> getDataSpecificationIec61360( x, env ) );
+      semanticIds.forEach( semanticId -> getDataSpecificationIec61360( semanticId, env ) );
    }
 
    private DataSpecificationContent getDataSpecificationIec61360( final String semanticId, final Environment env ) {
-      final List<ConceptDescription> conceptDescriptions = env.getConceptDescriptions();
       final List<ConceptDescription> filteredConceptDescriptions =
-            conceptDescriptions.stream()
-                  .filter( x -> x.getId().equals( semanticId ) )
+            env.getConceptDescriptions().stream()
+                  .filter( conceptDescription -> conceptDescription.getId().equals( semanticId ) )
                   .toList();
       assertThat( filteredConceptDescriptions ).hasSize( 1 );
 

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -35,6 +35,7 @@ import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
@@ -77,7 +78,7 @@ class AspectModelAasGeneratorTest {
                   .satisfies( property ->
                         assertThat( property ).asInstanceOf( type( MultiLanguageProperty.class ) )
                               .extracting( MultiLanguageProperty::getValue )
-                              .asList()
+                              .asInstanceOf( InstanceOfAssertFactories.LIST )
                               .hasSize( 2 )
                               .allSatisfy( langString ->
                                     assertThat( List.of( "en", "de" ) ).contains( ((AbstractLangString) langString).getLanguage() ) ) ) );
@@ -92,11 +93,11 @@ class AspectModelAasGeneratorTest {
                   .anySatisfy( sme ->
                         assertThat( sme ).asInstanceOf( type( SubmodelElementList.class ) )
                               .extracting( SubmodelElementList::getValue )
-                              .asList()
+                              .asInstanceOf( InstanceOfAssertFactories.LIST )
                               .anySatisfy( entity ->
                                     assertThat( entity ).asInstanceOf( type( SubmodelElementCollection.class ) )
                                           .extracting( SubmodelElementCollection::getValue )
-                                          .asList()
+                                          .asInstanceOf( InstanceOfAssertFactories.LIST )
                                           .singleElement( type( Property.class ) )
                                           .extracting( Property::getValue )
                                           .isEqualTo( "The result" ) ) ) );
@@ -111,11 +112,11 @@ class AspectModelAasGeneratorTest {
                   .anySatisfy( sme ->
                         assertThat( sme ).asInstanceOf( type( SubmodelElementList.class ) )
                               .extracting( SubmodelElementList::getValue )
-                              .asList()
+                              .asInstanceOf( InstanceOfAssertFactories.LIST )
                               .anySatisfy( entity ->
                                     assertThat( entity ).asInstanceOf( type( SubmodelElementCollection.class ) )
                                           .extracting( SubmodelElementCollection::getValue )
-                                          .asList()
+                                          .asInstanceOf( InstanceOfAssertFactories.LIST )
                                           .anySatisfy( property ->
                                                 assertThat( property ).asInstanceOf( type( Property.class ) )
                                                       .extracting( Property::getValue )
@@ -223,7 +224,7 @@ class AspectModelAasGeneratorTest {
       final Environment env = getAssetAdministrationShellFromAspect( TestAspect.ASPECT_WITH_EITHER_WITH_COMPLEX_TYPES );
       assertThat( env.getSubmodels() ).hasSize( 1 );
       assertThat( env.getSubmodels().get( 0 ).getSubmodelElements() ).hasSize( 1 );
-      final SubmodelElementList elementCollection = ( (SubmodelElementList) env.getSubmodels().get( 0 ).getSubmodelElements().get( 0 ) );
+      final SubmodelElementList elementCollection = ((SubmodelElementList) env.getSubmodels().get( 0 ).getSubmodelElements().get( 0 ));
       final Set<String> testValues = Set.of( "RightEntity", "LeftEntity" );
       assertThat( elementCollection.getValue() ).as( "Neither left nor right entity contained." )
             .anyMatch( x -> testValues.contains( x.getIdShort() ) );
@@ -246,7 +247,7 @@ class AspectModelAasGeneratorTest {
       final DataSpecificationContent dataSpecificationContent = getDataSpecificationIec61360(
             "urn:samm:org.eclipse.esmf.test:1.0.0#testProperty", env );
 
-      assertThat( ( (DataSpecificationIec61360) dataSpecificationContent ).getUnit() ).isEqualTo( "percent" );
+      assertThat( ((DataSpecificationIec61360) dataSpecificationContent).getUnit() ).isEqualTo( "percent" );
    }
 
    @Test

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGenerator.java
@@ -101,7 +101,7 @@ public class AspectModelAsyncApiGenerator
       messageNode.put( "name", event.getName() );
       messageNode.put( TITLE_FIELD, event.getPreferredName( locale ) );
       messageNode.put( "summary", event.getDescription( locale ) );
-      messageNode.put( "content-type", APPLICATION_JSON );
+      messageNode.put( "contentType", APPLICATION_JSON );
 
       final ObjectNode payloadNode = FACTORY.objectNode();
       payloadNode.put( "$ref", generateRef( COMPONENTS_SCHEMAS_PATH, event.getName() ) );
@@ -136,7 +136,7 @@ public class AspectModelAsyncApiGenerator
       messageNode.put( "name", property.getName() );
       messageNode.put( TITLE_FIELD, property.getPreferredName( locale ) );
       messageNode.put( "summary", property.getDescription( locale ) );
-      messageNode.put( "content-type", APPLICATION_JSON );
+      messageNode.put( "contentType", APPLICATION_JSON );
 
       final ObjectNode payloadNode = FACTORY.objectNode();
       payloadNode.put( "$ref", generateRef( COMPONENTS_SCHEMAS_PATH, property.getName() ) );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AsyncApiSchemaArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AsyncApiSchemaArtifact.java
@@ -53,6 +53,15 @@ public class AsyncApiSchemaArtifact extends AbstractSchemaArtifact implements Ar
       return content;
    }
 
+   /**
+    * Returns the AsyncAPI schema a single YAML string
+    *
+    * @return the AsyncAPI schema
+    */
+   public String getContentAsYaml() {
+      return jsonToYaml( getContent() );
+   }
+
    @Override
    public Map<Path, JsonNode> getContentWithSeparateSchemasAsJson() {
       return getContentWithSeparateSchemasAsJson( Optional.of( "aai" ) );

--- a/core/esmf-aspect-model-document-generators/src/main/resources/asyncapi/AsyncApiRootJson.json
+++ b/core/esmf-aspect-model-document-generators/src/main/resources/asyncapi/AsyncApiRootJson.json
@@ -1,6 +1,5 @@
 {
   "asyncapi": "${AsyncApiVer}",
-  "id": "",
   "info": {
     "title": "MQTT API",
     "version" : "",

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
@@ -114,7 +114,7 @@ class AspectModelAsyncApiGeneratorTest extends MetaModelVersions {
                            "name": "SomeEvent",
                            "title": "Some Event",
                            "summary": "This is some event",
-                           "content-type": "application/json",
+                           "contentType": "application/json",
                            "payload": {
                               "$ref": "#/components/schemas/SomeEvent"
                            }
@@ -184,7 +184,7 @@ class AspectModelAsyncApiGeneratorTest extends MetaModelVersions {
                      "name": "input",
                      "title": "input",
                      "summary": null,
-                     "content-type": "application/json",
+                     "contentType": "application/json",
                      "payload": {
                         "$ref": "#/components/schemas/input"
                      }
@@ -197,7 +197,7 @@ class AspectModelAsyncApiGeneratorTest extends MetaModelVersions {
                         "name": "output",
                         "title": "output",
                         "summary": null,
-                        "content-type": "application/json",
+                        "contentType": "application/json",
                         "payload": {
                            "$ref": "#/components/schemas/output"
                         }

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
@@ -13,8 +13,10 @@ import org.eclipse.esmf.test.MetaModelVersions;
 import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -73,6 +75,22 @@ class AspectModelAsyncApiGeneratorTest extends MetaModelVersions {
       );
 
       assertThat( json ).isEqualTo( expectedJson );
+   }
+
+   @Test
+   void testAsyncApiGeneratorWithoutApplicationIdDoesNotAddEmptyId() throws JsonProcessingException {
+      final Aspect aspect = loadAspect( TestAspect.ASPECT_WITH_EVENT, KnownVersion.getLatest() );
+      final AsyncApiSchemaGenerationConfig config = AsyncApiSchemaGenerationConfigBuilder.builder()
+            .useSemanticVersion( false )
+            .channelAddress( CHANNEL_ADDRESS )
+            .locale( Locale.ENGLISH )
+            .build();
+
+      final AsyncApiSchemaArtifact asyncSpec = asyncApiGenerator.apply( aspect, config );
+      final JsonNode json = asyncSpec.getContent();
+      final String result = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString( json );
+      assertThat( result ).doesNotContain( "\"id\" : \"\"" );
+      assertThat( asyncSpec.getContentAsYaml() ).doesNotContain( "id: \"\"" );
    }
 
    @ParameterizedTest

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/ModelCycleDetector.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/ModelCycleDetector.java
@@ -31,7 +31,7 @@ import org.eclipse.esmf.samm.KnownVersion;
 
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryExecutionDatasetBuilder;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
@@ -40,8 +40,6 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.vocabulary.RDF;
 
 /**
@@ -191,7 +189,7 @@ public class ModelCycleDetector {
 
    private boolean isOptionalProperty( final Resource propertyNode ) {
       final Statement optional = propertyNode.getProperty( samm.optional() );
-      return ( optional != null ) && optional.getBoolean();
+      return (optional != null) && optional.getBoolean();
    }
 
    private String getUniqueName( final Resource property ) {
@@ -260,8 +258,11 @@ public class ModelCycleDetector {
 
    private List<NextHopProperty> getDirectlyReachableProperties( final Model model, final Resource currentProperty ) {
       final List<NextHopProperty> nextHopProperties = new ArrayList<>();
-      try ( final QueryExecution qexec = QueryExecutionFactory.create( query, model ) ) {
-         qexec.setInitialBinding( Binding.builder().add( Var.alloc( "currentProperty" ), currentProperty.asNode() ).build() );
+      try ( final QueryExecution qexec = new QueryExecutionDatasetBuilder()
+            .substitution( "currentProperty", currentProperty )
+            .query( query )
+            .model( model )
+            .build() ) {
          final ResultSet results = qexec.execSelect();
          while ( results.hasNext() ) {
             final QuerySolution solution = results.nextSolution();

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -696,7 +696,7 @@ The name of the Aspect is used to generate parts of the AsyncAPI specification, 
 ==== Mapping of Aspect's operations
 
 The AsyncAPI specification is generated based on SAMM Operations and Events.
-his section describes how specification parts are generated for Operations.
+This section describes how specification parts are generated for Operations.
 If the Aspect also has a non-empty list of Operations defined, such as the one in the following example:
 
 [source,turtle]

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
@@ -121,7 +121,7 @@ public class AspectToAsyncapiCommand extends AbstractCommand {
          if ( generateJsonAsyncApiSpec ) {
             OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue( out, asyncApiSpec.getContent() );
          } else {
-            out.write( jsonToYaml( asyncApiSpec.getContent() ).getBytes( StandardCharsets.UTF_8 ) );
+            out.write( asyncApiSpec.getContentAsYaml().getBytes( StandardCharsets.UTF_8 ) );
          }
       }
    }
@@ -142,15 +142,6 @@ public class AspectToAsyncapiCommand extends AbstractCommand {
                out.write( entry.getValue().getBytes( StandardCharsets.UTF_8 ) );
             }
          }
-      }
-   }
-
-   private String jsonToYaml( final JsonNode json ) {
-      try {
-         return YAML_MAPPER.writeValueAsString( json );
-      } catch ( final JsonProcessingException exception ) {
-         LOG.error( "JSON could not be converted to YAML", exception );
-         return json.toString();
       }
    }
 }

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -896,7 +896,6 @@ class SammCliTest extends MetaModelVersions {
       assertThat( result.exitStatus() ).isZero();
       assertThat( result.stdout() ).isNotEmpty();
       assertThat( result.stdout() ).contains( "asyncapi: 3.0.0" );
-      assertThat( result.stdout() ).contains( "id:" );
       assertThat( result.stderr() ).isEmpty();
    }
 


### PR DESCRIPTION
## Description

When translating from SAMM to AAS, Properties pointing to Entities would lead to
SubmodelElementCollections named like the Entities. They should be named like
the Properties instead.

Fixes #578

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works