### PR TITLE
Correctly handle models containing multiple Aspects in Maven plugin

### DIFF
--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/ValidateTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/ValidateTest.java
@@ -38,4 +38,12 @@ public class ValidateTest extends AspectModelMojoTest {
             .isInstanceOf( MojoExecutionException.class )
             .hasMessageContaining( "Syntax error in line 17, column 2" );
    }
+
+   @Test
+   public void testValidateMultipleAspectModels() throws Exception {
+      final File testPom = getTestFile( "src/test/resources/validate-pom-multiple-aspect-models.xml" );
+      final Mojo validate = lookupMojo( "validate", testPom );
+      assertThatCode( validate::execute )
+            .doesNotThrowAnyException();
+   }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/validate-pom-multiple-aspect-models.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/validate-pom-multiple-aspect-models.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.eclipse.esmf</groupId>
+   <artifactId>test-validate-mojo</artifactId>
+   <version>1.0</version>
+   <packaging>jar</packaging>
+   <name>Test Validate Mojo</name>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>esmf-aspect-model-maven-plugin</artifactId>
+            <configuration>
+               <modelsRootDirectory>${basedir}/../../core/esmf-test-aspect-models/src/main/resources/valid</modelsRootDirectory>
+               <includes>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#Aspect</include>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithBlankNode</include>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithComplexSet</include>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithList</include>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithSee</include>
+               </includes>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>


### PR DESCRIPTION
-------

## Description

When models are loaded in the Maven plugin using multiple `<include>`
statements, that happen to contain multiple Aspects, it is nondeterministic
which of the Aspects is used for subsequent operations. This PR fixes it by
selecting the Aspect with the URN given in the `<include>`.

Fixes #614

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works