### PR TITLE
Improve resolution and loading error messages

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/MissingMetaModelVersionException.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/MissingMetaModelVersionException.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.aspectmodel;
 
+@Deprecated( forRemoval = true )
 public class MissingMetaModelVersionException extends RuntimeException {
    private static final long serialVersionUID = -6978063564517733205L;
 }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/MultipleMetaModelVersionsException.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/MultipleMetaModelVersionsException.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.aspectmodel;
 
+@Deprecated( forRemoval = true )
 public class MultipleMetaModelVersionsException extends RuntimeException {
    private static final long serialVersionUID = -592452975353816247L;
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/AspectModelLoader.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/AspectModelLoader.java
@@ -25,7 +25,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.eclipse.esmf.aspectmodel.AspectLoadingException;
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.RdfUtil;
 import org.eclipse.esmf.aspectmodel.resolver.AspectModelFileLoader;
@@ -208,14 +208,14 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
     */
    public AspectModel loadNamespacePackage( final File namespacePackage ) {
       if ( !namespacePackage.exists() || !namespacePackage.isFile() ) {
-         throw new ModelResolutionException( "The specified file does not exist or is not a file." );
+         throw new AspectLoadingException( "The specified file does not exist or is not a file." );
       }
 
       try ( final InputStream inputStream = new FileInputStream( namespacePackage ) ) {
          return loadNamespacePackage( inputStream );
       } catch ( final IOException exception ) {
          LOG.error( "Error reading the file: {}", namespacePackage.getAbsolutePath(), exception );
-         throw new ModelResolutionException( "Error reading the file: " + namespacePackage.getAbsolutePath(), exception );
+         throw new AspectLoadingException( "Error reading the file: " + namespacePackage.getAbsolutePath(), exception );
       }
    }
 
@@ -232,7 +232,7 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
          inputStream.transferTo( baos );
          hasAspectModelsFolder = containsFolderInNamespacePackage( new ByteArrayInputStream( baos.toByteArray() ) );
       } catch ( final IOException exception ) {
-         throw new ModelResolutionException( "Could not read from input", exception );
+         throw new AspectLoadingException( "Could not read from input", exception );
       }
       return loadNamespacePackageFromStream( new ByteArrayInputStream( baos.toByteArray() ), hasAspectModelsFolder );
    }
@@ -258,7 +258,7 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
          zis.closeEntry();
       } catch ( final IOException exception ) {
          LOG.error( "Error reading the Archive input stream", exception );
-         throw new ModelResolutionException( "Error reading the Archive input stream", exception );
+         throw new AspectLoadingException( "Error reading the Archive input stream", exception );
       }
 
       final LoaderContext loaderContext = new LoaderContext();
@@ -336,13 +336,14 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
          }
          final AspectModelFile resolutionResult = resolutionStrategy.apply( aspectModelUrn, this );
          if ( !containsType( resolutionResult.sourceModel(), urn ) ) {
-            throw new ModelResolutionException(
+            throw new AspectLoadingException(
                   "Resolution strategy returned a model which does not contain element definition for " + urn );
          }
          return Optional.of( resolutionResult );
-      } catch ( final UrnSyntaxException e ) {
+      } catch ( final UrnSyntaxException exception ) {
+         // This happens if the URN to load is no actual URN.
          // If it's no valid Aspect Model URN but some other URI (e.g., a samm:see value), there is nothing
-         // to resolve, so we return just an empty model
+         // to resolve, so we return just an empty model.
          return Optional.empty();
       }
    }
@@ -379,6 +380,7 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
          context.unresolvedFiles().push( aspectModelFile );
       }
 
+      final List<ModelResolutionException.LoadingFailure> loadingFailures = new ArrayList<>();
       while ( !context.unresolvedFiles().isEmpty() || !context.unresolvedUrns().isEmpty() ) {
          if ( !context.unresolvedFiles().isEmpty() ) {
             final AspectModelFile modelFile = context.unresolvedFiles().pop();
@@ -389,10 +391,24 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
          }
 
          while ( !context.unresolvedUrns().isEmpty() ) {
-            applyResolutionStrategy( context.unresolvedUrns().pop() )
-                  .map( this::migrate )
-                  .ifPresent( resolvedFile -> markModelFileAsLoaded( resolvedFile, context ) );
+            try {
+               applyResolutionStrategy( context.unresolvedUrns().pop() )
+                     .map( this::migrate )
+                     .ifPresent( resolvedFile -> markModelFileAsLoaded( resolvedFile, context ) );
+            } catch ( final ModelResolutionException exception ) {
+               // If one element can not be resolved, collect its cause and continue, so that
+               // we can create an comprehensive overview of all elements that can not be resolved
+               if ( exception.getCheckedLocations().isEmpty() ) {
+                  throw exception;
+               } else {
+                  loadingFailures.addAll( exception.getCheckedLocations() );
+               }
+            }
          }
+      }
+
+      if ( !loadingFailures.isEmpty() ) {
+         throw new ModelResolutionException( loadingFailures );
       }
    }
 
@@ -442,7 +458,6 @@ public class AspectModelLoader implements ModelSource, ResolutionStrategySupport
 
       final List<ModelElement> elements = new ArrayList<>();
       final List<AspectModelFile> files = new ArrayList<>();
-      final Map<AspectModelFile, MetaModelBaseAttributes> namespaceDefinitions = new HashMap<>();
       for ( final AspectModelFile file : inputFiles ) {
          final DefaultAspectModelFile aspectModelFile = new DefaultAspectModelFile( file.sourceModel(), file.headerComment(),
                file.sourceLocation() );

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/instantiator/PropertyInstantiator.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/instantiator/PropertyInstantiator.java
@@ -17,11 +17,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.eclipse.esmf.aspectmodel.AspectLoadingException;
 import org.eclipse.esmf.aspectmodel.loader.DefaultPropertyWrapper;
 import org.eclipse.esmf.aspectmodel.loader.Instantiator;
 import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
 import org.eclipse.esmf.aspectmodel.loader.ModelElementFactory;
-import org.eclipse.esmf.aspectmodel.resolver.exceptions.InvalidModelException;
 import org.eclipse.esmf.metamodel.Characteristic;
 import org.eclipse.esmf.metamodel.Property;
 import org.eclipse.esmf.metamodel.Scalar;
@@ -81,7 +81,7 @@ public class PropertyInstantiator extends Instantiator<Property> {
                .flatMap( statement -> characteristic.getDataType()
                      .map( type -> {
                         if ( !type.is( Scalar.class ) ) {
-                           throw new InvalidModelException( "Type of example value on Property " + property + " has incorrect type" );
+                           throw new AspectLoadingException( "Type of example value on Property " + property + " has incorrect type" );
                         }
                         return type.as( Scalar.class );
                      } )

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ClasspathStrategy.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ClasspathStrategy.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -34,8 +35,10 @@ import java.util.stream.Stream;
 
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
+import org.eclipse.esmf.aspectmodel.resolver.modelfile.RawAspectModelFile;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 
+import io.vavr.control.Try;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -160,28 +163,45 @@ public class ClasspathStrategy implements ResolutionStrategy {
             aspectModelUrn.getNamespaceMainPart(), aspectModelUrn.getVersion() );
       final URL namedResourceFile = resourceUrl( directory, aspectModelUrn.getName() + ".ttl" );
 
-      if ( namedResourceFile != null ) {
-         return AspectModelFileLoader.load( namedResourceFile );
+      final List<ModelResolutionException.LoadingFailure> checkedLocations = new ArrayList<>();
+      final Try<RawAspectModelFile> tryFile = Try.of( () -> AspectModelFileLoader.load( namedResourceFile ) );
+      if ( tryFile.isFailure() ) {
+         checkedLocations.add(
+               new ModelResolutionException.LoadingFailure( aspectModelUrn, "Class path file " + namedResourceFile.toString(),
+                     tryFile.getCause().getMessage(), tryFile.getCause() ) );
+      } else {
+         return tryFile.get();
       }
 
       LOG.warn( "Looking for {}, but no {}.ttl was found. Inspecting files in {}", aspectModelUrn.getName(),
             aspectModelUrn.getName(), directory );
 
-      return filesInDirectory( directory )
+      for ( final Iterator<URL> it = filesInDirectory( directory )
             .filter( name -> name.endsWith( ".ttl" ) )
             .map( name -> resourceUrl( directory, name ) )
             .sorted( Comparator.comparing( URL::getPath ) )
-            .map( AspectModelFileLoader::load )
-            .filter( aspectModelFile -> resolutionStrategySupport.containsDefinition( aspectModelFile, aspectModelUrn ) )
-            .findFirst()
-            .orElseThrow( () -> new ModelResolutionException(
-                  "No model file containing " + aspectModelUrn + " could be found in directory: " + directory ) );
+            .iterator(); it.hasNext(); ) {
+         final URL url = it.next();
+         final Try<RawAspectModelFile> file = Try.of( () -> AspectModelFileLoader.load( url ) );
+         if ( file.isFailure() ) {
+            checkedLocations.add( new ModelResolutionException.LoadingFailure( aspectModelUrn, url.toString(),
+                  "Could not load file", file.getCause() ) );
+            continue;
+         }
+         final AspectModelFile result = file.get();
+         if ( resolutionStrategySupport.containsDefinition( result, aspectModelUrn ) ) {
+            return result;
+         }
+         checkedLocations.add( new ModelResolutionException.LoadingFailure( aspectModelUrn, url.toString(),
+               "File does not contain the element definition" ) );
+      }
+      throw new ModelResolutionException( checkedLocations );
    }
 
    private URL toUrl( final URI uri ) {
       try {
          return uri.toURL();
-      } catch ( final MalformedURLException e ) {
+      } catch ( final MalformedURLException exception ) {
          throw new ModelResolutionException( "Could not translate URI to URL: " + uri );
       }
    }
@@ -189,7 +209,7 @@ public class ClasspathStrategy implements ResolutionStrategy {
    private URI toUri( final URL url ) {
       try {
          return url.toURI();
-      } catch ( final URISyntaxException e ) {
+      } catch ( final URISyntaxException exception ) {
          throw new ModelResolutionException( "Could not translate URL to URI: " + url );
       }
    }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/CommandExecutor.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/CommandExecutor.java
@@ -37,8 +37,8 @@ public class CommandExecutor {
             throw new ModelResolutionException( getOutputFrom( p.getErrorStream() ) );
          }
          return getOutputFrom( p.getInputStream() );
-      } catch ( final IOException | InterruptedException e ) {
-         throw new ModelResolutionException( "The attempt to execute external resolver failed with the error:", e );
+      } catch ( final IOException | InterruptedException exception ) {
+         throw new ModelResolutionException( "The attempt to execute external resolver failed with the error:", exception );
       }
    }
 
@@ -51,7 +51,8 @@ public class CommandExecutor {
    }
 
    private static String getOutputFrom( final InputStream stream ) {
-      final Scanner s = new Scanner( stream ).useDelimiter( "\\A" );
-      return s.hasNext() ? s.next() : "";
+      try ( final Scanner s = new Scanner( stream ).useDelimiter( "\\A" ) ) {
+         return s.hasNext() ? s.next() : "";
+      }
    }
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ExternalResolverStrategy.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ExternalResolverStrategy.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.util.stream.Stream;
 
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
+import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 
 /**
@@ -31,9 +32,15 @@ public class ExternalResolverStrategy implements ResolutionStrategy {
 
    @Override
    public AspectModelFile apply( final AspectModelUrn aspectModelUrn, final ResolutionStrategySupport resolutionStrategySupport ) {
-      final String commandWithParameters = command + " " + aspectModelUrn.toString();
-      final String result = CommandExecutor.executeCommand( commandWithParameters );
-      return AspectModelFileLoader.load( result );
+      try {
+         final String commandWithParameters = command + " " + aspectModelUrn.toString();
+         final String result = CommandExecutor.executeCommand( commandWithParameters );
+         return AspectModelFileLoader.load( result );
+      } catch ( final ModelResolutionException exception ) {
+         final ModelResolutionException.LoadingFailure failure = new ModelResolutionException.LoadingFailure(
+               aspectModelUrn, "The output of '" + command + "'", "Command evaluation failed", exception );
+         throw new ModelResolutionException( failure );
+      }
    }
 
    @Override

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/FromLoadedFileStrategy.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/FromLoadedFileStrategy.java
@@ -33,11 +33,14 @@ public class FromLoadedFileStrategy implements ResolutionStrategy {
    @Override
    public AspectModelFile apply( final AspectModelUrn aspectModelUrn, final ResolutionStrategySupport resolutionStrategySupport )
          throws ModelResolutionException {
-
       if ( resolutionStrategySupport.containsDefinition( aspectModelFile, aspectModelUrn ) ) {
          return aspectModelFile;
       }
-      throw new ModelResolutionException( "File " + aspectModelFile + " should contain defintion, but does not: " + aspectModelUrn );
+      final ModelResolutionException.LoadingFailure failure = new ModelResolutionException.LoadingFailure(
+            aspectModelUrn,
+            aspectModelFile.sourceLocation().map( uri -> "In-memory file " + uri ).orElse( "Anonymous in-memory file" ),
+            "File does not contain element definition" );
+      throw new ModelResolutionException( failure );
    }
 
    @Override

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/GithubRepository.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/GithubRepository.java
@@ -32,6 +32,8 @@ public record GithubRepository(
       String name();
 
       String refType();
+
+      String refTypeName();
    }
 
    public record Branch( String name ) implements Ref {
@@ -39,12 +41,22 @@ public record GithubRepository(
       public String refType() {
          return "heads";
       }
+
+      @Override
+      public String refTypeName() {
+         return "branch";
+      }
    }
 
    public record Tag( String name ) implements Ref {
       @Override
       public String refType() {
          return "tags";
+      }
+
+      @Override
+      public String refTypeName() {
+         return "tag";
       }
    }
 
@@ -58,5 +70,11 @@ public record GithubRepository(
       } catch ( final MalformedURLException exception ) {
          throw new ModelResolutionException( "Constructed GitHub URL is invalid: " + url );
       }
+   }
+
+   @Override
+   public String toString() {
+      return "GitHub repository %s/%s (%s %s)".formatted( owner(), repository(), branchOrTag().refTypeName(),
+            branchOrTag().name() );
    }
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidModelException.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidModelException.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.aspectmodel.resolver.exceptions;
 
+@Deprecated( forRemoval = true )
 public class InvalidModelException extends RuntimeException {
    private static final long serialVersionUID = 1329417418672113895L;
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidNamespaceException.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidNamespaceException.java
@@ -17,6 +17,7 @@ import java.io.Serial;
 /**
  * An exception indicating that usage of the given namespace is invalid.
  */
+@Deprecated( forRemoval = true )
 public final class InvalidNamespaceException extends RuntimeException {
 
    @Serial

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidRootElementCountException.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/InvalidRootElementCountException.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.aspectmodel.resolver.exceptions;
 
+@Deprecated( forRemoval = true )
 public class InvalidRootElementCountException extends RuntimeException {
    private static final long serialVersionUID = 5199212935274840329L;
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/MissingModelElementException.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/MissingModelElementException.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.aspectmodel.resolver.exceptions;
 
+@Deprecated( forRemoval = true )
 public class MissingModelElementException extends RuntimeException {
    private static final long serialVersionUID = 3564348052165487489L;
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/ModelResolutionException.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/exceptions/ModelResolutionException.java
@@ -13,14 +13,47 @@
 
 package org.eclipse.esmf.aspectmodel.resolver.exceptions;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
+
+import lombok.Getter;
+
+@Getter
 public class ModelResolutionException extends RuntimeException {
-   private static final long serialVersionUID = 1719805029020063645L;
+   public record LoadingFailure(
+         AspectModelUrn element,
+         String location,
+         String description,
+         Optional<Throwable> cause
+   ) {
+      public LoadingFailure( final AspectModelUrn element, final String location, final String description ) {
+         this( element, location, description, Optional.empty() );
+      }
+
+      public LoadingFailure( final AspectModelUrn element, final String location, final String description, final Throwable cause ) {
+         this( element, location, description, Optional.of( cause ) );
+      }
+   }
+
+   private final List<LoadingFailure> checkedLocations;
+
+   public ModelResolutionException( final LoadingFailure checkedLocation ) {
+      this( List.of( checkedLocation ) );
+   }
+
+   public ModelResolutionException( final List<LoadingFailure> checkedLocations ) {
+      this.checkedLocations = checkedLocations;
+   }
 
    public ModelResolutionException( final String message ) {
       super( message );
+      checkedLocations = List.of();
    }
 
    public ModelResolutionException( final String message, final Throwable cause ) {
       super( message, cause );
+      checkedLocations = List.of();
    }
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/parser/RdfTextFormatter.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/parser/RdfTextFormatter.java
@@ -17,7 +17,6 @@ package org.eclipse.esmf.aspectmodel.resolver.parser;
  * Interface to allow interested parties to do structured formatting of RDF documents (for example syntax highlighting)
  */
 public interface RdfTextFormatter {
-
    void reset();
 
    String getResult();

--- a/core/esmf-aspect-model-github-resolver/src/main/java/org/eclipse/esmf/aspectmodel/resolver/github/GitHubModelSource.java
+++ b/core/esmf-aspect-model-github-resolver/src/main/java/org/eclipse/esmf/aspectmodel/resolver/github/GitHubModelSource.java
@@ -48,7 +48,7 @@ public class GitHubModelSource implements ModelSource {
    private static final Logger LOG = LoggerFactory.getLogger( GitHubModelSource.class );
    File repositoryZipFile = null;
    private List<AspectModelFile> files = null;
-   GithubModelSourceConfig config;
+   protected final GithubModelSourceConfig config;
 
    public GitHubModelSource( final GithubModelSourceConfig config ) {
       this.config = config;
@@ -95,7 +95,7 @@ public class GitHubModelSource implements ModelSource {
             LOG.debug( "Temporary package file {} was deleted", outputZipFile.getName() );
          }
       } catch ( final IOException exception ) {
-         throw new GitHubResolverException( exception );
+         throw new GitHubResolverException( "Could not create temporary directory", exception );
       }
    }
 
@@ -125,7 +125,7 @@ public class GitHubModelSource implements ModelSource {
             return file.toJavaStream();
          } ).toList();
       } catch ( final IOException exception ) {
-         throw new GitHubResolverException( exception );
+         throw new GitHubResolverException( "Unable to load files from temporary file", exception );
       }
    }
 

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/RustLikeFormatter.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/RustLikeFormatter.java
@@ -47,7 +47,6 @@ import org.apache.jena.vocabulary.RDF;
  * </pre>
  */
 public class RustLikeFormatter {
-
    private SmartToken highlightToken;
    private int currentColumn;
    private final RdfTextFormatter textFormatter;
@@ -88,6 +87,10 @@ public class RustLikeFormatter {
             .filterKeep( statement -> spansLine( statement, highlightToken.line() ) )
             .toList();
       return formatError( message );
+   }
+
+   public RdfTextFormatter getFormatter() {
+      return textFormatter;
    }
 
    private boolean spansLine( final Statement statement, final int lineNumber ) {

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/ViolationRustLikeFormatter.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/ViolationRustLikeFormatter.java
@@ -13,6 +13,9 @@
 
 package org.eclipse.esmf.aspectmodel.validation.services;
 
+import java.util.stream.Collectors;
+
+import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
 import org.eclipse.esmf.aspectmodel.resolver.parser.RdfTextFormatter;
 import org.eclipse.esmf.aspectmodel.shacl.RustLikeFormatter;
 import org.eclipse.esmf.aspectmodel.shacl.fix.Fix;
@@ -38,6 +41,7 @@ import org.eclipse.esmf.aspectmodel.shacl.violation.MissingTypeViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.NodeKindViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.NotViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.PatternViolation;
+import org.eclipse.esmf.aspectmodel.shacl.violation.ProcessingViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.SparqlConstraintViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.UniqueLanguageViolation;
 import org.eclipse.esmf.aspectmodel.shacl.violation.ValueFromListViolation;
@@ -47,9 +51,7 @@ import org.eclipse.esmf.aspectmodel.shacl.violation.XoneViolation;
 import org.apache.jena.rdf.model.Model;
 
 public class ViolationRustLikeFormatter extends ViolationFormatter {
-
    private final RustLikeFormatter formatter;
-
    private final Model rawModel;
 
    public ViolationRustLikeFormatter() {

--- a/core/esmf-aspect-model-validator/src/test/java/org/eclipse/esmf/aspectmodel/validation/services/AspectModelValidatorTest.java
+++ b/core/esmf-aspect-model-validator/src/test/java/org/eclipse/esmf/aspectmodel/validation/services/AspectModelValidatorTest.java
@@ -15,11 +15,13 @@ package org.eclipse.esmf.aspectmodel.validation.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.aspectmodel.resolver.modelfile.MetaModelFile;
 import org.eclipse.esmf.aspectmodel.shacl.fix.Fix;
 import org.eclipse.esmf.aspectmodel.shacl.violation.DatatypeViolation;

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/AbstractCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/AbstractCommand.java
@@ -77,7 +77,7 @@ public abstract class AbstractCommand implements Runnable {
       } else if ( GitHubUrlInputHandler.appliesToInput( input ) ) {
          return new GitHubUrlInputHandler( input, resolverConfig, details );
       }
-      throw new CommandException( "Can not find file: " + input );
+      throw new CommandException( "File not found: " + input );
    }
 
    protected void generateDiagram( final String input, final DiagramGenerationConfig.Format targetFormat,

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/AbstractInputHandler.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/AbstractInputHandler.java
@@ -32,7 +32,6 @@ import org.eclipse.esmf.aspectmodel.resolver.github.GithubModelSourceConfigBuild
 import org.eclipse.esmf.aspectmodel.shacl.violation.Violation;
 import org.eclipse.esmf.aspectmodel.validation.services.AspectModelValidator;
 import org.eclipse.esmf.aspectmodel.validation.services.DetailedViolationFormatter;
-import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.metamodel.AspectModel;
@@ -113,7 +112,7 @@ public abstract class AbstractInputHandler implements InputHandler {
          if ( details ) {
             System.out.println( new DetailedViolationFormatter().apply( violations ) );
          } else {
-            System.out.println( new ViolationFormatter().apply( violations ) );
+            System.out.println( new HighlightingViolationFormatter().apply( violations ) );
          }
          System.exit( 1 );
          return null;

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/AspectModelUrnInputHandler.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/AspectModelUrnInputHandler.java
@@ -44,12 +44,12 @@ public class AspectModelUrnInputHandler extends AbstractInputHandler {
 
    @Override
    protected List<ResolutionStrategy> resolutionStrategies() {
-      if ( !urn.getName().isEmpty()
-            && resolverConfig != null
-            && resolverConfig.gitHubResolutionOptions != null
-            && resolverConfig.gitHubResolutionOptions.gitHubName == null
-            && ( resolverConfig.modelsRoots == null || resolverConfig.modelsRoots.isEmpty() )
-      ) {
+      final boolean noName = urn.getName().isEmpty();
+      final boolean noResolverConfig = resolverConfig == null;
+      final boolean noGitHubResolver =
+            noResolverConfig || resolverConfig.gitHubResolutionOptions == null || resolverConfig.gitHubResolutionOptions.gitHubName == null;
+      final boolean noLocalModelRoots = noResolverConfig || resolverConfig.modelsRoots == null || resolverConfig.modelsRoots.isEmpty();
+      if ( !noName && noGitHubResolver && noLocalModelRoots ) {
          throw new CommandException( "When resolving a URN, at least one models root directory or GitHub repository must be set" );
       }
       return configuredStrategies();

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/HighlightingViolationFormatter.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/HighlightingViolationFormatter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
+import org.eclipse.esmf.aspectmodel.shacl.violation.ProcessingViolation;
+import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
+import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
+
+/**
+ * Specific violation formatter that does highlighting for processing violations
+ */
+public class HighlightingViolationFormatter extends ViolationFormatter {
+   @Override
+   public String visitProcessingViolation( final ProcessingViolation violation ) {
+      if ( violation.cause() != null
+            && violation.cause() instanceof final ModelResolutionException modelResolutionException
+            && !modelResolutionException.getCheckedLocations().isEmpty() ) {
+
+         final Map<AspectModelUrn, List<ModelResolutionException.LoadingFailure>> failuresByElement =
+               modelResolutionException.getCheckedLocations()
+                     .stream()
+                     .collect( Collectors.groupingBy( ModelResolutionException.LoadingFailure::element ) );
+         final AspectModelUrn element = failuresByElement.keySet().stream().sorted().findFirst().orElseThrow();
+         final List<ModelResolutionException.LoadingFailure> loadingFailures = failuresByElement.get( element );
+         final String message = loadingFailures.stream()
+               .map( failure -> "- %s (%s)".formatted( failure.location(),
+                     new JansiRdfSyntaxHighlighter().formatError( failure.description() ).getResult() ) )
+               .collect( Collectors.joining( "\n",
+                     "A reference in the model to " + new JansiRdfSyntaxHighlighter().formatIri( element.toString() ).getResult()
+                           + " could not be resolved. Checked locations:\n", "" ) );
+
+         if ( modelResolutionException.getCheckedLocations().size() > 1 ) {
+            return "%s%n%n%s additional elements could not be resolved. Use --details for more information.%n".formatted(
+                  message,
+                  new JansiRdfSyntaxHighlighter().formatIri( "" + ( modelResolutionException.getCheckedLocations().size() - 1 ) )
+                        .getResult() );
+         }
+
+         return message;
+      }
+
+      return super.visitProcessingViolation( violation );
+   }
+}

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aas/AasToCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aas/AasToCommand.java
@@ -18,7 +18,6 @@ import picocli.CommandLine;
       mixinStandardHelpOptions = true
 )
 public class AasToCommand extends AbstractCommand {
-
    public static final String COMMAND_NAME = "to";
 
    @CommandLine.Mixin
@@ -29,6 +28,6 @@ public class AasToCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      throw new SubCommandException( COMMAND_NAME );
+      throw new SubCommandException( AasCommand.COMMAND_NAME + " " + COMMAND_NAME );
    }
 }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectEditCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectEditCommand.java
@@ -44,6 +44,6 @@ public class AspectEditCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      throw new SubCommandException( COMMAND_NAME );
+      throw new SubCommandException( AspectCommand.COMMAND_NAME + " " + COMMAND_NAME );
    }
 }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectToCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectToCommand.java
@@ -61,6 +61,6 @@ public class AspectToCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      throw new SubCommandException( COMMAND_NAME );
+      throw new SubCommandException( AspectCommand.COMMAND_NAME + " " + COMMAND_NAME );
    }
 }

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -132,6 +132,30 @@ class SammCliTest {
    }
 
    @Test
+   void testNonExistingFile() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile + "x", "validate" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).contains( "File not found" );
+      assertThat( result.stderr() ).doesNotContain( "CommandException" );
+   }
+
+   @Test
+   void testNonExistingFileWithDebugLogLevel() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile + "x", "validate", "-vvv" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).contains( "File not found" );
+      assertThat( result.stderr() ).contains( "CommandException" );
+   }
+
+   @Test
+   void testSubCommandWithoutRequiredInput() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile, "to" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).contains( "This command needs a subcommand" );
+      assertThat( result.stderr() ).doesNotContain( "CommandException" );
+   }
+
+   @Test
    void testHelp() {
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "help" );
       assertThat( result.stdout() ).contains( "Usage:" );
