### PR TITLE
Allow customization of error responses in open api generator

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -617,6 +617,8 @@ public class AspectModelOpenApiGenerator
                   node.set( key, mergeObjectNode( (ObjectNode) resultValue, (ObjectNode) value ) );
                } else if ( resultValue.isArray() && value.isArray() ) {
                   node.set( key, mergeArrayNode( (ArrayNode) resultValue, (ArrayNode) value ) );
+               } else {
+                  node.set( key, value );
                }
             } else {
                node.set( key, value );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
@@ -16,7 +16,6 @@ package org.eclipse.esmf.aspectmodel.generator.openapi;
 import static org.eclipse.esmf.aspectmodel.generator.openapi.AspectModelOpenApiGenerator.ObjectNodeExtension.getter;
 
 import java.util.Locale;
-import java.util.Optional;
 
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 
@@ -67,21 +66,20 @@ public record OpenApiSchemaGenerationConfig(
    }
 
    public ObjectNode queriesTemplate() {
-      return Optional.ofNullable( template )
-            .map( getter( "paths" ) )
-            .map( getter( QUERIES_TEMPLATE_PATH ) )
-            .orElse( null );
+      if ( template == null ) {
+         return null;
+      }
+
+      final ObjectNode objectNode = getter( "paths" ).apply( template );
+      return getter( QUERIES_TEMPLATE_PATH ).apply( objectNode );
    }
 
    public ObjectNode documentTemplate() {
-      return Optional.ofNullable( template )
-            .map( ObjectNode::deepCopy )
-            .map( doc -> {
-               Optional.of( doc ).map( getter( "paths" ) ).ifPresent(
-                     paths -> paths.remove( QUERIES_TEMPLATE_PATH )
-               );
-               return doc;
-            } )
-            .orElse( null );
+      if ( template == null ) {
+         return null;
+      }
+      final ObjectNode objectNode = template.deepCopy();
+      getter( "paths" ).apply( objectNode ).remove( QUERIES_TEMPLATE_PATH );
+      return objectNode;
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/test/resources/openapi/open-api-error-template.yaml
+++ b/core/esmf-aspect-model-document-generators/src/test/resources/openapi/open-api-error-template.yaml
@@ -1,0 +1,10 @@
+paths:
+  __DEFAULT_QUERIES_TEMPLATE__:
+    get:
+      responses:
+        '400':
+          $ref: "core-api.yaml#/components/responses/ClientError"
+        '401':
+          $ref: "core-api.yaml#/components/responses/Unauthorized"
+        '403':
+          $ref: "core-api.yaml#/components/responses/Forbidden"


### PR DESCRIPTION
## Description

Allow customization of error responses in open api generator

Fixes #635

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
