### PR TITLE
Add Prefix and Postfix to Java Generation

### DIFF
--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import org.eclipse.esmf.aspectmodel.java.exception.CodeGenerationException;
 import org.eclipse.esmf.aspectmodel.visitor.AspectStreamTraversalVisitor;
 import org.eclipse.esmf.metamodel.AbstractEntity;
-import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.metamodel.Characteristic;
 import org.eclipse.esmf.metamodel.ComplexType;
 import org.eclipse.esmf.metamodel.Entity;
@@ -354,7 +353,7 @@ public class AspectModelJavaUtil {
       }
       return TO_CONSTANT.convert( StringUtils.capitalize( upperOrLowerCamel ) );
    }
-   
+
    public static boolean isAllUppercaseWithUnderscore( final String upperOrLowerCamel ) {
       return upperOrLowerCamel != null && upperOrLowerCamel.matches( "[A-Z0-9_]+" );
    }
@@ -561,8 +560,8 @@ public class AspectModelJavaUtil {
    }
 
    public static String generateClassName( final StructureElement element, final JavaCodeGenerationConfig config ) {
-      if ( ( !config.aspectPrefix().isBlank() || !config.aspectPostfix().isBlank() ) && element instanceof Aspect ) {
-         return config.aspectPrefix() + element.getName() + config.aspectPostfix();
+      if ( ( !config.namePrefix().isBlank() || !config.namePostfix().isBlank() ) && element.is( StructureElement.class ) ) {
+         return config.namePrefix() + element.getName() + config.namePostfix();
       }
       return element.getName();
    }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -173,7 +173,7 @@ public class AspectModelJavaUtil {
          return String.format( "Either<%s,%s>", left, right );
       }
 
-      return getDataType( dataType, codeGenerationConfig.importTracker() );
+      return getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig );
    }
 
    public static String determineCollectionAspectClassDefinition( final StructureElement element,
@@ -186,7 +186,7 @@ public class AspectModelJavaUtil {
          final Characteristic characteristic = property.getEffectiveCharacteristic().orElseThrow( error );
          if ( characteristic instanceof Collection ) {
             final String collectionType = determineCollectionType( (Collection) characteristic, false, codeGenerationConfig );
-            final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.importTracker() );
+            final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.importTracker(), codeGenerationConfig );
             return String.format( "public class %s implements CollectionAspect<%s,%s>", element.getName(), collectionType, dataType );
          }
       }
