### PR TITLE
Make ProxySelector and Authenticator optional in ProxyConfig

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/Download.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/Download.java
@@ -23,7 +23,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
@@ -70,8 +69,8 @@ public class Download {
                .version( HttpClient.Version.HTTP_1_1 )
                .followRedirects( HttpClient.Redirect.ALWAYS )
                .connectTimeout( Duration.ofSeconds( 10 ) );
-         Optional.ofNullable( proxyConfig.proxy() ).ifPresent( clientBuilder::proxy );
-         Optional.ofNullable( proxyConfig.authenticator() ).ifPresent( clientBuilder::authenticator );
+         proxyConfig.proxy().ifPresent( clientBuilder::proxy );
+         proxyConfig.authenticator().ifPresent( clientBuilder::authenticator );
          final HttpClient client = clientBuilder.build();
          final String[] headersArray = headers.entrySet().stream()
                .flatMap( entry -> Stream.of( entry.getKey(), entry.getValue() ) )

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ProxyConfig.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/ProxyConfig.java
@@ -16,6 +16,7 @@ package org.eclipse.esmf.aspectmodel.resolver;
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
 import java.net.ProxySelector;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,17 +24,23 @@ import io.soabase.recordbuilder.core.RecordBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Configuration of proxy settings with optional {@link ProxySelector} and {@link Authenticator}
+ *
+ * @param proxy the proxy selector
+ * @param authenticator the authenticator
+ */
 @RecordBuilder
 public record ProxyConfig(
-      ProxySelector proxy,
-      Authenticator authenticator
+      Optional<ProxySelector> proxy,
+      Optional<Authenticator> authenticator
 ) {
    private static final Logger LOG = LoggerFactory.getLogger( ProxyConfig.class );
 
-   public static final ProxyConfig NO_PROXY = new ProxyConfig( null, null );
+   public static final ProxyConfig NO_PROXY = new ProxyConfig( Optional.empty(), Optional.empty() );
 
    public static ProxyConfig from( final String host, final int port ) {
-      return new ProxyConfig( ProxySelector.of( new InetSocketAddress( host, port ) ), null );
+      return new ProxyConfig( Optional.of( ProxySelector.of( new InetSocketAddress( host, port ) ) ), Optional.empty() );
    }
 
    public static ProxyConfig detectProxySettings() {
@@ -54,7 +61,8 @@ public record ProxyConfig(
       final String host = System.getProperty( "http.proxyHost" );
       final String port = System.getProperty( "http.proxyPort" );
       if ( host != null && port != null ) {
-         return new ProxyConfig( ProxySelector.of( new InetSocketAddress( host, Integer.parseInt( port ) ) ), null );
+         return new ProxyConfig( Optional.of( ProxySelector.of( new InetSocketAddress( host, Integer.parseInt( port ) ) ) ),
+               Optional.empty() );
       }
       return NO_PROXY;
    }


### PR DESCRIPTION
-------

## Description

Prevent invalid use of ProxyConfig.proxySelector() if it's null

Fixes #744

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works