### PR TITLE
Extend aspect-to-aas output file path description

### DIFF
--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -135,10 +135,10 @@ of model resolution] for more information.
                                    | _--comment, -c_ : only in combination with --json; generates `$comment`
                                        OpenAPI 3.1 keyword for all `samm:see` attributes                                     |
                                    | _--parameter-file, -p_ : the path to a file including the parameter for the Aspect
-                                       API endpoints                                                                         | For detailed description, see the section bellow
+                                       API endpoints                                                                         | For detailed description, see the section below
                                    | _--semantic-version, -sv_ : use the full semantic version from the Aspect Model as the
                                        version for the Aspect API                                                            |
-                                   | _--resource-path, -r_ : the resource path for the Aspect API endpoints                  | For detailed description, see the section bellow
+                                   | _--resource-path, -r_ : the resource path for the Aspect API endpoints                  | For detailed description, see the section below
                                    | _--include-query-api, -q_ : include the path for the Query Aspect API Endpoint in the
                                        https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification                           |
                                    | _--include-crud, -cr_ : include the POST/PUT/PATCH methods in the OpenAPI specification |
@@ -156,7 +156,7 @@ of model resolution] for more information.
                                    | _--language, -l_ : The language from the model for which an OpenAPI specification should
                                        be generated (default: en)                                                            | `samm aspect AspectModel.ttl to openapi -l de`
                                    | _--template-file, -t_ : the path to a file including a template for
-                                       the resulting specification, can be in JSON or YAML                                   | For detailed description, see the section bellow
+                                       the resulting specification, can be in JSON or YAML                                   | For detailed description, see the section below
                                    | _--separate-files, -sf_ : Create separate files for each schema                         |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
 .8+| [[aspect-to-asyncapi]] aspect <model> to asyncapi | Generate https://www.asyncapi.com/docs/reference/specification/v3.0.0[AsyncAPI] specification for an Aspect Model| `samm aspect AspectModel.ttl to asyncapi`
@@ -199,8 +199,8 @@ of model resolution] for more information.
                                    | _--custom-column, -col_ : Additional custom column definition, e.g. for databricks following the pattern `column_name DATATYPE [NOT NULL] [COMMENT 'custom']`. This parameter can be repeated for multiple columns.                                                  | `samm aspect AspectModel.ttl to sql --custom-column "column_name STRING NOT NULL COMMENT 'custom'"`
 .5+| [[aspect-to-aas]] aspect <model> to aas | Generate an Asset Administration Shell (AAS) submodel template from an
                                      Aspect Model                                                                            | `samm aspect AspectModel.ttl to aas`
-                                   | _--output, -o_ : output file path (default: stdout)                                     | `samm aspect AspectModel.ttl to aas -o="some-path-`
-                                   | _--format, -f_ : output file format (XML, JSON, or AASX, default: XML)                  |
+                                   | _--output, -o_ : output file path (default: stdout)                                     | `samm aspect AspectModel.ttl to aas -o="somewhere\new-file-name.extension"`
+                                   | _--format, -f_ : output file format (XML, JSON, or AASX, default: XML)                  | `samm aspect AspectModel.ttl to aas -f="aasx" -o="somewhere\newfile.aasx"`
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--aspect-data, -a_ : path to a JSON file containing aspect data corresponding to the
                                      Aspect Model                                                                            |

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -65,7 +65,7 @@ In place of `<model>` in the command descriptions below, you can provide either 
 
 * a relative file name, such as `AspectModel.ttl` or `./somewhere/AspectModel.ttl` (on Linux and
 MacOS) or `.\somewhere\AspectModel.ttl` (on Windows),
-* an absolut file name, such as
+* an absolut file name (put it in quotes ("") if the path or file name contains blank spaces), such as
 `/home/me/aspect-models/org.eclipse.esmf.example/1.0.0/AspectModel.ttl` (on Linux and MacOS) or
 `C:\Users\me\aspect-models\org.eclipse.esmf.example\1.0.0\AspectModel.ttl` (on Windows),
 * a URL pointing to a .ttl file in a publically accessible GitHub repository, such as
@@ -199,7 +199,7 @@ of model resolution] for more information.
                                    | _--custom-column, -col_ : Additional custom column definition, e.g. for databricks following the pattern `column_name DATATYPE [NOT NULL] [COMMENT 'custom']`. This parameter can be repeated for multiple columns.                                                  | `samm aspect AspectModel.ttl to sql --custom-column "column_name STRING NOT NULL COMMENT 'custom'"`
 .5+| [[aspect-to-aas]] aspect <model> to aas | Generate an Asset Administration Shell (AAS) submodel template from an
                                      Aspect Model                                                                            | `samm aspect AspectModel.ttl to aas`
-                                   | _--output, -o_ : output file path (default: stdout)                                     |
+                                   | _--output, -o_ : output file path (default: stdout)                                     | `samm aspect AspectModel.ttl to aas -o="some-path-`
                                    | _--format, -f_ : output file format (XML, JSON, or AASX, default: XML)                  |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--aspect-data, -a_ : path to a JSON file containing aspect data corresponding to the


### PR DESCRIPTION
## Description

In the documentation, the aspect to aas command now includes examples that specify how the output path (incl. file name) needs to look like. The page now also provides a hint to use quotes for paths that include blank spaces.

This is a quick fix (no related GitHub issue).

## Type of change

Documentation updated.