### PR TITLE
Make `@JsonFormat` annotation configurable

### DIFF
--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -35,7 +35,7 @@ import io.soabase.recordbuilder.core.RecordBuilder;
 @RecordBuilder
 public record JavaCodeGenerationConfig(
       boolean enableJacksonAnnotations,
-      boolean disableJsonFormatJacksonAnnotation,
+      boolean enableJacksonAnnotationJsonFormatShapeObject,
       JsonTypeInfoType jsonTypeInfo,
       String packageName,
       ImportTracker importTracker,
@@ -45,6 +45,7 @@ public record JavaCodeGenerationConfig(
       String namePostfix
 
 ) implements GenerationConfig {
+   enableJacksonAnnotationJsonFormatShapeObject = true;
    public enum JsonTypeInfoType {
       NONE, CLASS, MINIMAL_CLASS, NAME, SIMPLE_NAME, DEDUCTION, CUSTOM
    }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -35,6 +35,7 @@ import io.soabase.recordbuilder.core.RecordBuilder;
 @RecordBuilder
 public record JavaCodeGenerationConfig(
       boolean enableJacksonAnnotations,
+      boolean disableJsonFormatJacksonAnnotation,
       JsonTypeInfoType jsonTypeInfo,
       String packageName,
       ImportTracker importTracker,

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -35,7 +35,7 @@ import io.soabase.recordbuilder.core.RecordBuilder;
 @RecordBuilder
 public record JavaCodeGenerationConfig(
       boolean enableJacksonAnnotations,
-      boolean enableJacksonAnnotationJsonFormatShapeObject,
+      Boolean enableJacksonAnnotationJsonFormatShapeObject,
       JsonTypeInfoType jsonTypeInfo,
       String packageName,
       ImportTracker importTracker,
@@ -50,8 +50,9 @@ public record JavaCodeGenerationConfig(
    }
 
    public JavaCodeGenerationConfig {
-      enableJacksonAnnotationJsonFormatShapeObject = true;
-
+      if ( enableJacksonAnnotationJsonFormatShapeObject == null ) {
+         enableJacksonAnnotationJsonFormatShapeObject = true;
+      }
       if ( jsonTypeInfo == null ) {
          jsonTypeInfo = JsonTypeInfoType.DEDUCTION;
       }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -50,7 +50,6 @@ public record JavaCodeGenerationConfig(
    }
 
    public JavaCodeGenerationConfig {
-
       enableJacksonAnnotationJsonFormatShapeObject = true;
 
       if ( jsonTypeInfo == null ) {

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -45,12 +45,14 @@ public record JavaCodeGenerationConfig(
       String namePostfix
 
 ) implements GenerationConfig {
-   enableJacksonAnnotationJsonFormatShapeObject = true;
    public enum JsonTypeInfoType {
       NONE, CLASS, MINIMAL_CLASS, NAME, SIMPLE_NAME, DEDUCTION, CUSTOM
    }
 
    public JavaCodeGenerationConfig {
+
+      enableJacksonAnnotationJsonFormatShapeObject = true;
+
       if ( jsonTypeInfo == null ) {
          jsonTypeInfo = JsonTypeInfoType.DEDUCTION;
       }

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
@@ -22,7 +22,7 @@ $codeGenerationConfig.importTracker().importExplicit( $Arrays )
 /**
 * Generated class {@link ${enumeration.name}}.
 */
-#if( $codeGenerationConfig.enableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
+#if( !$codeGenerationConfig.disableJsonFormatJacksonAnnotation() && $codeGenerationConfig.enableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
 public enum ${enumeration.name} {
 #foreach( $value in $enumeration.values )
     $util.generateEnumKey($value)($util.generateEnumValue($value, $codeGenerationConfig))

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-enumeration-class-body-lib.vm
@@ -22,7 +22,7 @@ $codeGenerationConfig.importTracker().importExplicit( $Arrays )
 /**
 * Generated class {@link ${enumeration.name}}.
 */
-#if( !$codeGenerationConfig.disableJsonFormatJacksonAnnotation() && $codeGenerationConfig.enableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
+#if( $codeGenerationConfig.enableJacksonAnnotationJsonFormatShapeObject() && $codeGenerationConfig.enableJacksonAnnotations() )@JsonFormat(shape = JsonFormat.Shape.OBJECT) #end
 public enum ${enumeration.name} {
 #foreach( $value in $enumeration.values )
     $util.generateEnumKey($value)($util.generateEnumValue($value, $codeGenerationConfig))

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -536,16 +536,6 @@ public class AspectModelJavaGeneratorTest {
 
    @Test
    void testGenerateAspectModelWithEnumerationDisableJsonFormatAnnotation() throws IOException {
-      final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object> builder()
-            .put( "result", "EvaluationResults" )
-            .put( "simpleResult", "YesNo" )
-            .build();
-
-      final ImmutableMap<String, Object> expectedFieldsForEvaluationResult = ImmutableMap.<String, Object> builder()
-            .put( "numericCode", Short.class.getSimpleName() )
-            .put( "description", String.class.getSimpleName() )
-            .build();
-
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENUM;
       final JavaCodeGenerationConfig codeGenerationConfig = JavaCodeGenerationConfigBuilder.builder()
             .enableJacksonAnnotations( true )
@@ -554,7 +544,6 @@ public class AspectModelJavaGeneratorTest {
             .enableJacksonAnnotationJsonFormatShapeObject( false )
             .build();
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, codeGenerationConfig ) );
-
       assertThat( result.getGeneratedSource( new QualifiedName( "EvaluationResults", "org.eclipse.esmf.test" ) ) )
             .doesNotContain( "@JsonFormat" );
    }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/GenerationResult.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/GenerationResult.java
@@ -65,10 +65,12 @@ class GenerationResult {
    private final long numFailedCompilationUnits;
    private final Collection<Problem> parseProblems;
    private final Map<QualifiedName, Class<?>> generatedClasses;
-
+   private final Map<QualifiedName, String> sources;
    final Map<String, CompilationUnit> compilationUnits;
 
-   GenerationResult( final File outputDirectory, final Map<QualifiedName, Class<?>> generatedClasses ) throws IOException {
+   GenerationResult( final File outputDirectory, final Map<QualifiedName, Class<?>> generatedClasses,
+         final Map<QualifiedName, String> sources ) throws IOException {
+      this.sources = sources;
       combinedTypeSolver.add( new ReflectionTypeSolver() );
       combinedTypeSolver.add( new JavaParserTypeSolver( outputDirectory ) );
       combinedTypeSolver.add( new ClassLoaderTypeSolver( getClass().getClassLoader() ) );
@@ -373,5 +375,9 @@ class GenerationResult {
 
    Class<?> getGeneratedClass( final QualifiedName qualifiedName ) {
       return generatedClasses.get( qualifiedName );
+   }
+
+   String getGeneratedSource( final QualifiedName qualifiedName ) {
+      return sources.get( qualifiedName );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
@@ -36,9 +36,9 @@ import com.github.javaparser.ast.stmt.Statement;
 
 public class StaticClassGenerationResult extends GenerationResult {
 
-   public StaticClassGenerationResult( final File outputDirectory, final Map<QualifiedName, Class<?>> generatedClasses )
-         throws IOException {
-      super( outputDirectory, generatedClasses );
+   public StaticClassGenerationResult( final File outputDirectory, final Map<QualifiedName, Class<?>> generatedClasses,
+         final Map<QualifiedName, String> sources ) throws IOException {
+      super( outputDirectory, generatedClasses, sources );
    }
 
    /**

--- a/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
@@ -156,6 +156,7 @@ are replaced using `packageName` | `String` | none | {nok}
 | `templateFile` | The path and name of the velocity template file containing the macro library. See xref:java-aspect-tooling.adoc#providing-custom-macros-for-code-generation[Providing Custom Macros for Code Generation]. | `String` | none | {nok}
 | `executeLibraryMacros` | Execute the macros provided in the velocity macro library. | `Boolean` | `false` | {nok}
 | `disableJacksonAnnotations` | Leads to generated Java code that does not contain https://github.com/FasterXML/jackson[Jackson] annotations. | `Boolean` | `false` | {nok}
+| `disableJacksonAnnotationJsonFormatShapeObject` | Leads to generated Java code that does not contain https://github.com/FasterXML/jackson-annotations/blob/2.19/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java[JsonFormat.Shape] annotation. | `Boolean` | `false` | {nok}
 | `jsonTypeInfo` | If Jackson annotations are enabled, determines the value of `JsonTypeInfo.Id`, e.g., `NAME`.  | `String` | `DEDUCTION` | {nok}
 | `skip` | Skip execution of plugin and generation | `Boolean` | `false` | {nok}
 | `namePrefix` | Name prefix for generated Aspect, Entity Java classes | `String` | none | {nok}

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -111,6 +111,8 @@ of model resolution] for more information.
                                    | _--package-name, -pn_ : package to use for generated Java classes                       | `samm aspect AspectModel.ttl to java -pn org.company.product`
                                    | _--no-jackson, -nj_ : disable https://github.com/FasterXML/jackson[Jackson] annotation
                                        generation in generated Java classes                                                  |
+                                   | _--no-jackson-jsonformat-shape, -njjs_ : disable https://github.com/FasterXML/jackson-annotations/blob/2.19/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java[JsonFormat.Shape] annotation
+                                       generation in generated Java classes               |
                                    | _--json-type-info_, _-jti_ : If Jackson annotations are enabled, determines the value
                                        of JsonTypeInfo.Id. Default: DEDUCTION                                                |
                                    | _--template-library-file, -tlf_ : the path and name of the

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -105,7 +105,7 @@ of model resolution] for more information.
                                    | _--language, -l_ : the language from the model for which the diagram should be
                                        generated (default: en)                                                               |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements | `samm aspect AspectModel.ttl to svg --custom-resolver "java -jar resolver.jar"`
-.11+| [[aspect-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                 | `samm aspect AspectModel.ttl to java`
+.12+| [[aspect-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                 | `samm aspect AspectModel.ttl to java`
                                    | _--output-directory, -d_ : output directory to write files to (default:
                                        current directory)                                                                    |
                                    | _--package-name, -pn_ : package to use for generated Java classes                       | `samm aspect AspectModel.ttl to java -pn org.company.product`

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
@@ -38,6 +38,9 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
    @Parameter( defaultValue = "false" )
    private boolean disableJacksonAnnotations;
 
+   @Parameter( defaultValue = "false" )
+   private boolean disableJacksonAnnotationJsonFormatShapeObject;
+
    @Parameter( defaultValue = "deduction" )
    protected String jsonTypeInfo;
 
@@ -49,6 +52,7 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
 
    public GenerateJavaClasses(
          final boolean disableJacksonAnnotations,
+         boolean disableJacksonAnnotationJsonFormatShapeObject,
          final String jsonTypeInfo,
          final String packageName,
          final String templateFile,
@@ -58,6 +62,7 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
          final String namePostfix
    ) {
       this.disableJacksonAnnotations = disableJacksonAnnotations;
+      this.disableJacksonAnnotationJsonFormatShapeObject = disableJacksonAnnotationJsonFormatShapeObject;
       this.jsonTypeInfo = jsonTypeInfo;
       this.packageName = packageName;
       this.templateFile = templateFile;
@@ -76,6 +81,7 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
          try {
             final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
                   .enableJacksonAnnotations( !disableJacksonAnnotations )
+                  .enableJacksonAnnotationJsonFormatShapeObject( !disableJacksonAnnotationJsonFormatShapeObject )
                   .jsonTypeInfo( JavaCodeGenerationConfig.JsonTypeInfoType.valueOf(
                         Optional.ofNullable( jsonTypeInfo ).map( String::toUpperCase ).orElse( "DEDUCTION" ) ) )
                   .packageName( determinePackageName( aspect ) )

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -46,6 +46,11 @@ public class AspectToJavaCommand extends AbstractCommand {
    private boolean disableJacksonAnnotations = false;
 
    @CommandLine.Option(
+         names = { "--no-jackson-jsonformat-shape", "-njjs" },
+         description = "Disable Jackson annotation JsonFormat.Shape object generation in generated Java classes." )
+   private boolean disableJacksonAnnotationJsonFormatShapeObject = false;
+
+   @CommandLine.Option(
          names = { "--json-type-info", "-jti" },
          description = "If Jackson annotations are enabled, determines the value of JsonTypeInfo.Id. Default: DEDUCTION",
          converter = JsonTypeInfoConverter.class
@@ -141,6 +146,7 @@ public class AspectToJavaCommand extends AbstractCommand {
             .jsonTypeInfo( jsonTypeInfo )
             .templateLibFile( templateLibFile )
             .enableJacksonAnnotations( !disableJacksonAnnotations )
+            .enableJacksonAnnotationJsonFormatShapeObject(!disableJacksonAnnotationJsonFormatShapeObject)
             .packageName( pkgName )
             .namePrefix( namePrefix )
             .namePostfix( namePostfix )

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -146,7 +146,7 @@ public class AspectToJavaCommand extends AbstractCommand {
             .jsonTypeInfo( jsonTypeInfo )
             .templateLibFile( templateLibFile )
             .enableJacksonAnnotations( !disableJacksonAnnotations )
-            .enableJacksonAnnotationJsonFormatShapeObject(!disableJacksonAnnotationJsonFormatShapeObject)
+            .enableJacksonAnnotationJsonFormatShapeObject( !disableJacksonAnnotationJsonFormatShapeObject )
             .packageName( pkgName )
             .namePrefix( namePrefix )
             .namePostfix( namePostfix )


### PR DESCRIPTION
# Make `@JsonFormat` annotation configurable

## Description

Java code generation: Includes an additional flag to disable the `@JsonFormat` annotation in generated enum when enableJacksonAnnotations flag is enabled.

Fixes #691

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
