### PR TITLE
OpenAPI generation: fix properties alongside $refs are ignored 

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
@@ -267,12 +267,12 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
       final Characteristic characteristic = determineCharacteristic( property );
       final String referenceNodeName = getSchemaNameForModelElement( characteristic, property );
       if ( processedProperties.contains( property ) ) {
-         return propertyNode.put( "$ref", "#/components/schemas/" + referenceNodeName );
+         return generateRefOrWrappedRef( propertyNode, referenceNodeName );
       }
       processedProperties.add( property );
       final JsonNode schemaNode = characteristic.accept( this, context );
       setNodeInRootSchema( schemaNode, referenceNodeName );
-      return propertyNode.put( "$ref", "#/components/schemas/" + referenceNodeName );
+      return generateRefOrWrappedRef( propertyNode, referenceNodeName );
    }
 
    @Override
@@ -650,6 +650,19 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
    private void addSammExtensionAttribute( final ObjectNode node, final ModelElement describedElement ) {
       if ( !describedElement.isAnonymous() ) {
          node.put( AspectModelJsonSchemaGenerator.SAMM_EXTENSION, describedElement.urn().toString() );
+      }
+   }
+
+   private ObjectNode generateRefOrWrappedRef( final ObjectNode propertyNode, final String referenceNodeName ) {
+      if ( !propertyNode.isEmpty() ) {
+         ArrayNode allOfArray = FACTORY.arrayNode();
+         ObjectNode refNode = FACTORY.objectNode();
+         refNode.put( "$ref", "#/components/schemas/" + referenceNodeName );
+         allOfArray.add( refNode );
+         propertyNode.set( "allOf", allOfArray );
+         return propertyNode;
+      } else {
+         return FACTORY.objectNode().put( "$ref", "#/components/schemas/" + referenceNodeName );
       }
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -86,6 +86,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<OpenApiSchemaGene
    private static final String FIELD_REQUEST_BODY = "requestBody";
    private static final String FIELD_REQUIRED = "required";
    private static final String FIELD_RESPONSES = "responses";
+   private static final String FIELD_ALL_OF = "allOf";
    private static final String FIELD_SCHEMA = "schema";
    private static final String FIELD_SCHEMAS = "schemas";
    private static final String FIELD_STRING = "string";
@@ -508,7 +509,9 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<OpenApiSchemaGene
       objectNode.set( FIELD_PARAMETERS, getRequiredParameters( parameterNode, isEmpty( resourcePath ) ) );
       final ObjectNode requestBody = FACTORY.objectNode();
       requestBody.put( FIELD_REQUIRED, true );
-      requestBody.put( REF, COMPONENTS_REQUESTS + aspect.getName() );
+
+      generateAllOfObjectForRef( requestBody, aspect.getName() );
+
       objectNode.set( FIELD_REQUEST_BODY, requestBody );
       objectNode.set( FIELD_RESPONSES, getResponsesForGet( aspect ) );
       return objectNode;
@@ -591,6 +594,20 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<OpenApiSchemaGene
             rootSchemaNode.set( nodeName, node );
          }
       }
