### PR TITLE
Correctly return the source file for ScalarValue objects

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/Instantiator.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/Instantiator.java
@@ -164,10 +164,9 @@ public abstract class Instantiator<T extends ModelElement> extends AttributeValu
       }
 
       if ( node.isResource() ) {
-         Resource resource = node.asResource();
-
+         final Resource resource = node.asResource();
          if ( resource.hasProperty( RDF.type, SammNs.SAMM.Value() ) ) {
-            Optional<String> valueOpt = optionalAttributeValue( resource, SammNs.SAMM.value() ).map( Statement::getString );
+            final Optional<String> valueOpt = optionalAttributeValue( resource, SammNs.SAMM.value() ).map( Statement::getString );
 
             if ( valueOpt.isEmpty() ) {
                throw new AspectLoadingException( "samm:Value must contain a samm:value property" );

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/instantiator/ScalarValueInstantiator.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/instantiator/ScalarValueInstantiator.java
@@ -10,7 +10,6 @@ import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
 import org.apache.jena.rdf.model.Resource;
 
 public class ScalarValueInstantiator extends Instantiator<ScalarValue> {
-
    public ScalarValueInstantiator( final ModelElementFactory modelElementFactory ) {
       super( modelElementFactory, ScalarValue.class );
    }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/metamodel/impl/DefaultScalarValue.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/metamodel/impl/DefaultScalarValue.java
@@ -62,14 +62,9 @@ public class DefaultScalarValue implements ScalarValue {
       return metaModelBaseAttributes.getDescriptions();
    }
 
-   /**
-    * Similar to {@link DefaultScalar#getSourceFile()}, scalar values are not defined in Aspect Model files, so this returns null.
-    *
-    * @return null
-    */
    @Override
    public AspectModelFile getSourceFile() {
-      return null;
+      return metaModelBaseAttributes.getSourceFile();
    }
 
    @Override
@@ -90,7 +85,7 @@ public class DefaultScalarValue implements ScalarValue {
 
    @SuppressWarnings( "unchecked" )
    private <T extends Comparable<T>> int compareTo( final Object value1, final Object value2 ) {
-      return ((T) value1).compareTo( (T) value2 );
+      return ( (T) value1 ).compareTo( (T) value2 );
    }
 
    @Override

--- a/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/AspectModelLoaderTest.java
+++ b/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/AspectModelLoaderTest.java
@@ -29,6 +29,7 @@ import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException
 import org.eclipse.esmf.metamodel.AbstractEntity;
 import org.eclipse.esmf.metamodel.AspectModel;
 import org.eclipse.esmf.metamodel.ComplexType;
+import org.eclipse.esmf.metamodel.ModelElement;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.test.InvalidTestAspect;
 import org.eclipse.esmf.test.TestAspect;
@@ -38,8 +39,23 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class AspectModelLoaderTest {
+   @ParameterizedTest
+   @EnumSource( value = TestAspect.class )
+   void testLoadAspectModelsSourceFilesArePresent( final TestAspect testAspect ) {
+      final AspectModel aspectModel = TestResources.load( testAspect );
+      for ( final ModelElement element : aspectModel.elements() ) {
+         assertThat( element.getSourceFile() )
+               .describedAs( "Element %s has no source file", element ).isNotNull();
+         assertThat( element.getSourceFile() )
+               .describedAs( "Source file %s must contain defintion for %s", element.getSourceFile(), element.urn() )
+               .elements().contains( element );
+      }
+   }
+
    @Test
    void loadAspectModelWithoutCharacteristicDatatype() {
       assertThatThrownBy( () -> TestResources.load( InvalidTestAspect.INVALID_CHARACTERISTIC_DATATYPE ) )

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGenerator.java
@@ -36,7 +36,6 @@ import java.util.Random;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -37,7 +37,6 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 


### PR DESCRIPTION
-------

## Description

Since ScalarValue objects now have base attributes (as they can have
descriptions, preferredName and see references), they should also correctly
return their source file when `getSourceFile()` is called.

Fixes #726

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works