### PR TITLE
Make generated OpenAPI request bodies required

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -586,6 +586,8 @@ public class AspectModelOpenApiGeneratorTest {
       final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
       final OpenAPI openApi = result.getOpenAPI();
 
+      assertThat( openApi.getComponents().getRequestBodies().get( "AspectWithoutSeeAttribute" ).getRequired() ).isTrue();
+
       final String apiEndpoint = "/{tenant-id}/aspect-without-see-attribute";
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();


### PR DESCRIPTION
-------

## Description

Request bodies in generated OpenAPI specs should be marked `required`, since
OpenAPI defaults to optional.

Fixes #707

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works