@@ -232,6 +256,13 @@ class SammCliTest {
    }
 
    @Test
+   void testAspectValidateFromUrnWithoutModelsRoot() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputUrn, "validate" );
+      assertThat( result.stdout() ).contains( "at least one models root directory" );
+      assertThat( result.stderr() ).isEmpty();
+   }
+
+   @Test
    void testAspectFromGitHubWithFullUrlValidateModel() {
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect",
             "https://github.com/eclipse-esmf/esmf-sdk/blob/main/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf"
@@ -246,6 +277,15 @@ class SammCliTest {
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect",
             defaultInputUrn, "validate", "--github", "eclipse-esmf/esmf-sdk", "--github-directory", remoteModelsDirectory );
       assertThat( result.stdout() ).contains( "Input model is valid" );
+      assertThat( result.stderr() ).isEmpty();
+   }
+
+   @Test
+   void testAspectFromGitHubButRepoNotActuallyContainingFile() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect",
+            defaultInputUrn, "validate", "--github", "eclipse-esmf/esmf-parent" );
+      assertThat( result.stdout() ).contains( "could not be resolved" );
+      assertThat( result.stdout() ).contains( "Repository does not contain any file that contains the element" );
       assertThat( result.stderr() ).isEmpty();
    }
 


### PR DESCRIPTION
-------

## Description

* Improves error messages when models can not be loaded (e.g. "file not found")
* Improves error messages when resolution fails, including information about resolution strategy failures (e.g. HTTP error code when resolution from GitHub fails)
* Stacktraces are not any more printed unless -vv (debug) or -vvv (trace) are used

Fixes #421. Fixes 353.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works