### PR TITLE
Make chain resolution via null collections safe

### DIFF
--- a/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/propertychain/CollectionPropertyChainElementAccessor.java
+++ b/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/propertychain/CollectionPropertyChainElementAccessor.java
@@ -38,7 +38,7 @@ public class CollectionPropertyChainElementAccessor
             return nextCollection.stream();
          }
 
-         return Stream.of( nextValue );
+         return Stream.ofNullable( nextValue );
       } ).toList();
    }
 }


### PR DESCRIPTION
## Description

Resolution of property chains via potential null collections is now safe.

Fixes #717

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
