### PR TITLE
Fix header comment parsing

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/AspectModelFileLoader.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/AspectModelFileLoader.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.esmf.aspectmodel.resolver;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -92,12 +90,10 @@ public class AspectModelFileLoader {
    private static List<String> headerComment( final String content ) {
       final List<String> list = content.lines()
             .dropWhile( String::isBlank )
-            .takeWhile( line -> line.startsWith( "#" ) || isBlank( line ) )
-            .map( line -> line.startsWith( "#" ) ? line.substring( 1 ).trim() : line )
+            .takeWhile( line -> line.startsWith( "#" ) )
+            .map( line -> line.substring( 1 ).trim() )
             .toList();
-      return !list.isEmpty() && list.get( list.size() - 1 ).isEmpty()
-            ? list.subList( 0, list.size() - 1 )
-            : list;
+      return list;
    }
 
    public static RawAspectModelFile load( final InputStream inputStream ) {

--- a/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/resolver/AspectModelResolverTest.java
+++ b/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/resolver/AspectModelResolverTest.java
@@ -63,6 +63,44 @@ class AspectModelResolverTest {
    }
 
    @Test
+   void testLoadModelWithNoEmptyLineAfterHeaderCommentBlock() {
+      assertThat( AspectModelFileLoader.load( """
+            #
+            # Test copyright
+            #
+            @prefix : <urn:samm:com.xyz:0.0.1#> .
+            """ ) )
+            .headerComment().hasSize( 3 ).matches( list -> list.get( 1 ).contains( "Test copyright" ) );
+      assertThat( AspectModelFileLoader.load( """
+            #
+            # Test copyright
+            #
+            
+            @prefix : <urn:samm:com.xyz:0.0.1#> .
+            """ ) )
+            .headerComment().hasSize( 3 ).matches( list -> list.get( 1 ).contains( "Test copyright" ) );
+      assertThat( AspectModelFileLoader.load( """
+            #
+            # Test copyright
+            #
+            
+            # Another comment
+            @prefix : <urn:samm:com.xyz:0.0.1#> .
+            """ ) )
+            .headerComment().hasSize( 3 ).matches( list -> list.get( 1 ).contains( "Test copyright" ) );
+      assertThat( AspectModelFileLoader.load( """
+            #
+            # Test copyright
+            #
+            
+            # Another comment
+            
+            @prefix : <urn:samm:com.xyz:0.0.1#> .
+            """ ) )
+            .headerComment().hasSize( 3 ).matches( list -> list.get( 1 ).contains( "Test copyright" ) );
+   }
+
+   @Test
    void testLoadLegacyBammModelWithoutPrefixesExpectSuccess() throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader()


### PR DESCRIPTION
-------

## Description

Fixes parsing of file header comment blocks

Fixes #701

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works