@@ -199,7 +199,7 @@ public class AspectModelJavaUtil {
       if ( element.isAbstractEntity() ) {
          classDefinitionBuilder.append( "abstract " );
       }
-      classDefinitionBuilder.append( "class " ).append( element.getName() );
+      classDefinitionBuilder.append( "class " ).append( generateClassName( element, codeGenerationConfig ) );
       classDefinitionBuilder.append( genericClassSignature( element ) );
       if ( element.getExtends().isPresent() ) {
          final ComplexType extendedComplexType = element.getExtends().get();
@@ -265,20 +265,20 @@ public class AspectModelJavaUtil {
 
       if ( collection.isAllowDuplicates() && collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( List.class );
-         return containerType( List.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
+         return containerType( List.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( LinkedHashSet.class );
-         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
+         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
       }
       if ( collection.isAllowDuplicates() && !collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( java.util.Collection.class );
-         return containerType( java.util.Collection.class, getDataType( dataType, codeGenerationConfig.importTracker() ),
+         return containerType( java.util.Collection.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
                elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && !collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( Set.class );
-         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.importTracker() ), elementConstraint );
+         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
       }
       throw new CodeGenerationException( "Could not determine Java collection type for " + collection.getName() );
    }
@@ -304,11 +304,15 @@ public class AspectModelJavaUtil {
     * @param importTracker the import tracker
     * @return a {@link String} containing the definition of the Java Data Type
     */
-   public static String getDataType( final Optional<Type> dataType, final ImportTracker importTracker ) {
+   public static String getDataType( final Optional<Type> dataType, final ImportTracker importTracker, final JavaCodeGenerationConfig codeGenerationConfig ) {
       return dataType.map( type -> {
          final Type actualDataType = dataType.get();
          if ( actualDataType instanceof ComplexType ) {
-            return ((ComplexType) actualDataType).getName();
+            final String complexDataType = ((ComplexType) actualDataType).getName();
+            if ( ( !codeGenerationConfig.namePrefix().isBlank() || !codeGenerationConfig.namePostfix().isBlank() ) ) {
+               return codeGenerationConfig.namePrefix() + complexDataType + codeGenerationConfig.namePostfix();
+            }
+            return complexDataType;
          }
 
          if ( actualDataType instanceof Scalar ) {
@@ -487,7 +491,7 @@ public class AspectModelJavaUtil {
    public static String getCharacteristicJavaType( final Property property, final JavaCodeGenerationConfig codeGenerationConfig ) {
       final Supplier<RuntimeException> error = () -> new CodeGenerationException( "No data type found for Property " + property.getName() );
       if ( hasContainerType( property ) ) {
-         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.importTracker() );
+         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.importTracker(), codeGenerationConfig );
       }
 
       return property.getEffectiveCharacteristic().flatMap( Characteristic::getDataType ).map( type -> {

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.eclipse.esmf.aspectmodel.java.exception.CodeGenerationException;
 import org.eclipse.esmf.aspectmodel.visitor.AspectStreamTraversalVisitor;
 import org.eclipse.esmf.metamodel.AbstractEntity;
+import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.metamodel.Characteristic;
 import org.eclipse.esmf.metamodel.ComplexType;
 import org.eclipse.esmf.metamodel.Entity;
@@ -557,6 +558,13 @@ public class AspectModelJavaUtil {
             .mapToObj( i -> "T" + i + " /* type of " + properties.get( i ).getName() + " */" )
             .collect( Collectors.joining( "," ) );
       return generics.isEmpty() ? "" : "<" + generics + ">";
+   }
+
+   public static String generateClassName( final StructureElement element, final JavaCodeGenerationConfig config ) {
+      if ( ( !config.aspectPrefix().isBlank() || !config.aspectPostfix().isBlank() ) && element instanceof Aspect ) {
+         return config.aspectPrefix() + element.getName() + config.aspectPostfix();
+      }
+      return element.getName();
    }
 
    /**

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -265,20 +265,24 @@ public class AspectModelJavaUtil {
 
       if ( collection.isAllowDuplicates() && collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( List.class );
-         return containerType( List.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
+         return containerType( List.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
+               elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( LinkedHashSet.class );
-         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
+         return containerType( LinkedHashSet.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
+               elementConstraint );
       }
       if ( collection.isAllowDuplicates() && !collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( java.util.Collection.class );
-         return containerType( java.util.Collection.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
+         return containerType( java.util.Collection.class,
+               getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
                elementConstraint );
       }
       if ( !collection.isAllowDuplicates() && !collection.isOrdered() ) {
          codeGenerationConfig.importTracker().importExplicit( Set.class );
-         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ), elementConstraint );
+         return containerType( Set.class, getDataType( dataType, codeGenerationConfig.importTracker(), codeGenerationConfig ),
+               elementConstraint );
       }
       throw new CodeGenerationException( "Could not determine Java collection type for " + collection.getName() );
    }
@@ -304,12 +308,13 @@ public class AspectModelJavaUtil {
     * @param importTracker the import tracker
     * @return a {@link String} containing the definition of the Java Data Type
     */
-   public static String getDataType( final Optional<Type> dataType, final ImportTracker importTracker, final JavaCodeGenerationConfig codeGenerationConfig ) {
+   public static String getDataType( final Optional<Type> dataType, final ImportTracker importTracker,
+         final JavaCodeGenerationConfig codeGenerationConfig ) {
       return dataType.map( type -> {
          final Type actualDataType = dataType.get();
          if ( actualDataType instanceof ComplexType ) {
             final String complexDataType = ((ComplexType) actualDataType).getName();
-            if ( ( !codeGenerationConfig.namePrefix().isBlank() || !codeGenerationConfig.namePostfix().isBlank() ) ) {
+            if ( (!codeGenerationConfig.namePrefix().isBlank() || !codeGenerationConfig.namePostfix().isBlank()) ) {
                return codeGenerationConfig.namePrefix() + complexDataType + codeGenerationConfig.namePostfix();
             }
             return complexDataType;
@@ -491,7 +496,8 @@ public class AspectModelJavaUtil {
    public static String getCharacteristicJavaType( final Property property, final JavaCodeGenerationConfig codeGenerationConfig ) {
       final Supplier<RuntimeException> error = () -> new CodeGenerationException( "No data type found for Property " + property.getName() );
       if ( hasContainerType( property ) ) {
-         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.importTracker(), codeGenerationConfig );
+         return getDataType( property.getCharacteristic().orElseThrow( error ).getDataType(), codeGenerationConfig.importTracker(),
+               codeGenerationConfig );
       }
 
       return property.getEffectiveCharacteristic().flatMap( Characteristic::getDataType ).map( type -> {
@@ -564,7 +570,7 @@ public class AspectModelJavaUtil {
    }
 
    public static String generateClassName( final StructureElement element, final JavaCodeGenerationConfig config ) {
-      if ( ( !config.namePrefix().isBlank() || !config.namePostfix().isBlank() ) && element.is( StructureElement.class ) ) {
+      if ( (!config.namePrefix().isBlank() || !config.namePostfix().isBlank()) && element.is( StructureElement.class ) ) {
          return config.namePrefix() + element.getName() + config.namePostfix();
       }
       return element.getName();

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -29,7 +29,10 @@ public record JavaCodeGenerationConfig(
       String packageName,
       ImportTracker importTracker,
       boolean executeLibraryMacros,
-      File templateLibFile
+      File templateLibFile,
+      String aspectPrefix,
+      String aspectPostfix
+
 ) implements GenerationConfig {
    public JavaCodeGenerationConfig {
       if ( packageName == null ) {
@@ -43,6 +46,12 @@ public record JavaCodeGenerationConfig(
       }
       if ( executeLibraryMacros && !templateLibFile.exists() ) {
          throw new CodeGenerationException( "Incorrect configuration. Please provide a valid path to the velocity template library file." );
+      }
+      if ( aspectPrefix == null ) {
+         aspectPrefix = "";
+      }
+      if ( aspectPostfix == null ) {
+         aspectPostfix = "";
       }
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -30,8 +30,8 @@ public record JavaCodeGenerationConfig(
       ImportTracker importTracker,
       boolean executeLibraryMacros,
       File templateLibFile,
-      String aspectPrefix,
-      String aspectPostfix
+      String namePrefix,
+      String namePostfix
 
 ) implements GenerationConfig {
    public JavaCodeGenerationConfig {
@@ -47,11 +47,11 @@ public record JavaCodeGenerationConfig(
       if ( executeLibraryMacros && !templateLibFile.exists() ) {
          throw new CodeGenerationException( "Incorrect configuration. Please provide a valid path to the velocity template library file." );
       }
-      if ( aspectPrefix == null ) {
-         aspectPrefix = "";
+      if ( namePrefix == null ) {
+         namePrefix = "";
       }
-      if ( aspectPostfix == null ) {
-         aspectPostfix = "";
+      if ( namePostfix == null ) {
+         namePostfix = "";
       }
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/EnumerationJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/EnumerationJavaArtifactGenerator.java
@@ -56,7 +56,7 @@ public class EnumerationJavaArtifactGenerator<E extends Enumeration> implements 
             .put( "className", element.getName() )
             .put( "codeGenerationConfig", config )
             .put( "currentYear", Year.now() )
-            .put( "dataType", AspectModelJavaUtil.getDataType( element.getDataType(), config.importTracker() ) )
+            .put( "dataType", AspectModelJavaUtil.getDataType( element.getDataType(), config.importTracker(), config ) )
             .put( "Entity", Entity.class )
             .put( "enumeration", element )
             .put( "importTracker", importTracker )

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
@@ -131,7 +131,7 @@ public class StructureElementJavaArtifactGenerator<E extends StructureElement> i
 
       final String generatedSource = new TemplateEngine( context, engineConfiguration ).apply( "java-pojo" );
       try {
-         return new JavaArtifact( Roaster.format( generatedSource ), element.getName(),
+         return new JavaArtifact( Roaster.format( generatedSource ), AspectModelJavaUtil.generateClassName( element, config ),
                config.packageName() );
       } catch ( final Exception exception ) {
          throw new CodeGenerationException( generatedSource, exception );

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
@@ -28,7 +28,7 @@ ${util.determineCollectionAspectClassDefinition( $element, $codeGenerationConfig
 ${util.generateAbstractEntityClassAnnotations( $complexElement, $codeGenerationConfig, $extendingEntities )}
 ${util.determineComplexTypeClassDefinition( $complexElement, $codeGenerationConfig )}
 #else
-public class $element.getName()${util.genericClassSignature( $element )} {
+public class ${util.generateClassName( $element, $codeGenerationConfig )}${util.genericClassSignature( $element )} {
 #end
 #foreach( $property in $element.properties )
     #javaPojoProperty( $property )

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
@@ -18,7 +18,7 @@
         $codeGenerationConfig.importTracker().importExplicit( $JsonCreator )
         @JsonCreator
     #end
-    public ${element.name}(
+    public ${util.generateClassName( $element, $codeGenerationConfig )}(
     $util.constructorArguments( $allProperties, $codeGenerationConfig, $enableJacksonAnnotations )
     ) #if( $needInitializer ) throws DatatypeConfigurationException #end {
     super(

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-equals-method-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-equals-method-lib.vm
@@ -31,8 +31,9 @@ if (o == null || getClass() != o.getClass()) {
     #if( $element.getProperties().isEmpty() ) return true
     #else
         #set( $objectEqualsExpression = $util.objectEqualsExpression( $element ) )
+        #set( $className = ${util.generateClassName( $element, $codeGenerationConfig )} )
         #if( $objectEqualsExpression && !$objectEqualsExpression.empty )
-            final $element.getName() that = ($element.getName())o;
+            final $className that = ($className)o;
             return $objectEqualsExpression
         #else
             return true

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
@@ -13,11 +13,12 @@
 #parse( "java-static-class-property-lib.vm" )
 
 #macro( javaStaticClassBody )
-$codeGenerationConfig.importTracker().importExplicit( "${codeGenerationConfig.packageName()}.${element.getName()}" )
+#set( $className = ${util.generateClassName( $element, $codeGenerationConfig )} )
+$codeGenerationConfig.importTracker().importExplicit( "${codeGenerationConfig.packageName()}.${className}" )
 /**
-* Generated class {@link Meta${element.getName()}}.
+* Generated class {@link Meta${className}}.
 */
-public class Meta${element.getName()} implements StaticMetaClass<${element.getName()}>, PropertyContainer {
+public class Meta${className} implements StaticMetaClass<${className}>, PropertyContainer {
 public static final String NAMESPACE = "${modelUrnPrefix}";
 public static final String MODEL_ELEMENT_URN = NAMESPACE + "${element.getName()}";
 
@@ -49,8 +50,8 @@ static {
     #end
 #end
 
-    public Class<${element.getName()}> getModelClass() {
-        return ${element.getName()}.class;
+    public Class<${className}> getModelClass() {
+        return ${className}.class;
     }
 
     @Override
@@ -65,13 +66,13 @@ static {
 
     @Override
     public String getName() {
-        return "${element.getName()}";
+        return "${className}";
     }
 
     #if( $element.getExtends().isPresent() )
-        #set( $propertyTypeParameter = "? super ${element.getName()}" )
+        #set( $propertyTypeParameter = "? super ${className}" )
     #else
-        #set( $propertyTypeParameter = ${element.getName()} )
+        #set( $propertyTypeParameter = ${className} )
     #end
     @Override
     public List<StaticProperty<$propertyTypeParameter, ?>> getProperties() {

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -1136,4 +1136,18 @@ public class AspectModelJavaGeneratorTest {
       result.assertFields( "BaseAspectWithPropertyPostfix", expectedFieldsForAspectClass, new HashMap<>() );
       assertConstructor( result, "BaseAspectWithPropertyPostfix", expectedFieldsForAspectClass );
    }
+
+   @Test
+   void testGenerateEntityWithPrefixAndPostfix() throws IOException {
+      final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
+            .put( "testProperty", "BaseTestEntityPostfix" )
+            .build();
+
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
+      final GenerationResult result = TestContext.generateAspectCode()
+            .apply( getGenerators( aspect, "Base", "Postfix" ) );
+      result.assertNumberOfFiles( 2 );
+      result.assertFields( "BaseAspectWithEntityPostfix", expectedFieldsForAspectClass, new HashMap<>() );
+      assertConstructor( result, "BaseAspectWithEntityPostfix", expectedFieldsForAspectClass );
+   }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -98,6 +99,18 @@ public class AspectModelJavaGeneratorTest {
       return List.of( new AspectModelJavaGenerator( aspectModel.aspect(), config ) );
    }
 
+   private Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final String aspectPrefix, final String aspectPostfix ) {
+      final AspectModel aspectModel = TestResources.load( testAspect );
+      final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
+            .enableJacksonAnnotations( true )
+            .executeLibraryMacros( false )
+            .packageName( aspectModel.aspect().urn().getNamespaceMainPart() )
+            .aspectPrefix( aspectPrefix )
+            .aspectPostfix( aspectPostfix )
+            .build();
+      return List.of( new AspectModelJavaGenerator( aspectModel.aspect(), config ) );
+   }
+
    /**
     * Tests that code generation succeeds for all test models for the latest meta model version
     *
@@ -108,7 +121,7 @@ public class AspectModelJavaGeneratorTest {
          "ASPECT_WITH_USED_AND_UNUSED_ENUMERATION", // No code will be generated for an unused enumeration
          "MODEL_WITH_BROKEN_CYCLES" // Contains elements that are not references from the Aspect
    } )
-   public void testCodeGeneration( final TestAspect testAspect ) {
+   void testCodeGeneration( final TestAspect testAspect ) {
       assertThatCode( () -> {
                final AspectModel aspectModel = TestResources.load( testAspect );
                final Model model = aspectModel.files().iterator().next().sourceModel();
@@ -137,7 +150,7 @@ public class AspectModelJavaGeneratorTest {
     * In total 4 classes should be written.
     */
    @Test
-   public void testGenerateAspectModelMultipleEntitiesOnMultipleLevels() throws IOException {
+   void testGenerateAspectModelMultipleEntitiesOnMultipleLevels() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testEntityOne", "TestEntity" )
             .put( "testEntityTwo", "TestEntity" )
@@ -170,7 +183,7 @@ public class AspectModelJavaGeneratorTest {
     * also nested ones. In total 5 classes should be written.
     */
    @Test
-   public void testGenerateAspectModelMultipleEnumerationsOnMultipleLevels() throws IOException {
+   void testGenerateAspectModelMultipleEnumerationsOnMultipleLevels() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testPropertyWithEnumOne", "TestEnumOneCharacteristic" )
             .put( "testPropertyWithEnumTwo", "TestEnumTwoCharacteristic" )
@@ -189,7 +202,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateRecursiveAspectModel() throws IOException {
+   void testGenerateRecursiveAspectModel() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", "Optional<TestEntity>" )
             .build();
@@ -202,7 +215,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithOptionalProperties() throws IOException {
+   void testGenerateAspectModelWithOptionalProperties() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "numberProperty", "Optional<BigInteger>" )
             .put( "timestampProperty", XMLGregorianCalendar.class )
@@ -216,7 +229,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithCurie() throws IOException {
+   void testGenerateAspectModelWithCurie() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testCurie", "Curie" )
             .put( "testCurieWithoutExampleValue", "Curie" )
@@ -230,7 +243,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithExtendedEnums() throws IOException {
+   void testGenerateAspectModelWithExtendedEnums() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "result", "EvaluationResults" )
             .put( "simpleResult", "YesNo" )
@@ -267,7 +280,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithExtendedEnumsWithNotInPayloadProperty() throws IOException {
+   void testGenerateAspectModelWithExtendedEnumsWithNotInPayloadProperty() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForEvaluationResults = ImmutableMap.<String, Object> builder()
             .put( "average", new TypeToken<Optional<BigInteger>>() {
             } )
@@ -311,7 +324,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithConstraints() throws IOException {
+   void testGenerateAspectModelWithConstraints() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testPropertyWithRegularExpression", String.class )
             .put( "testPropertyWithDecimalMinDecimalMaxRangeConstraint", BigDecimal.class )
@@ -355,7 +368,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithOptionalAndConstraints() throws IOException {
+   void testGenerateAspectModelWithOptionalAndConstraints() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "stringProperty", "Optional<@Size(max = 3) String>" )
             .build();
@@ -371,7 +384,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithConstrainedCollection() throws IOException {
+   void testGenerateAspectWithConstrainedCollection() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testCollection", new TypeToken<List<BigInteger>>() {
             } ).build();
@@ -385,7 +398,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithExclusiveRangeConstraint() throws IOException {
+   void testGenerateAspectWithExclusiveRangeConstraint() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "floatProp", Float.class )
             .put( "doubleProp", Double.class )
@@ -421,7 +434,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithEither() throws IOException {
+   void testGenerateAspectWithEither() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", "Either<LeftEntity, RightEntity>" )
             .build();
@@ -434,7 +447,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithBoolean() throws IOException {
+   void testGenerateAspectWithBoolean() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testBoolean", Boolean.class.getSimpleName() ).build();
 
@@ -448,7 +461,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithBinary() throws IOException {
+   void testGenerateAspectWithBinary() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testBinary", new ResolvedArrayType( ResolvedPrimitiveType.BYTE ) )
             .build();
@@ -465,7 +478,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithCustomJavaPackageNameExpectCustomPackageDeclaration() throws IOException {
+   void testGenerateAspectWithCustomJavaPackageNameExpectCustomPackageDeclaration() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BINARY;
       final String customJavaPackageName = "test.test.test";
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, customJavaPackageName ) );
@@ -474,7 +487,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithEmptyJavaPackageNameExpectDefaultPackageDeclaration() throws IOException {
+   void testGenerateAspectWithEmptyJavaPackageNameExpectDefaultPackageDeclaration() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BINARY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 1 );
@@ -482,7 +495,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithComplexEnumeration() throws IOException {
+   void testGenerateAspectModelWithComplexEnumeration() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "result", "EvaluationResults" )
             .put( "simpleResult", "YesNo" )
@@ -515,7 +528,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithState() throws IOException {
+   void testGenerateAspectWithState() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "status", "TestState" )
             .build();
@@ -531,7 +544,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelMultipleEntitiesOnMultipleLevelsWithoutJacksonAnnotations() throws IOException {
+   void testGenerateAspectModelMultipleEntitiesOnMultipleLevelsWithoutJacksonAnnotations() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testEntityOne", "TestEntity" )
             .put( "testEntityTwo", "TestEntity" )
@@ -556,7 +569,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithStructuredValue() throws IOException {
+   void testGenerateAspectWithStructuredValue() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "date", XMLGregorianCalendar.class )
             .put( "year", Long.class )
@@ -576,7 +589,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithComplexEnumerationInclOptional() throws IOException {
+   void testGenerateAspectModelWithComplexEnumerationInclOptional() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENUM_INCL_OPTIONAL;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 4 );
@@ -590,7 +603,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithComplexEnumerations() throws IOException {
+   void testGenerateAspectModelWithComplexEnumerations() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_COLLECTION_ENUM;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 9 );
@@ -613,7 +626,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithComplexEntityCollectionEnumeration() throws IOException {
+   void testGenerateAspectModelWithComplexEntityCollectionEnumeration() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENTITY_COLLECTION_ENUM;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 4 );
@@ -624,7 +637,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithFixedPointConstraint() throws IOException {
+   void testGenerateAspectModelWithFixedPointConstraint() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", BigDecimal.class.getSimpleName() )
             .build();
@@ -642,7 +655,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithList() throws IOException {
+   void testGenerateAspectModelWithList() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", new TypeToken<List<String>>() {
             } )
@@ -658,7 +671,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithListAndElementCharacteristic() throws IOException {
+   void testGenerateAspectModelWithListAndElementCharacteristic() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", new TypeToken<List<String>>() {
             } )
@@ -674,7 +687,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithListAndElementConstraint() throws IOException {
+   void testGenerateAspectModelWithListAndElementConstraint() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", new TypeToken<List<Float>>() {
             } )
@@ -695,7 +708,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithSet() throws IOException {
+   void testGenerateAspectModelWithSet() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", new TypeToken<Set<String>>() {
             } )
@@ -711,7 +724,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithRdfLangString() throws IOException {
+   void testGenerateAspectWithRdfLangString() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "prop", LangString.class )
             .build();
@@ -739,7 +752,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithDurationTypeForRangeConstraints() throws IOException {
+   void testGenerateAspectModelWithDurationTypeForRangeConstraints() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testPropertyWithDayTimeDuration", Duration.class )
             .put( "testPropertyWithDuration", Duration.class )
@@ -767,7 +780,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithDateTimeTypeForRangeConstraints() throws IOException {
+   void testGenerateAspectModelWithDateTimeTypeForRangeConstraints() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testPropertyWithDateTime", XMLGregorianCalendar.class )
             .put( "testPropertyWithDateTimeStamp", XMLGregorianCalendar.class )
@@ -791,7 +804,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithGtypeForRangeConstraints() throws IOException {
+   void testGenerateAspectModelWithGtypeForRangeConstraints() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testPropertyWithGYear", XMLGregorianCalendar.class )
             .put( "testPropertyWithGMonth", XMLGregorianCalendar.class )
@@ -827,7 +840,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithPropertyWithPayloadName() throws IOException {
+   void testGenerateAspectModelWithPropertyWithPayloadName() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "test", "String" )
             .build();
@@ -840,7 +853,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithBlankNode() throws IOException {
+   void testGenerateAspectModelWithBlankNode() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "list", new TypeToken<Collection<String>>() {
             } )
@@ -853,7 +866,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateEqualsForAspectWithEntity() throws IOException {
+   void testGenerateEqualsForAspectWithEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
 
@@ -885,7 +898,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateHashCodeForAspectWithEntity() throws IOException {
+   void testGenerateHashCodeForAspectWithEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
 
@@ -902,7 +915,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithAbstractEntity() throws IOException {
+   void testGenerateAspectModelWithAbstractEntity() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", "ExtendingTestEntity" )
             .build();
@@ -942,7 +955,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithCollectionWithAbstractEntity() throws IOException {
+   void testGenerateAspectModelWithCollectionWithAbstractEntity() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
             .put( "testProperty", "Collection<AbstractTestEntity>" )
             .build();
@@ -985,7 +998,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectModelWithEntityEnumerationAndLangString() throws IOException {
+   void testGenerateAspectModelWithEntityEnumerationAndLangString() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY_ENUMERATION_AND_LANG_STRING;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 3 );
@@ -999,7 +1012,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateEqualsForAspectWithAbstractEntity() throws IOException {
+   void testGenerateEqualsForAspectWithAbstractEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ABSTRACT_ENTITY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
 
@@ -1047,7 +1060,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateHashCodeForAspectWithAbstractEntity() throws IOException {
+   void testGenerateHashCodeForAspectWithAbstractEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ABSTRACT_ENTITY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
 
@@ -1068,7 +1081,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithoutFileHeader() throws IOException {
+   void testGenerateAspectWithoutFileHeader() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENUM;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       final CompilationUnit aspectClass = result.compilationUnits.get( TestAspect.ASPECT_WITH_COMPLEX_ENUM.getName() );
@@ -1080,7 +1093,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithFileHeader() throws IOException {
+   void testGenerateAspectWithFileHeader() throws IOException {
       final String currentWorkingDirectory = System.getProperty( "user.dir" );
       final File templateLibFile = Path.of( currentWorkingDirectory, "/templates", "/test-macro-lib.vm" ).toFile();
 
@@ -1095,7 +1108,7 @@ public class AspectModelJavaGeneratorTest {
    }
 
    @Test
-   public void testGenerateAspectWithMultipleInheritance() throws IOException {
+   void testGenerateAspectWithMultipleInheritance() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_EXTENDED_ENTITY;
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
       result.assertNumberOfFiles( 4 );
@@ -1108,5 +1121,19 @@ public class AspectModelJavaGeneratorTest {
             Collections.singletonList( "ParentOfParentEntity" ), Collections.emptyList(),
             List.of( "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)",
                   "@JsonSubTypes({ @JsonSubTypes.Type(value = TestEntity.class, name = \"TestEntity\") })" ) );
+   }
+
+   @Test
+   void testGenerateAspectWithPrefixAndPostfix() throws IOException {
+      final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
+            .put( "testProperty", String.class )
+            .build();
+
+      final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY;
+      final GenerationResult result = TestContext.generateAspectCode()
+            .apply( getGenerators( aspect, "Base", "Postfix" ) );
+      result.assertNumberOfFiles( 1 );
+      result.assertFields( "BaseAspectWithPropertyPostfix", expectedFieldsForAspectClass, new HashMap<>() );
+      assertConstructor( result, "BaseAspectWithPropertyPostfix", expectedFieldsForAspectClass );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -99,14 +99,14 @@ public class AspectModelJavaGeneratorTest {
       return List.of( new AspectModelJavaGenerator( aspectModel.aspect(), config ) );
    }
 
-   private Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final String aspectPrefix, final String aspectPostfix ) {
+   private Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final String namePrefix, final String namePostfix ) {
       final AspectModel aspectModel = TestResources.load( testAspect );
       final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
             .enableJacksonAnnotations( true )
             .executeLibraryMacros( false )
             .packageName( aspectModel.aspect().urn().getNamespaceMainPart() )
-            .aspectPrefix( aspectPrefix )
-            .aspectPostfix( aspectPostfix )
+            .namePrefix( namePrefix )
+            .namePostfix( namePostfix )
             .build();
       return List.of( new AspectModelJavaGenerator( aspectModel.aspect(), config ) );
    }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
@@ -36,8 +36,8 @@ public class JavaCodeGenerationConfigurationTest {
                   .packageName( "" )
                   .executeLibraryMacros( true )
                   .templateLibFile( templateLibFile )
-                  .aspectPrefix( "" )
-                  .aspectPostfix( "" )
+                  .namePrefix( "" )
+                  .namePostfix( "" )
                   .build()
       ).doesNotThrowAnyException();
 
@@ -47,8 +47,8 @@ public class JavaCodeGenerationConfigurationTest {
                   .packageName( "" )
                   .executeLibraryMacros( false )
                   .templateLibFile( emptyTemplateLibFile )
-                  .aspectPrefix( "" )
-                  .aspectPostfix( "" )
+                  .namePrefix( "" )
+                  .namePostfix( "" )
                   .build()
       ).doesNotThrowAnyException();
    }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfigurationTest.java
@@ -36,6 +36,8 @@ public class JavaCodeGenerationConfigurationTest {
                   .packageName( "" )
                   .executeLibraryMacros( true )
                   .templateLibFile( templateLibFile )
+                  .aspectPrefix( "" )
+                  .aspectPostfix( "" )
                   .build()
       ).doesNotThrowAnyException();
 
@@ -45,6 +47,8 @@ public class JavaCodeGenerationConfigurationTest {
                   .packageName( "" )
                   .executeLibraryMacros( false )
                   .templateLibFile( emptyTemplateLibFile )
+                  .aspectPrefix( "" )
+                  .aspectPostfix( "" )
                   .build()
       ).doesNotThrowAnyException();
    }

--- a/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
@@ -119,6 +119,8 @@ are replaced using `packageName` | `String` | none | {nok}
 | `executeLibraryMacros` | Execute the macros provided in the velocity macro library. | `Boolean` | `false` | {nok}
 | `disableJacksonAnnotations` | Leads to generated Java code that does not contain https://github.com/FasterXML/jackson[Jackson] annotations. | `Boolean` | `false` | {nok}
 | `skip` | Skip execution of plugin and generation | `Boolean` | `false` | {nok}
+| `namePrefix` | Name prefix for generated Aspect, Entity Java classes | `String` | none | {nok}
+| `namePostfix` | Name postfix for generated Aspect, Entity Java classes | `String` | none | {nok}
 |===
 
 === Generate Static Meta Classes

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -78,7 +78,7 @@ The available options and their meaning can also be seen in the help text of the
                                    | _--language, -l_ : the language from the model for which the diagram should be
                                        generated (default: en)                                                               |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements | `samm aspect AspectModel.ttl to svg --custom-resolver "java -jar resolver.jar"`
-.8+| [[asepct-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                  | `samm aspect AspectModel.ttl to java`
+.10+| [[asepct-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                  | `samm aspect AspectModel.ttl to java`
                                    | _--output-directory, -d_ : output directory to write files to (default:
                                        current directory)                                                                    |
                                    | _--package-name, -pn_ : package to use for generated Java classes                       | `samm aspect AspectModel.ttl to java -pn org.company.product`
@@ -90,6 +90,8 @@ The available options and their meaning can also be seen in the help text of the
                                        https://velocity.apache.org/[Velocity] macro library                                  |
                                    | _--static, -s_ : generate Java domain classes for a Static Meta Model                   |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
+                                   | _--name-prefix, -namePrefix_ : name prefix for generated Aspect, Entity Java classes    | `samm aspect AspectModel.ttl to java -namePrefix "Prefix"`
+                                   | _--name-postfix, -namePostfix_ : name postfix for generated Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java -namePostfix "Postfix"`
 .21+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
                                      for an Aspect Model                                                                     | `samm aspect AspectModel.ttl to openapi -j`
                                    | _--output, -o_ : output file path (default: stdout)                                     |

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
@@ -39,10 +39,10 @@ public abstract class CodeGenerationMojo extends AspectModelMojo {
    protected String stripNamespace = "";
 
    @Parameter
-   protected String aspectPrefix = "";
+   protected String namePrefix = "";
 
    @Parameter
-   protected String aspectPostfix = "";
+   protected String namePostfix = "";
 
    protected void validateParameters( final File templateLibFile ) throws MojoExecutionException {
       if ( executeLibraryMacros && !templateLibFile.exists() ) {

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
@@ -38,6 +38,12 @@ public abstract class CodeGenerationMojo extends AspectModelMojo {
    @Parameter
    protected String stripNamespace = "";
 
+   @Parameter
+   protected String aspectPrefix = "";
+
+   @Parameter
+   protected String aspectPostfix = "";
+
    protected void validateParameters( final File templateLibFile ) throws MojoExecutionException {
       if ( executeLibraryMacros && !templateLibFile.exists() ) {
          throw new MojoExecutionException( "Missing configuration. Valid path to velocity template library file must be provided." );

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
@@ -47,8 +47,8 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
                .packageName( determinePackageName( aspect ) )
                .executeLibraryMacros( executeLibraryMacros )
                .templateLibFile( templateLibFile )
-               .aspectPrefix( aspectPrefix )
-               .aspectPostfix( aspectPostfix )
+               .namePrefix( namePrefix )
+               .namePostfix( namePostfix )
                .build();
          new AspectModelJavaGenerator( aspect, config ).generate( nameMapper );
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
@@ -47,6 +47,8 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
                .packageName( determinePackageName( aspect ) )
                .executeLibraryMacros( executeLibraryMacros )
                .templateLibFile( templateLibFile )
+               .aspectPrefix( aspectPrefix )
+               .aspectPostfix( aspectPostfix )
                .build();
          new AspectModelJavaGenerator( aspect, config ).generate( nameMapper );
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
@@ -42,6 +42,8 @@ public class GenerateStaticJavaClasses extends CodeGenerationMojo {
                .packageName( determinePackageName( aspect ) )
                .executeLibraryMacros( executeLibraryMacros )
                .templateLibFile( templateLibFile )
+               .aspectPrefix( aspectPrefix )
+               .aspectPostfix( aspectPostfix )
                .build();
          new StaticMetaModelJavaGenerator( aspect, config ).generate( nameMapper );
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
@@ -42,8 +42,8 @@ public class GenerateStaticJavaClasses extends CodeGenerationMojo {
                .packageName( determinePackageName( aspect ) )
                .executeLibraryMacros( executeLibraryMacros )
                .templateLibFile( templateLibFile )
-               .aspectPrefix( aspectPrefix )
-               .aspectPostfix( aspectPostfix )
+               .namePrefix( namePrefix )
+               .namePostfix( namePostfix )
                .build();
          new StaticMetaModelJavaGenerator( aspect, config ).generate( nameMapper );
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
@@ -64,4 +64,12 @@ public class GenerateJavaClassesTest extends AspectModelMojoTest {
       assertThatCode( generateJavaClasses::execute ).doesNotThrowAnyException();
       assertThat( generatedFilePath( "org", "eclipse", "esmf", "test", "Aspect.java" ) ).doesNotExist();
    }
+
+   @Test
+   public void testGenerateJavaClassesWithPrefixAndPostfix() throws Exception {
+      final File testPom = getTestFile( "src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml" );
+      final Mojo generateJavaClasses = lookupMojo( "generateJavaClasses", testPom );
+      assertThatCode( generateJavaClasses::execute ).doesNotThrowAnyException();
+      assertThat( generatedFilePath( "org", "eclipse", "esmf", "test", "BaseAspectPostfix.java" ) ).exists();
+   }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
@@ -66,10 +66,19 @@ public class GenerateJavaClassesTest extends AspectModelMojoTest {
    }
 
    @Test
-   public void testGenerateJavaClassesWithPrefixAndPostfix() throws Exception {
+   public void testGenerateJavaClassesAspectWithPrefixAndPostfix() throws Exception {
       final File testPom = getTestFile( "src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml" );
       final Mojo generateJavaClasses = lookupMojo( "generateJavaClasses", testPom );
       assertThatCode( generateJavaClasses::execute ).doesNotThrowAnyException();
       assertThat( generatedFilePath( "example", "com", "BaseAspectPostfix.java" ) ).exists();
+   }
+
+   @Test
+   public void testGenerateJavaClassesEntityWithPrefixAndPostfix() throws Exception {
+      final File testPom = getTestFile( "src/test/resources/generate-java-classes-pom-entity-with-prefix-and-postfix.xml" );
+      final Mojo generateJavaClasses = lookupMojo( "generateJavaClasses", testPom );
+      assertThatCode( generateJavaClasses::execute ).doesNotThrowAnyException();
+      assertThat( generatedFilePath( "example", "com", "BaseAspectWithEntityPostfix.java" ) ).exists();
+      assertThat( generatedFilePath( "example", "com", "BaseTestEntityPostfix.java" ) ).exists();
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateJavaClassesTest.java
@@ -70,6 +70,6 @@ public class GenerateJavaClassesTest extends AspectModelMojoTest {
       final File testPom = getTestFile( "src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml" );
       final Mojo generateJavaClasses = lookupMojo( "generateJavaClasses", testPom );
       assertThatCode( generateJavaClasses::execute ).doesNotThrowAnyException();
-      assertThat( generatedFilePath( "org", "eclipse", "esmf", "test", "BaseAspectPostfix.java" ) ).exists();
+      assertThat( generatedFilePath( "example", "com", "BaseAspectPostfix.java" ) ).exists();
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-entity-with-prefix-and-postfix.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-entity-with-prefix-and-postfix.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.eclipse.esmf</groupId>
+   <artifactId>test-generate-java-classes-mojo</artifactId>
+   <version>1.0</version>
+   <packaging>jar</packaging>
+   <name>Test Generate Java Classes Mojo</name>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>esmf-aspect-model-maven-plugin</artifactId>
+            <configuration>
+               <modelsRootDirectory>${basedir}/../../core/esmf-test-aspect-models/src/main/resources/valid</modelsRootDirectory>
+               <includes>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithEntity</include>
+               </includes>
+               <outputDirectory>${basedir}/target/test-artifacts</outputDirectory>
+               <packageName>example.com</packageName>
+               <namePrefix>Base</namePrefix>
+               <namePostfix>Postfix</namePostfix>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
@@ -33,8 +33,8 @@
                </includes>
                <outputDirectory>${basedir}/target/test-artifacts</outputDirectory>
                <packageName>example.com</packageName>
-               <aspectPrefix>Base</aspectPrefix>
-               <aspectPostfix>Postfix</aspectPostfix>
+               <namePrefix>Base</namePrefix>
+               <namePostfix>Postfix</namePostfix>
             </configuration>
          </plugin>
       </plugins>

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
@@ -33,8 +33,8 @@
                </includes>
                <outputDirectory>${basedir}/target/test-artifacts</outputDirectory>
                <packageName>example.com</packageName>
-               <prefix>Base</prefix>
-               <postfix>Postfix</postfix>
+               <aspectPrefix>Base</aspectPrefix>
+               <aspectPostfix>Postfix</aspectPostfix>
             </configuration>
          </plugin>
       </plugins>

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-java-classes-pom-with-prefix-and-postfix.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.eclipse.esmf</groupId>
+   <artifactId>test-generate-java-classes-mojo</artifactId>
+   <version>1.0</version>
+   <packaging>jar</packaging>
+   <name>Test Generate Java Classes Mojo</name>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>esmf-aspect-model-maven-plugin</artifactId>
+            <configuration>
+               <modelsRootDirectory>${basedir}/../../core/esmf-test-aspect-models/src/main/resources/valid</modelsRootDirectory>
+               <includes>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#Aspect</include>
+               </includes>
+               <outputDirectory>${basedir}/target/test-artifacts</outputDirectory>
+               <packageName>example.com</packageName>
+               <prefix>Base</prefix>
+               <postfix>Postfix</postfix>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -60,6 +60,12 @@ public class AspectToJavaCommand extends AbstractCommand {
    @CommandLine.Option( names = { "--static", "-s" }, description = "Generate Java domain classes for a Static Meta Model" )
    private boolean generateStaticMetaModelJavaClasses = false;
 
+   @CommandLine.Option( names = { "--aspect-prefix", "-prefix" }, description = "Aspect prefix for generated Java class of Aspect" )
+   private String aspectPrefix = "";
+
+   @CommandLine.Option( names = { "--aspect-postfix", "-postfix" }, description = "Aspect postfix for generated Java class of Aspect" )
+   private String aspectPostfix = "";
+
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
 
@@ -92,6 +98,8 @@ public class AspectToJavaCommand extends AbstractCommand {
             .templateLibFile( templateLibFile )
             .enableJacksonAnnotations( !disableJacksonAnnotations )
             .packageName( pkgName )
+            .aspectPrefix( aspectPrefix )
+            .aspectPostfix( aspectPostfix )
             .build();
    }
 

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -60,10 +60,10 @@ public class AspectToJavaCommand extends AbstractCommand {
    @CommandLine.Option( names = { "--static", "-s" }, description = "Generate Java domain classes for a Static Meta Model" )
    private boolean generateStaticMetaModelJavaClasses = false;
 
-   @CommandLine.Option( names = { "--name-prefix", "-namePrefix" }, description = "Name prefix for generated Java class of Aspect" )
+   @CommandLine.Option( names = { "--name-prefix", "-namePrefix" }, description = "Name prefix for generated Aspect, Entity Java classes" )
    private String namePrefix = "";
 
-   @CommandLine.Option( names = { "--name-postfix", "-namePostfix" }, description = "Name postfix for generated Java class of Aspect" )
+   @CommandLine.Option( names = { "--name-postfix", "-namePostfix" }, description = "Name postfix for generated Aspect, Entity Java classes" )
    private String namePostfix = "";
 
    @CommandLine.ParentCommand

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -60,11 +60,11 @@ public class AspectToJavaCommand extends AbstractCommand {
    @CommandLine.Option( names = { "--static", "-s" }, description = "Generate Java domain classes for a Static Meta Model" )
    private boolean generateStaticMetaModelJavaClasses = false;
 
-   @CommandLine.Option( names = { "--aspect-prefix", "-prefix" }, description = "Aspect prefix for generated Java class of Aspect" )
-   private String aspectPrefix = "";
+   @CommandLine.Option( names = { "--name-prefix", "-namePrefix" }, description = "Name prefix for generated Java class of Aspect" )
+   private String namePrefix = "";
 
-   @CommandLine.Option( names = { "--aspect-postfix", "-postfix" }, description = "Aspect postfix for generated Java class of Aspect" )
-   private String aspectPostfix = "";
+   @CommandLine.Option( names = { "--name-postfix", "-namePostfix" }, description = "Name postfix for generated Java class of Aspect" )
+   private String namePostfix = "";
 
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
@@ -98,8 +98,8 @@ public class AspectToJavaCommand extends AbstractCommand {
             .templateLibFile( templateLibFile )
             .enableJacksonAnnotations( !disableJacksonAnnotations )
             .packageName( pkgName )
-            .aspectPrefix( aspectPrefix )
-            .aspectPostfix( aspectPostfix )
+            .namePrefix( namePrefix )
+            .namePostfix( namePostfix )
             .build();
    }
 

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -60,10 +60,12 @@ public class AspectToJavaCommand extends AbstractCommand {
    @CommandLine.Option( names = { "--static", "-s" }, description = "Generate Java domain classes for a Static Meta Model" )
    private boolean generateStaticMetaModelJavaClasses = false;
 
-   @CommandLine.Option( names = { "--name-prefix", "-namePrefix" }, description = "Name prefix for generated Aspect, Entity Java classes" )
+   @CommandLine.Option( names = { "--name-prefix", "-namePrefix" },
+         description = "Name prefix for generated Aspect, Entity Java classes" )
    private String namePrefix = "";
 
-   @CommandLine.Option( names = { "--name-postfix", "-namePostfix" }, description = "Name postfix for generated Aspect, Entity Java classes" )
+   @CommandLine.Option( names = { "--name-postfix", "-namePostfix" },
+         description = "Name postfix for generated Aspect, Entity Java classes" )
    private String namePostfix = "";
 
    @CommandLine.ParentCommand


### PR DESCRIPTION
## Description

Allow customizing the class name when generating POJOs from aspect models

Fixes #538 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes
