### PR TITLE
Declare missing dependency

### DIFF
--- a/tools/esmf-aspect-model-maven-plugin/pom.xml
+++ b/tools/esmf-aspect-model-maven-plugin/pom.xml
@@ -60,7 +60,6 @@
          <artifactId>record-builder-processor</artifactId>
          <scope>provided</scope>
       </dependency>
-
       <dependency>
          <groupId>org.eclipse.esmf</groupId>
          <artifactId>esmf-aspect-model-starter</artifactId>
@@ -68,6 +67,10 @@
       <dependency>
          <groupId>org.eclipse.esmf</groupId>
          <artifactId>esmf-aspect-model-github-resolver</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-lang3</artifactId>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Using the code generation in Maven Plugin 2.10.0 can fail due to a missing
runtime dependency to commons-lang3.

Fixes #729

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works