### PR TITLE
Fix changing directory in Jenkinsfile

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -53,8 +53,9 @@ pipeline {
                     sh "mkdir -p signed_dir"
                     sh "find unpack_dir -name '*.dll' -exec mv {} signed_dir \\;"
                     sh "curl -o signed_dir/samm.exe -F file=@unpack_dir/samm.exe https://cbi.eclipse.org/authenticode/sign"
-                    sh "cd signed_dir"
-                    sh "zip -r ../samm-cli-${env.version}-windows-x86_64.zip *"
+                    dir('signed_dir') {
+                        sh "zip -r ../samm-cli-${env.version}-windows-x86_64.zip *"
+                    }
                 }
             }
         }


### PR DESCRIPTION
-------

## Description

Since every command is run in a separate shell process, 'sh "cd something"' does
not work as intended. This leads to a creating of the archive with the signed
file in the wrong place, which leads to uploading the original unsigned archive.
This PR uses the correct way to change a directory, the `dir` command block.

Fixes #593

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.