### PR TITLE
Fix SQL generator's -cc option to be effective with Collection

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
@@ -301,7 +301,7 @@ public class AspectModelDatabricksDenormalizedSqlVisitor
                     ? Optional.ofNullable( Optional.ofNullable( context.forceDescriptionFromElement() ).orElse( property )
                     .getDescription( config.commentLanguage() ) )
                     : Optional.empty();
-            columns.append( column( columnPrefix, typeDef, property.isOptional(), comment) )
+            columns.append( column( columnPrefix, typeDef, property.isOptional(), comment ) )
                   .append( lineDelimiter );
          } else if ( type instanceof ComplexType ) {
             columns.append( processComplexType( type.as( ComplexType.class ), context, columnPrefix, type.is( DefaultList.class ) ) );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
@@ -297,8 +297,11 @@ public class AspectModelDatabricksDenormalizedSqlVisitor
 
          if ( type instanceof Scalar ) {
             final String typeDef = type.accept( this, context );
-            columns.append( column( columnPrefix, typeDef, property.isOptional(),
-                        Optional.ofNullable( property.getDescription( config.commentLanguage() ) ) ) )
+            final Optional<String> comment = config.includeColumnComments()
+                    ? Optional.ofNullable( Optional.ofNullable( context.forceDescriptionFromElement() ).orElse( property )
+                    .getDescription( config.commentLanguage() ) )
+                    : Optional.empty();
+            columns.append( column( columnPrefix, typeDef, property.isOptional(), comment) )
                   .append( lineDelimiter );
          } else if ( type instanceof ComplexType ) {
             columns.append( processComplexType( type.as( ComplexType.class ), context, columnPrefix, type.is( DefaultList.class ) ) );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/AspectModelSqlGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/AspectModelSqlGeneratorTest.java
@@ -48,4 +48,26 @@ public class AspectModelSqlGeneratorTest {
          assertThat( result ).doesNotContain( "ARRAY<ARRAY" );
       } ).doesNotThrowAnyException();
    }
+
+   @ParameterizedTest
+   @EnumSource( value = TestAspect.class )
+   void testDatabricksGenerationExcludeComments( final TestAspect testAspect ) {
+      final Aspect aspect = TestResources.load( testAspect ).aspect();
+      assertThatCode( () -> {
+         final DatabricksSqlGenerationConfig dialectSpecificConfig = DatabricksSqlGenerationConfigBuilder.builder()
+                 .includeTableComment( false )
+                 .includeColumnComments( false )
+                 .commentLanguage( Locale.ENGLISH )
+                 .build();
+         final SqlArtifact sqlArtifact = new AspectModelSqlGenerator( aspect, SqlGenerationConfigBuilder.builder()
+                 .dialect( SqlGenerationConfig.Dialect.DATABRICKS )
+                 .dialectSpecificConfig( dialectSpecificConfig )
+                 .build() ).singleResult();
+         final String result = sqlArtifact.getContent();
+
+         assertThat( result ).contains( "TBLPROPERTIES ('x-samm-aspect-model-urn'='" );
+         assertThat( result ).doesNotContain( "ARRAY<ARRAY" );
+         assertThat( result ).doesNotContain( "COMMENT" );
+      } ).doesNotThrowAnyException();
+   }
 }


### PR DESCRIPTION
## Description

This PR fixes SQL generator's -cc option to suppress COMMENT output for Collection.

Fixes #780 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