+   }
+
+   private void generateAllOfObjectForRef( final ObjectNode requestBody, final String ref ) {
+      final ObjectNode contentNode = FACTORY.objectNode();
+      final ObjectNode appJsonNode = FACTORY.objectNode();
+      final ObjectNode schemaNode = FACTORY.objectNode();
+      final ArrayNode allOfArray = FACTORY.arrayNode();
+      final ObjectNode refNode = FACTORY.objectNode();
+      refNode.put( REF, COMPONENTS_REQUESTS + ref );
+      allOfArray.add( refNode );
+      schemaNode.set( FIELD_ALL_OF, allOfArray );
+      appJsonNode.set( FIELD_SCHEMA, schemaNode );
+      contentNode.set( APPLICATION_JSON, appJsonNode );
+      requestBody.set( FIELD_CONTENT, contentNode );
    }
 
    static final class ObjectNodeExtension {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelPagingGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelPagingGenerator.java
@@ -134,7 +134,7 @@ class AspectModelPagingGenerator {
       schemaNode.set( AspectModelOpenApiGenerator.FIELD_PAGING_SCHEMA, node );
 
       final ObjectNode itemNode = (ObjectNode) node.get( "properties" ).get( "items" );
-      itemNode.put( "$ref", "#/components/schemas/" + aspect.getName() );
+      itemNode.set( "items", FACTORY.objectNode().put( "$ref", "#/components/schemas/" + aspect.getName() ) );
    }
 
    private void validatePaging( final PagingOption definedPagingOption, final Set<PagingOption> possiblePagingOptions ) {

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.LoggerFactory;
 
-public class AspectModelOpenApiGeneratorTest {
+class AspectModelOpenApiGeneratorTest {
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
    private static final String TEST_BASE_URL = "https://test-aspect.example.com";
    private static final String TEST_RESOURCE_PATH = "my-test-aspect";
@@ -520,11 +520,11 @@ public class AspectModelOpenApiGeneratorTest {
       final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
       final OpenAPI openApi = result.getOpenAPI();
       assertThat(
-            ( (Schema) openApi.getComponents().getSchemas().get( "testOperation" ).getAllOf()
-                  .get( 1 ) ).getProperties() ).doesNotContainKey(
+            ((Schema) openApi.getComponents().getSchemas().get( "testOperation" ).getAllOf()
+                  .get( 1 )).getProperties() ).doesNotContainKey(
             "params" );
-      assertThat( ( (Schema) openApi.getComponents().getSchemas().get( "testOperationTwo" ).getAllOf()
-            .get( 1 ) ).getProperties() ).doesNotContainKey( "params" );
+      assertThat( ((Schema) openApi.getComponents().getSchemas().get( "testOperationTwo" ).getAllOf()
+            .get( 1 )).getProperties() ).doesNotContainKey( "params" );
    }
 
    @Test
@@ -662,8 +662,8 @@ public class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getSpecVersion() ).isEqualTo( SpecVersion.V31 );
       assertThat( openApi.getComponents().getSchemas().get( "AspectWithCollection" ).get$comment() ).isEqualTo(
             "See: http://example.com/" );
-      assertThat( ( (Schema) openApi.getComponents().getSchemas().get( "AspectWithCollection" ).getProperties()
-            .get( "testProperty" ) ).get$comment() )
+      assertThat( ((Schema) openApi.getComponents().getSchemas().get( "AspectWithCollection" ).getProperties()
+            .get( "testProperty" )).get$comment() )
             .isEqualTo( "See: http://example.com/, http://example.com/me" );
       assertThat( openApi.getComponents().getSchemas().get( "TestCollection" ).get$comment() )
             .isEqualTo( "See: http://example.com/" );
@@ -684,15 +684,15 @@ public class AspectModelOpenApiGeneratorTest {
       final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
       final OpenAPI openApi = result.getOpenAPI();
 
-      Schema pagingSchema = openApi.getComponents().getSchemas().get( "PagingSchema" );
+      final Schema pagingSchema = openApi.getComponents().getSchemas().get( "PagingSchema" );
       assertThat( pagingSchema ).isNotNull();
 
-      Schema itemsProperty = (Schema) pagingSchema.getProperties().get( "items" );
-      assertThat( itemsProperty.get$ref() )
-            .isEqualTo( "#/components/schemas/" + aspect.getName() );
+      final Schema itemsProperty = (Schema) pagingSchema.getProperties().get( "items" );
 
-      assertThat( itemsProperty.getType() ).isNull();
-      assertThat( itemsProperty.getItems() ).isNull();
+      assertThat( itemsProperty.getType() ).isEqualTo( "array" );
+      final Schema itemsInner = itemsProperty.getItems();
+      assertThat( itemsInner ).isNotNull();
+      assertThat( itemsInner.get$ref() ).isEqualTo( "#/components/schemas/" + aspect.getName() );
 
       assertThat( pagingSchema.getProperties() ).containsKeys(
             "totalItems",
@@ -701,8 +701,41 @@ public class AspectModelOpenApiGeneratorTest {
             "currentPage"
       );
 
-      assertThat( openApi.getComponents().getSchemas().get( aspect.getName() ) )
-            .isNotNull();
+      assertThat( openApi.getComponents().getSchemas().get( aspect.getName() ) ).isNotNull();
+   }
+
+   @Test
+   void testPropertyWithDescriptionInCollection_ShouldBeWrappedInAllOf() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_COLLECTION ).aspect();
+
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .useSemanticVersion( true )
+            .baseUrl( TEST_BASE_URL )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .locale( Locale.ENGLISH )
+            .build();
+
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
+      final OpenAPI openApi = result.getOpenAPI();
+
+      final Schema<?> schema = openApi.getComponents().getSchemas().get( aspect.getName() );
+      assertThat( schema ).isNotNull();
+
+      final Schema<?> property = (Schema<?>) schema.getProperties().get( "testProperty" );
+      assertThat( property ).isNotNull();
+
+      assertThat( property.get$ref() ).isNull();
+
+      assertThat( property.getDescription() ).isEqualTo( "This is a test property." );
+
+      final List<Schema> allOfSchemas = property.getAllOf();
+      assertThat( allOfSchemas ).isNotNull().hasSize( 1 );
+      assertThat( allOfSchemas.get( 0 ).get$ref() ).isEqualTo( "#/components/schemas/TestCollection" );
+
+      if ( property.getExtensions() != null && property.getExtensions().containsKey( "x-comment" ) ) {
+         assertThat( property.getExtensions().get( "x-comment" ).toString() ).contains( "http://example.com/" );
+      }
    }
 
    private void assertSpecificationIsValid( final JsonNode jsonNode, final String json, final Aspect aspect ) throws IOException {


### PR DESCRIPTION
OpenAPI generation: fix properties alongside $refs are ignored  and roll back items in items for array type fix

## Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes #761

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes
