### PR TITLE
Meta Class doesn't include exampleValue

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/MetaModelBaseAttributes.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/MetaModelBaseAttributes.java
@@ -25,7 +25,10 @@ import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.metamodel.HasDescription;
 import org.eclipse.esmf.metamodel.ModelElement;
+import org.eclipse.esmf.metamodel.ScalarValue;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.impl.DefaultScalar;
+import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
 
 /**
  * Wrapper class for the attributes all Aspect Meta Model elements have.
@@ -38,13 +41,16 @@ public class MetaModelBaseAttributes implements HasDescription {
    private final boolean isAnonymous;
    private final AspectModelFile sourceFile;
 
+   private final ScalarValue exampleValue;
+
    private MetaModelBaseAttributes(
          final AspectModelUrn urn,
          final Set<LangString> preferredNames,
          final Set<LangString> descriptions,
          final List<String> see,
          final boolean isAnonymous,
-         final AspectModelFile sourceFile
+         final AspectModelFile sourceFile,
+         final ScalarValue exampleValue
    ) {
       this.urn = urn;
       this.preferredNames = preferredNames;
@@ -52,6 +58,7 @@ public class MetaModelBaseAttributes implements HasDescription {
       this.see = see;
       this.isAnonymous = isAnonymous;
       this.sourceFile = sourceFile;
+      this.exampleValue = exampleValue;
    }
 
    public AspectModelUrn urn() {
@@ -86,6 +93,10 @@ public class MetaModelBaseAttributes implements HasDescription {
       return sourceFile;
    }
 
+   public ScalarValue getExampleValue() {
+      return exampleValue;
+   }
+
    public static Builder builder() {
       return new Builder();
    }
@@ -105,7 +116,7 @@ public class MetaModelBaseAttributes implements HasDescription {
 
    @Override
    public int hashCode() {
-      return Objects.hash( urn, preferredNames, descriptions, see, isAnonymous );
+      return Objects.hash( urn, preferredNames, descriptions, see, isAnonymous, exampleValue );
    }
 
    /**
@@ -116,7 +127,8 @@ public class MetaModelBaseAttributes implements HasDescription {
     */
    public static MetaModelBaseAttributes fromModelElement( final ModelElement modelElement ) {
       return new MetaModelBaseAttributes( modelElement.urn(), modelElement.getPreferredNames(),
-            modelElement.getDescriptions(), modelElement.getSee(), modelElement.isAnonymous(), modelElement.getSourceFile() );
+            modelElement.getDescriptions(), modelElement.getSee(), modelElement.isAnonymous(), modelElement.getSourceFile(),
+            new DefaultScalarValue( "", new DefaultScalar( "http://www.w3.org/2001/XMLSchema#string" ) ) );
    }
 
    public static class Builder {
@@ -126,6 +138,8 @@ public class MetaModelBaseAttributes implements HasDescription {
       private final List<String> see = new ArrayList<>();
       private boolean isAnonymous = true;
       private AspectModelFile sourceFile;
+
+      private ScalarValue exampleValue;
 
       public Builder withUrn( final String urn ) {
          return withUrn( AspectModelUrn.fromUrn( urn ) );
@@ -190,8 +204,13 @@ public class MetaModelBaseAttributes implements HasDescription {
          return this;
       }
 
+      public Builder withExampleValue( final ScalarValue exampleValue ) {
+         this.exampleValue = exampleValue;
+         return this;
+      }
+
       public MetaModelBaseAttributes build() {
-         return new MetaModelBaseAttributes( urn, preferredNames, descriptions, see, isAnonymous, sourceFile );
+         return new MetaModelBaseAttributes( urn, preferredNames, descriptions, see, isAnonymous, sourceFile, exampleValue );
       }
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
@@ -90,6 +91,7 @@ import org.eclipse.esmf.metamodel.impl.DefaultCharacteristic;
 import org.eclipse.esmf.metamodel.impl.DefaultComplexType;
 import org.eclipse.esmf.metamodel.impl.DefaultEntity;
 import org.eclipse.esmf.metamodel.impl.DefaultScalar;
+import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.samm.KnownVersion;
 import org.eclipse.esmf.staticmetamodel.PropertyContainer;
@@ -170,6 +172,7 @@ public class StaticMetaModelJavaArtifactGenerator<E extends StructureElement> im
             .put( "DefaultRangeConstraint", DefaultRangeConstraint.class )
             .put( "DefaultRegularExpressionConstraint", DefaultRegularExpressionConstraint.class )
             .put( "DefaultScalar", DefaultScalar.class )
+            .put( "DefaultScalarValue", DefaultScalarValue.class )
             .put( "DefaultSet", DefaultSet.class )
             .put( "DefaultSingleEntity", DefaultSingleEntity.class )
             .put( "DefaultSortedSet", DefaultSortedSet.class )

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelVisitor.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelVisitor.java
@@ -527,7 +527,7 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
       }
 
       if ( optionalValue.get() instanceof ScalarValue ) {
-         return "Optional.of(" + ( (ScalarValue) optionalValue.get() ).accept( this, context ) + ")";
+         return "Optional.of(" + ((ScalarValue) optionalValue.get()).accept( this, context ) + ")";
       }
 
       context.getCodeGenerationConfig().importTracker().importExplicit( AspectModelJavaUtil.getDataTypeClass( type ) );
@@ -574,6 +574,15 @@ public class StaticMetaModelVisitor implements AspectVisitor<String, StaticCodeG
       } );
       element.getSee().stream().sorted()
             .forEach( see -> builder.append( ".withSee(" ).append( AspectModelJavaUtil.createLiteral( see ) ).append( ")" ) );
+
+      if ( element instanceof final Property property ) {
+         property.getExampleValue().ifPresent( exampleValue ->
+               builder.append( ".withExampleValue(" )
+                     .append( this.visitScalarValue( property.getExampleValue().get(), context ) )
+                     .append( ")" )
+         );
+      }
+
       builder.append( ".build()" );
       return builder.toString();
    }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
@@ -24,8 +24,11 @@ import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
+
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -496,6 +499,26 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
 
       result.assertConstructorArgumentForProperties( "MetaAspectWithQuantifiableWithoutUnit",
             ImmutableMap.<String, String> builder().put( "TEST_PROPERTY", expectedTestPropertyCharacteristicConstructorCall ).build(), 1 );
+   }
+
+   @Test
+   void testCharacteristicInstantiationForPropertyWithExampleValue() throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_COLLECTION;
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+
+      result.assertNumberOfFiles( 2 );
+
+      Map<String, Set<String>> expectedBaseAttributes = new HashMap<>();
+      expectedBaseAttributes.put( "TEST_PROPERTY", Set.of(
+            "withUrn(AspectModelUrn.fromUrn(NAMESPACE + \"testProperty\"))",
+            "withPreferredName(Locale.forLanguageTag(\"en\"), \"Test Property\")",
+            "withDescription(Locale.forLanguageTag(\"en\"), \"This is a test property.\")",
+            "withSee(\"http://example.com/\")",
+            "withSee(\"http://example.com/me\")",
+            "withExampleValue(new DefaultScalarValue(\"Example Value\", new DefaultScalar(\"http://www.w3.org/2001/XMLSchema#string\")))"
+      ) );
+
+      result.assertMetaModelBaseAttributesForProperties( "MetaAspectWithCollection", expectedBaseAttributes );
    }
 
    @Test


### PR DESCRIPTION
## Description

Update Meta Class generation to include exampleValue.

Fixes #623  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes
