### PR TITLE
[BUG] .jar Release Asset misses dependencies since 2.10.0

### DIFF
--- a/tools/samm-cli/pom.xml
+++ b/tools/samm-cli/pom.xml
@@ -32,7 +32,7 @@
       <main-class>org.eclipse.esmf.SammCli</main-class>
       <binary-name>samm</binary-name>
       <skip.maven.surefire>false</skip.maven.surefire>
-      <skip.maven.failsafe>true</skip.maven.failsafe>
+      <skip.maven.failsafe>false</skip.maven.failsafe>
       <skip.maven.surefire.report.plugin>false</skip.maven.surefire.report.plugin>
       <skip.maven.shade>false</skip.maven.shade>
    </properties>
@@ -298,6 +298,14 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.2</version>
+            <configuration>
+               <archive>
+                  <manifest>
+                     <mainClass>${main-class}</mainClass>
+                  </manifest>
+               </archive>
+            </configuration>
             <executions>
                <!-- For testing of the command executor, we need a test JAR file -->
                <execution>
@@ -314,6 +322,28 @@
                         </manifest>
                      </archive>
                      <classifier>tests</classifier>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+               <execution>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                     <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                           <mainClass>${main-class}</mainClass>
+                        </transformer>
+                     </transformers>
                   </configuration>
                </execution>
             </executions>


### PR DESCRIPTION
## Description

Rollback maven-shade-plugin

Fixes #731 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes
