### PR TITLE
Fix execution of external commands using custom resolver

### DIFF
--- a/core/esmf-aspect-meta-model-java/pom.xml
+++ b/core/esmf-aspect-meta-model-java/pom.xml
@@ -103,6 +103,26 @@
          </plugin>
 
          <plugin>
+            <groupId>pl.project13.maven</groupId>
+            <artifactId>git-commit-id-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>get-the-git-infos</id>
+                  <phase>initialize</phase>
+                  <goals>
+                     <goal>revision</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+               <generateGitPropertiesFile>true</generateGitPropertiesFile>
+               <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
+               </generateGitPropertiesFilename>
+            </configuration>
+         </plugin>
+
+         <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>

--- a/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/BuildtimeCodeGenerator.java
+++ b/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/BuildtimeCodeGenerator.java
@@ -82,7 +82,11 @@ public abstract class BuildtimeCodeGenerator {
             final Matcher singleVariableMatcher = replaceSingleVariablePattern.matcher( line );
             if ( singleVariableMatcher.matches() ) {
                final String variableName = singleVariableMatcher.group( 1 );
-               lineToAdd = line.replace( "${" + variableName + "}", interpolateVariable( variableName ) );
+               final String targetValue = interpolateVariable( variableName );
+               if ( targetValue == null ) {
+                  throw new RuntimeException( "Build-time code generation failed: Value for " + variableName + " could not be determined" );
+               }
+               lineToAdd = line.replace( "${" + variableName + "}", targetValue );
             } else {
                lineToAdd = line;
             }

--- a/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/template/VersionInfo.java
+++ b/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/template/VersionInfo.java
@@ -19,4 +19,6 @@ import javax.annotation.processing.Generated;
 public class VersionInfo {
    public static final String ESMF_SDK_VERSION = "${esmfSdkVersion}";
    public static final String ASPECT_META_MODEL_VERSION = "${aspectMetaModelVersion}";
+   public static final String BUILD_DATE = "${buildDate}";
+   public static final String COMMIT_ID = "${commitId}";
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/CommandExecutor.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/CommandExecutor.java
@@ -30,13 +30,13 @@ public class CommandExecutor {
    public static String executeCommand( final String command ) {
       final List<String> parts = Arrays.asList( command.split( " " ) );
       final String executableOrJar = parts.get( 0 );
-      final ProcessLauncher processLauncher = executableOrJar.toLowerCase().endsWith( ".jar" )
+      final ProcessLauncher<Process> processLauncher = executableOrJar.toLowerCase().endsWith( ".jar" )
             ? new ExecutableJarLauncher( new File( executableOrJar ) )
             : new BinaryLauncher( new File( executableOrJar ) );
       final List<String> arguments = parts.size() == 1
             ? List.of()
             : parts.subList( 1, parts.size() );
-      final ProcessLauncher.ExecutionContext context = new ProcessLauncher.ExecutionContext(
+      final ProcessLauncher<Process>.ExecutionContext context = processLauncher.new ExecutionContext(
             arguments, Optional.empty(), new File( System.getProperty( "user.dir" ) ) );
       final ProcessLauncher.ExecutionResult result = processLauncher.apply( context );
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/OsProcessLauncher.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/OsProcessLauncher.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A {@link ProcessLauncher} that spawns an external operating system process
  */
-public class OsProcessLauncher extends ProcessLauncher {
+public class OsProcessLauncher extends ProcessLauncher<Process> {
    private static final Logger LOG = LoggerFactory.getLogger( OsProcessLauncher.class );
    private final List<String> commandWithArguments;
 
@@ -74,6 +74,7 @@ public class OsProcessLauncher extends ProcessLauncher {
          final Future<ByteArrayOutputStream> stderrFuture = executor.submit( new StreamAccumulator( process.getErrorStream() ) );
 
          LOG.debug( "Waiting for process {} to finish", process.pid() );
+         context.processConsumer().ifPresent( consumer -> consumer.accept( process ) );
          process.waitFor();
 
          final byte[] stdoutRaw;

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/ProcessLauncher.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/ProcessLauncher.java
@@ -16,7 +16,9 @@ package org.eclipse.esmf.aspectmodel.resolver.process;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ProcessExecutionException;
@@ -24,10 +26,12 @@ import org.eclipse.esmf.aspectmodel.resolver.exceptions.ProcessExecutionExceptio
 /**
  * This class abstracts running a "process", i.e. running a program by providing its arguments, optional stdin and its working directory,
  * and representing the output using exit status and stdout and stderr streams.
+ *
+ * @param <T> the type of "process" that is created (such as {@link Process} or {@link Thread})
  */
-public abstract class ProcessLauncher implements Function<ProcessLauncher.ExecutionContext, ProcessLauncher.ExecutionResult> {
+public abstract class ProcessLauncher<T> implements Function<ProcessLauncher<T>.ExecutionContext, ProcessLauncher.ExecutionResult> {
    /**
-    * Convenience constructor that to apply the launcher to a list of arguments with empty stdin and default working directory
+    * Convenience method to apply the launcher to a list of arguments with empty stdin and default working directory
     */
    public ExecutionResult apply( final String... arguments ) {
       return apply( new ExecutionContext( Arrays.asList( arguments ), Optional.empty(), new File( System.getProperty( "user.dir" ) ) ) );
@@ -37,20 +41,95 @@ public abstract class ProcessLauncher implements Function<ProcessLauncher.Execut
       final ExecutionResult result = apply( arguments );
       if ( result.exitStatus() != 0 ) {
          throw new ProcessExecutionException(
-               "Execution failed (status " + result.exitStatus + "):\n"
-                     + "stdout:"
-                     + result.stdout()
-                     + "\n"
-                     + "stderr:"
-                     + result.stderr()
-         );
+               "Execution failed (status %d):\nstdout:%s\nstderr:%s".formatted( result.exitStatus, result.stdout(), result.stderr() ) );
       }
       return result;
    }
 
-   public record ExecutionContext( List<String> arguments, Optional<byte[]> stdin, File workingDirectory ) {
+   public ExecutionResult apply( final List<String> arguments, final Optional<byte[]> stdin, final File workingDirectory,
+         final Consumer<T> processConsumer ) {
+      return apply( new ExecutionContext( arguments, stdin, workingDirectory, Optional.of( processConsumer ) ) );
    }
 
-   public record ExecutionResult( int exitStatus, String stdout, String stderr, byte[] stdoutRaw, byte[] stderrRaw ) {
+   public ExecutionResult apply( final List<String> arguments, final Optional<byte[]> stdin, final File workingDirectory ) {
+      return apply( new ExecutionContext( arguments, stdin, workingDirectory ) );
    }
+
+   /**
+    * The execution context determines inputs for the new process: arguments, stdin and working directory
+    */
+   public final class ExecutionContext {
+      private final List<String> arguments;
+      private final Optional<byte[]> stdin;
+      private final File workingDirectory;
+      private final Optional<Consumer<T>> processConsumer;
+
+      public ExecutionContext( final List<String> arguments, final Optional<byte[]> stdin, final File workingDirectory,
+            final Optional<Consumer<T>> processConsumer ) {
+         this.arguments = arguments;
+         this.stdin = stdin;
+         this.workingDirectory = workingDirectory;
+         this.processConsumer = processConsumer;
+      }
+
+      public ExecutionContext( final List<String> arguments, final Optional<byte[]> stdin, final File workingDirectory ) {
+         this( arguments, stdin, workingDirectory, Optional.empty() );
+      }
+
+      public List<String> arguments() {
+         return arguments;
+      }
+
+      public Optional<byte[]> stdin() {
+         return stdin;
+      }
+
+      public File workingDirectory() {
+         return workingDirectory;
+      }
+
+      public Optional<Consumer<T>> processConsumer() {
+         return processConsumer;
+      }
+
+      @Override
+      public boolean equals( final Object obj ) {
+         if ( obj == this ) {
+            return true;
+         }
+         if ( obj == null || obj.getClass() != getClass() ) {
+            return false;
+         }
+         @SuppressWarnings( "unchecked" ) final ExecutionContext that = (ExecutionContext) obj;
+         return Objects.equals( arguments, that.arguments ) &&
+               Objects.equals( stdin, that.stdin ) &&
+               Objects.equals( workingDirectory, that.workingDirectory ) &&
+               Objects.equals( processConsumer, that.processConsumer );
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash( arguments, stdin, workingDirectory, processConsumer );
+      }
+
+      @Override
+      public String toString() {
+         return "ExecutionContext[" +
+               "arguments=" + arguments + ", " +
+               "stdin=" + stdin + ", " +
+               "workingDirectory=" + workingDirectory + ", " +
+               "processConsumer=" + processConsumer + ']';
+      }
+   }
+
+   /**
+    * The execution result provides the process' status and stderr and stdout results
+    */
+   public record ExecutionResult(
+         int exitStatus,
+         String stdout,
+         String stderr,
+         byte[] stdoutRaw,
+         byte[] stderrRaw
+   ) {}
 }

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/ProcessLauncher.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/resolver/process/ProcessLauncher.java
@@ -101,10 +101,10 @@ public abstract class ProcessLauncher<T> implements Function<ProcessLauncher<T>.
             return false;
          }
          @SuppressWarnings( "unchecked" ) final ExecutionContext that = (ExecutionContext) obj;
-         return Objects.equals( arguments, that.arguments ) &&
-               Objects.equals( stdin, that.stdin ) &&
-               Objects.equals( workingDirectory, that.workingDirectory ) &&
-               Objects.equals( processConsumer, that.processConsumer );
+         return Objects.equals( arguments, that.arguments )
+               && Objects.equals( stdin, that.stdin )
+               && Objects.equals( workingDirectory, that.workingDirectory )
+               && Objects.equals( processConsumer, that.processConsumer );
       }
 
       @Override
@@ -114,11 +114,11 @@ public abstract class ProcessLauncher<T> implements Function<ProcessLauncher<T>.
 
       @Override
       public String toString() {
-         return "ExecutionContext[" +
-               "arguments=" + arguments + ", " +
-               "stdin=" + stdin + ", " +
-               "workingDirectory=" + workingDirectory + ", " +
-               "processConsumer=" + processConsumer + ']';
+         return "ExecutionContext["
+               + "arguments=" + arguments + ", "
+               + "stdin=" + stdin + ", "
+               + "workingDirectory=" + workingDirectory + ", "
+               + "processConsumer=" + processConsumer + ']';
       }
    }
 

--- a/tools/samm-cli/pom.xml
+++ b/tools/samm-cli/pom.xml
@@ -169,7 +169,7 @@
                </systemPropertyVariables>
                <forkCount>1</forkCount>
                <reuseForks>false</reuseForks>
-               <argLine>-Xmx6g -Djava.security.manager=allow</argLine>
+               <argLine>-Xmx6g</argLine>
                <skip>${skip.maven.surefire}</skip>
                <reportsDirectory>${project.build.directory}/${testreports.surefire}</reportsDirectory>
                <!-- Do NOT wildcard include *Test.java, because then we would also run the SammCliIntegrationTest -->
@@ -293,26 +293,6 @@
          </plugin>
 
          <plugin>
-            <groupId>pl.project13.maven</groupId>
-            <artifactId>git-commit-id-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>get-the-git-infos</id>
-                  <phase>compile</phase>
-                  <goals>
-                     <goal>revision</goal>
-                  </goals>
-               </execution>
-            </executions>
-            <configuration>
-               <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
-               <generateGitPropertiesFile>true</generateGitPropertiesFile>
-               <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
-               </generateGitPropertiesFilename>
-            </configuration>
-         </plugin>
-
-         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>
@@ -374,6 +354,7 @@
                   <executableJar>${project.build.directory}/${project.artifactId}-${project.version}.jar
                   </executableJar>
                   <binary>${project.build.directory}/${binary-name}</binary>
+                  <nativeConfigPath>${native-config-path}</nativeConfigPath>
                   <forkCount>1</forkCount>
                   <reuseForks>true</reuseForks>
                   <argLine>-Xmx4096m</argLine>

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/SammCli.java
@@ -15,13 +15,10 @@ package org.eclipse.esmf;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIST;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.IntStream;
 
 import org.eclipse.esmf.aas.AasCommand;
@@ -32,6 +29,7 @@ import org.eclipse.esmf.aspect.AspectEditCommand;
 import org.eclipse.esmf.aspect.AspectPrettyPrintCommand;
 import org.eclipse.esmf.aspect.AspectToCommand;
 import org.eclipse.esmf.aspect.to.AspectToSvgCommand;
+import org.eclipse.esmf.aspectmodel.VersionInfo;
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.exception.SubCommandException;
 import org.eclipse.esmf.namespacepackage.PackageCommand;
@@ -245,27 +243,14 @@ public class SammCli extends AbstractCommand {
       return commandLine.getColorScheme().ansi().string( string );
    }
 
-   private Properties loadProperties( final String filename ) {
-      final Properties properties = new Properties();
-      final InputStream propertiesResource = SammCli.class.getClassLoader().getResourceAsStream( filename );
-      try {
-         properties.load( propertiesResource );
-      } catch ( final IOException exception ) {
-         throw new RuntimeException( "Failed to load Properties: " + filename );
-      }
-      return properties;
-   }
-
    @Override
    public void run() {
       if ( version ) {
-         final Properties applicationProperties = loadProperties( "application.properties" );
-         final Properties gitProperties = loadProperties( "git.properties" );
-         System.out.printf( "samm-cli - %s%nVersion: %s%nBuild date: %s%nGit commit: %s%n",
-               applicationProperties.get( "application.name" ),
-               applicationProperties.get( "version" ),
-               applicationProperties.get( "build.date" ),
-               gitProperties.get( "git.commit.id" ) );
+         System.out.println(
+               "samm-cli - Semantic Aspect Meta Model Command Line Tool\n"
+                     + "Version: " + VersionInfo.ESMF_SDK_VERSION + "\n"
+                     + "Build date: " + VersionInfo.BUILD_DATE + "\n"
+                     + "Git commit: " + VersionInfo.COMMIT_ID );
          System.exit( 0 );
       }
       System.out.println( commandLine.getHelp().fullSynopsis() );


### PR DESCRIPTION
## Description

Fixes execution of external commands in samm-cli using `--custom-resolver`.

Fixes #756.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

This PR also removes use of the finally deprecated class java.lang.SecurityManager: The MainClassProcessLauncher now spawns a new standalone JVM process, thus addressing the issue of capturing System.exit() calls.
