### PR TITLE
Fix SQL generation for samm-c:Either

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
@@ -209,7 +209,7 @@ public class AspectModelDatabricksDenormalizedSqlVisitor
             .forceOptional( true )
             .forceDescriptionFromElement( either.getRight() )
             .build() );
-      return leftResult + "\n" + ( rightResult.startsWith( "  " ) ? "" : "  " ) + rightResult;
+      return leftResult + ( leftResult.isBlank() ? "" : ",\n" ) + ( rightResult.startsWith( "  " ) ? "" : "  " ) + rightResult;
    }
 
    @Override

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitorTest.java
@@ -140,7 +140,7 @@ class AspectModelDatabricksDenormalizedSqlVisitorTest extends DatabricksTestBase
    void testAspectWithEither() {
       assertThat( sql( TestAspect.ASPECT_WITH_EITHER ) ).isEqualTo( """
             CREATE TABLE IF NOT EXISTS aspect_with_either (
-              test_property__left STRING COMMENT 'Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc.'
+              test_property__left STRING COMMENT 'Describes a Property which contains plain text. This is intended exclusively for human readable strings, not for identifiers, measurement values, etc.',
               test_property__right BOOLEAN COMMENT 'Represents a boolean value (i.e. a "flag").'
             )
             TBLPROPERTIES ('x-samm-aspect-model-urn'='urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithEither');
@@ -151,7 +151,7 @@ class AspectModelDatabricksDenormalizedSqlVisitorTest extends DatabricksTestBase
    void testAspectWithEitherWithComplexTypes() {
       assertThat( sql( TestAspect.ASPECT_WITH_EITHER_WITH_COMPLEX_TYPES ) ).isEqualTo( """
             CREATE TABLE IF NOT EXISTS aspect_with_either_with_complex_types (
-              test_property__left__result STRING COMMENT 'Left Type Characteristic'
+              test_property__left__result STRING COMMENT 'Left Type Characteristic',
               test_property__right__error STRING COMMENT 'Right Type Characteristic'
             )
             TBLPROPERTIES ('x-samm-aspect-model-urn'='urn:samm:org.eclipse.esmf.test:1.0.0#AspectWithEitherWithComplexTypes');
@@ -280,7 +280,7 @@ class AspectModelDatabricksDenormalizedSqlVisitorTest extends DatabricksTestBase
               test_either_property__left__test_int INT COMMENT 'Left type Characteristic',
               test_either_property__left__test_float FLOAT COMMENT 'Left type Characteristic',
               test_either_property__left__test_local_date_time TIMESTAMP COMMENT 'Left type Characteristic',
-              test_either_property__left__random_value STRING COMMENT 'Left type Characteristic'
+              test_either_property__left__random_value STRING COMMENT 'Left type Characteristic',
               test_either_property__right__test_string STRING COMMENT 'Right type Characteristic',
               test_either_property__right__test_int INT COMMENT 'Right type Characteristic',
               test_either_property__right__test_float FLOAT COMMENT 'Right type Characteristic',


### PR DESCRIPTION
## Description

This PR fixes the SQL generator to insert a comma between the left and right sides of samm-c:Either so that a correct query is generated.

Fixes #771

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

  - No comment needed since it's a concise fix.

- [x] I have made corresponding changes to the documentation

  - This fix doesn't affect the documentation at all.

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

  - I've fixed the existing (wrong) tests instead of adding a new one.
