### PR TITLE
Feature/695 extend code generator setters

### DIFF
--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -29,7 +29,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 import javax.xml.datatype.DatatypeConstants;
+
 import org.eclipse.esmf.aspectmodel.VersionInfo;
 import org.eclipse.esmf.aspectmodel.java.exception.CodeGenerationException;
 import org.eclipse.esmf.aspectmodel.visitor.AspectStreamTraversalVisitor;
@@ -121,7 +123,7 @@ public class AspectModelJavaUtil {
     */
    public static boolean hasContainerType( final Property property ) {
       return property.isOptional()
-            || ( property.getEffectiveCharacteristic().map( characteristic -> characteristic.is( Collection.class ) ).orElse( false ) );
+            || (property.getEffectiveCharacteristic().map( characteristic -> characteristic.is( Collection.class ) ).orElse( false ));
    }
 
    /**
@@ -324,8 +326,8 @@ public class AspectModelJavaUtil {
       return dataType.map( type -> {
          final Type actualDataType = dataType.get();
          if ( actualDataType instanceof ComplexType ) {
-            final String complexDataType = ( (ComplexType) actualDataType ).getName();
-            if ( ( !codeGenerationConfig.namePrefix().isBlank() || !codeGenerationConfig.namePostfix().isBlank() ) ) {
+            final String complexDataType = ((ComplexType) actualDataType).getName();
+            if ( (!codeGenerationConfig.namePrefix().isBlank() || !codeGenerationConfig.namePostfix().isBlank()) ) {
                return codeGenerationConfig.namePrefix() + complexDataType + codeGenerationConfig.namePostfix();
             }
             return complexDataType;
@@ -349,7 +351,7 @@ public class AspectModelJavaUtil {
 
    public static Class<?> getDataTypeClass( final Type dataType ) {
       if ( dataType instanceof ComplexType ) {
-         return ( (ComplexType) dataType ).getClass();
+         return ((ComplexType) dataType).getClass();
       }
 
       final Resource typeResource = ResourceFactory.createResource( dataType.getUrn() );
@@ -575,7 +577,7 @@ public class AspectModelJavaUtil {
    }
 
    public static String generateClassName( final StructureElement element, final JavaCodeGenerationConfig config ) {
-      if ( ( !config.namePrefix().isBlank() || !config.namePostfix().isBlank() ) && element.is( StructureElement.class ) ) {
+      if ( (!config.namePrefix().isBlank() || !config.namePostfix().isBlank()) && element.is( StructureElement.class ) ) {
          return config.namePrefix() + element.getName() + config.namePostfix();
       }
       return element.getName();
@@ -672,6 +674,15 @@ public class AspectModelJavaUtil {
             .map( type -> XSD.xboolean.getURI().equals( type.getUrn() ) )
             .orElse( false );
       return (isBooleanType ? "is" : "get") + StringUtils.capitalize( property.getPayloadName() );
+   }
+
+   public static String setterName( final Property property, final JavaCodeGenerationConfig codeGenerationConfig ) {
+      switch ( codeGenerationConfig.setterStyle() ) {
+         case FLUENT_COMPACT:
+            return StringUtils.uncapitalize( property.getPayloadName() );
+         default:
+            return "set" + StringUtils.capitalize( property.getPayloadName() );
+      }
    }
 
    public static String codeGeneratorName() {

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -197,7 +197,8 @@ public class AspectModelJavaUtil {
          if ( characteristic instanceof Collection ) {
             final String collectionType = determineCollectionType( (Collection) characteristic, false, codeGenerationConfig );
             final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.importTracker(), codeGenerationConfig );
-            return String.format( "public class %s implements CollectionAspect<%s,%s>", generateClassName( element, codeGenerationConfig ), collectionType, dataType );
+            return String.format( "public class %s implements CollectionAspect<%s,%s>", generateClassName( element, codeGenerationConfig ),
+                  collectionType, dataType );
          }
       }
       throw error.get();

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import javax.xml.datatype.DatatypeConstants;
 
 import org.eclipse.esmf.aspectmodel.VersionInfo;

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -40,6 +40,7 @@ import org.eclipse.esmf.metamodel.Characteristic;
 import org.eclipse.esmf.metamodel.ComplexType;
 import org.eclipse.esmf.metamodel.Entity;
 import org.eclipse.esmf.metamodel.HasProperties;
+import org.eclipse.esmf.metamodel.ModelElement;
 import org.eclipse.esmf.metamodel.Property;
 import org.eclipse.esmf.metamodel.Scalar;
 import org.eclipse.esmf.metamodel.StructureElement;
@@ -196,7 +197,7 @@ public class AspectModelJavaUtil {
          if ( characteristic instanceof Collection ) {
             final String collectionType = determineCollectionType( (Collection) characteristic, false, codeGenerationConfig );
             final String dataType = getDataType( characteristic.getDataType(), codeGenerationConfig.importTracker(), codeGenerationConfig );
-            return String.format( "public class %s implements CollectionAspect<%s,%s>", element.getName(), collectionType, dataType );
+            return String.format( "public class %s implements CollectionAspect<%s,%s>", generateClassName( element, codeGenerationConfig ), collectionType, dataType );
          }
       }
       throw error.get();
@@ -576,7 +577,7 @@ public class AspectModelJavaUtil {
       return generics.isEmpty() ? "" : "<" + generics + ">";
    }
 
-   public static String generateClassName( final StructureElement element, final JavaCodeGenerationConfig config ) {
+   public static String generateClassName( final ModelElement element, final JavaCodeGenerationConfig config ) {
       if ( (!config.namePrefix().isBlank() || !config.namePostfix().isBlank()) && element.is( StructureElement.class ) ) {
          return config.namePrefix() + element.getName() + config.namePostfix();
       }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -27,10 +27,12 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  * @param jsonTypeInfo Corresponds to com.fasterxml.jackson.annotation.JsonTypeInfo.Id and selects which JsonTypeInfo kind is used
  * @param packageName the package name that classes should be created in
  * @param importTracker the instance of the tracker that tracks imports during code generation
- * @param executeLibraryMacros determines whether template macros given in templateLibFile should be evaluatated
+ * @param executeLibraryMacros determines whether template macros given in templateLibFile should be evaluated
  * @param templateLibFile a file containing velocity macros overriding sections in the default code templates
  * @param namePrefix custom class name prefix
  * @param namePostfix custom class name postfix
+ * @param enableSetters controls whether setters should be generated for the properties of the generated Java classes
+ * @param setterStyle the style of setters to be generated, if {@code enableSetters} is true
  */
 @RecordBuilder
 public record JavaCodeGenerationConfig(
@@ -42,10 +44,16 @@ public record JavaCodeGenerationConfig(
       boolean executeLibraryMacros,
       File templateLibFile,
       String namePrefix,
-      String namePostfix
+      String namePostfix,
+      boolean enableSetters,
+      SetterStyle setterStyle
 ) implements GenerationConfig {
    public enum JsonTypeInfoType {
       NONE, CLASS, MINIMAL_CLASS, NAME, SIMPLE_NAME, DEDUCTION, CUSTOM
+   }
+
+   public enum SetterStyle {
+      STANDARD, FLUENT, FLUENT_COMPACT
    }
 
    public JavaCodeGenerationConfig {
@@ -61,7 +69,7 @@ public record JavaCodeGenerationConfig(
       if ( importTracker == null ) {
          importTracker = new ImportTracker();
       }
-      if ( executeLibraryMacros && ( templateLibFile == null || templateLibFile.toString().isEmpty() ) ) {
+      if ( executeLibraryMacros && (templateLibFile == null || templateLibFile.toString().isEmpty()) ) {
          throw new CodeGenerationException( "Missing configuration. Please provide path to velocity template library file." );
       }
       if ( executeLibraryMacros && !templateLibFile.exists() ) {
@@ -72,6 +80,9 @@ public record JavaCodeGenerationConfig(
       }
       if ( namePostfix == null ) {
          namePostfix = "";
+      }
+      if (setterStyle == null ) {
+         setterStyle = SetterStyle.STANDARD;
       }
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/JavaCodeGenerationConfig.java
@@ -81,7 +81,7 @@ public record JavaCodeGenerationConfig(
       if ( namePostfix == null ) {
          namePostfix = "";
       }
-      if (setterStyle == null ) {
+      if ( setterStyle == null ) {
          setterStyle = SetterStyle.STANDARD;
       }
    }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+
 import javax.annotation.processing.Generated;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -235,7 +236,7 @@ public class StaticMetaModelJavaArtifactGenerator<E extends StructureElement> im
 
       final String generatedSource = new TemplateEngine( context, engineConfiguration ).apply( "java-static-class" );
       try {
-         return new JavaArtifact( Roaster.format( generatedSource ), "Meta" + element.getName(),
+         return new JavaArtifact( Roaster.format( generatedSource ), "Meta" + AspectModelJavaUtil.generateClassName( element, config ),
                config.packageName() );
       } catch ( final Exception exception ) {
          throw new CodeGenerationException( generatedSource, exception );

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/metamodel/StaticMetaModelJavaArtifactGenerator.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-
 import javax.annotation.processing.Generated;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
@@ -13,10 +13,12 @@
 #parse( "java-pojo-property-lib.vm" )
 #parse( "java-pojo-constructor-lib.vm" )
 #parse( "java-pojo-getter-lib.vm" )
+#parse( "java-pojo-setter-lib.vm" )
 #parse( "java-pojo-equals-method-lib.vm" )
 #parse( "java-pojo-hashcode-method-lib.vm" )
 
 #macro( javaPojoClassBody )
+#set( $className = ${util.generateClassName( $element, $codeGenerationConfig )}+${util.genericClassSignature( $element )} )
 /**
 * Generated class for $element.getPreferredName( $localeEn ) (${elementUrn}).
 *#if ( $element.getDescription( $localeEn ) ) $element.getDescription( $localeEn )#end
@@ -29,7 +31,7 @@ ${util.determineCollectionAspectClassDefinition( $element, $codeGenerationConfig
 ${util.generateAbstractEntityClassAnnotations( $complexElement, $codeGenerationConfig, $extendingEntities )}
 ${util.determineComplexTypeClassDefinition( $complexElement, $codeGenerationConfig )}
 #else
-public class ${util.generateClassName( $element, $codeGenerationConfig )}${util.genericClassSignature( $element )} {
+public class ${className} {
 #end
 #foreach( $property in $element.properties )
     #javaPojoProperty( $property )
@@ -43,6 +45,9 @@ public class ${util.generateClassName( $element, $codeGenerationConfig )}${util.
 #foreach( $property in $element.properties )
     #set( $index = $foreach.count - 1 )
     #javaPojoGetter( $property, $index )
+#if ( $codeGenerationConfig.enableSetters() )
+    #javaPojoSetter( $property, $index, $className )
+#end
 #end
 #foreach( $property in $deconstructor.allProperties )
     #javaPojoGetter( $property, 0 )

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
@@ -31,7 +31,7 @@ ${util.determineCollectionAspectClassDefinition( $element, $codeGenerationConfig
 ${util.generateAbstractEntityClassAnnotations( $complexElement, $codeGenerationConfig, $extendingEntities )}
 ${util.determineComplexTypeClassDefinition( $complexElement, $codeGenerationConfig )}
 #else
-public class ${className} {
+public class $className {
 #end
 #foreach( $property in $element.properties )
     #javaPojoProperty( $property )

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-constructor-lib.vm
@@ -49,6 +49,12 @@
     }
     #end
     }
+
+    #if ( $codeGenerationConfig.enableSetters() )
+    public ${util.generateClassName( $element, $codeGenerationConfig )}() {
+        super();
+    }
+    #end
 #end
 
 #macro( javaPojoConstructor )

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-setter-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-setter-lib.vm
@@ -1,0 +1,41 @@
+#**
+ ~ Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+ ~
+ ~ See the AUTHORS file(s) distributed with this work for additional
+ ~ information regarding authorship.
+ ~
+ ~ This Source Code Form is subject to the terms of the Mozilla Public
+ ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+ ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ ~
+ ~ SPDX-License-Identifier: MPL-2.0
+ *#
+
+#macro( javaPojoSetter $property $propertyIndex $className )
+
+#set( $methodName = $util.setterName( $property, $codeGenerationConfig ) )
+#if ( $codeGenerationConfig.setterStyle().name().equals( "STANDARD" ) )
+#set( $returnType = "void" )
+#else
+#set( $returnType = $className )
+#end
+/**
+* Sets a new value for $property.getPreferredName( $localeEn )
+#if( !$codeGenerationConfig.setterStyle().name().equals( "STANDARD" ) )
+*
+* @return {@code this} for chaining
+#end
+*/
+#if( $property.isAbstract() )
+    public abstract ${returnType} $methodName( $propertyType $property.getPayloadName() );
+#else
+    #set( $propertyType = $util.getPropertyType( $property, false, $codeGenerationConfig ) )
+    #if( $property.getExtends().isPresent() )@Override #end
+public $returnType $methodName( final $propertyType $property.getPayloadName() ) {
+    this.$property.getPayloadName() = $property.getPayloadName();
+#if( !$codeGenerationConfig.setterStyle().name().equals( "STANDARD" ) )
+    return this;
+#end
+}
+#end
+#end

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-setter-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-setter-lib.vm
@@ -31,7 +31,7 @@
 #else
     #set( $propertyType = $util.getPropertyType( $property, false, $codeGenerationConfig ) )
     #if( $property.getExtends().isPresent() )@Override #end
-public $returnType $methodName( final $propertyType $property.getPayloadName() ) {
+public $returnType $methodName( final   $propertyType $property.getPayloadName() ) {
     this.$property.getPayloadName() = $property.getPayloadName();
 #if( !$codeGenerationConfig.setterStyle().name().equals( "STANDARD" ) )
     return this;

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-body-lib.vm
@@ -25,7 +25,7 @@ public static final String MODEL_ELEMENT_URN = NAMESPACE + "${element.getName()}
 
 private static String CHARACTERISTIC_NAMESPACE = "${characteristicBaseUrn}";
 
-#propertyDeclaration() Meta${element.getName()} INSTANCE = new Meta${element.getName()}();
+#propertyDeclaration() Meta${className} INSTANCE = new Meta${className}();
 
 #if( $util.isXmlDatatypeFactoryRequired( $element ) )
     $codeGenerationConfig.importTracker().importExplicit( $DatatypeConfigurationException )

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
@@ -59,6 +59,7 @@
 
 #macro( javaStaticClassProperty $property $codeGenerationConfig $element )
 #set( $propertyType = $util.getPropertyType( $property, $codeGenerationConfig ) )
+#set( $containingClass = $util.generateClassName( $element, $codeGenerationConfig ) )
 
 ## public static final $type $property = (definition)
 #if( $Trait.isAssignableFrom( $property.getCharacteristic().get().getClass() ) )
@@ -66,31 +67,31 @@
     #if( $util.hasContainerType( $property ) )
         $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintContainerProperty )
         #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
-        #propertyDeclaration() StaticConstraintContainerProperty<${element.getName()}, $containedType, $propertyType, #getCharacteristicClassName()>
-          $util.toConstant( $property.getName() ) = #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticConstraintContainerProperty<$containingClass, $containedType, $propertyType, #getCharacteristicClassName()>
+          $util.toConstant( $property.getName() ) = #staticProperty( $property $containingClass $codeGenerationConfig );
     #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
         $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintUnitProperty )
         $codeGenerationConfig.importTracker().importExplicit( $Unit )
-        #propertyDeclaration() StaticConstraintUnitProperty<${element.getName()}, $propertyType, #getCharacteristicClassName()>
-          $util.toConstant( $property.getName() ) = #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticConstraintUnitProperty<$containingClass, $propertyType, #getCharacteristicClassName()>
+          $util.toConstant( $property.getName() ) = #staticProperty( $property $containingClass $codeGenerationConfig );
     #else
-        #propertyDeclaration() StaticConstraintProperty<${element.getName()}, $propertyType, #getCharacteristicClassName()>
-          $util.toConstant( $property.getName() ) = #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticConstraintProperty<$containingClass, $propertyType, #getCharacteristicClassName()>
+          $util.toConstant( $property.getName() ) = #staticProperty( $property $containingClass $codeGenerationConfig );
     #end
 #else
     #if( $util.hasContainerType( $property ) && !$propertyType.startsWith( "Map" ) )
         $codeGenerationConfig.importTracker().importExplicit( $StaticContainerProperty )
         #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
-        #propertyDeclaration() StaticContainerProperty<${element.getName()}, $containedType, java.util.$propertyType> $util.toConstant( $property.getName() ) =
-          #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticContainerProperty<$containingClass, $containedType, java.util.$propertyType> $util.toConstant( $property.getName() ) =
+          #staticProperty( $property $containingClass $codeGenerationConfig );
     #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
         $codeGenerationConfig.importTracker().importExplicit( $StaticUnitProperty )
         $codeGenerationConfig.importTracker().importExplicit( $Unit )
-        #propertyDeclaration() StaticUnitProperty<${element.getName()}, $propertyType> $util.toConstant( $property.getName() ) =
-          #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticUnitProperty<$containingClass, $propertyType> $util.toConstant( $property.getName() ) =
+          #staticProperty( $property $containingClass $codeGenerationConfig );
     #else
-        #propertyDeclaration() StaticProperty<${element.getName()}, $propertyType> $util.toConstant( $property.getName() ) =
-          #staticProperty( $property $codeGenerationConfig );
+        #propertyDeclaration() StaticProperty<$containingClass, $propertyType> $util.toConstant( $property.getName() ) =
+          #staticProperty( $property $containingClass $codeGenerationConfig );
     #end
 #end
 
@@ -98,7 +99,7 @@
 
 ## -------------------------------------------------
 
-#macro( staticProperty $property $codeGenerationConfig )
+#macro( staticProperty $property $containingClass $codeGenerationConfig )
     #set( $propertyType = $util.getPropertyType( $property, $codeGenerationConfig ) )
 
     ## new $type(
@@ -107,25 +108,25 @@
         #if( $util.hasContainerType( $property ) )
             $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintContainerProperty )
             #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
-            new StaticConstraintContainerProperty<${element.getName()}, $containedType, $propertyType, #getCharacteristicClassName()>(
+            new StaticConstraintContainerProperty<$containingClass, $containedType, $propertyType, #getCharacteristicClassName()>(
         #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
             $codeGenerationConfig.importTracker().importExplicit( $StaticConstraintUnitProperty )
             $codeGenerationConfig.importTracker().importExplicit( $Unit )
-            new StaticConstraintUnitProperty<${element.getName()}, $propertyType, #getCharacteristicClassName()>(
+            new StaticConstraintUnitProperty<$containingClass, $propertyType, #getCharacteristicClassName()>(
         #else
-            new StaticConstraintProperty<${element.getName()}, $propertyType, #getCharacteristicClassName()>(
+            new StaticConstraintProperty<$containingClass, $propertyType, #getCharacteristicClassName()>(
         #end
     #else
         #if( $util.hasContainerType( $property ) && !$propertyType.startsWith( "Map" ) )
             $codeGenerationConfig.importTracker().importExplicit( $StaticContainerProperty )
             #set( $containedType = $util.getCharacteristicJavaType( $property, $codeGenerationConfig ) )
-        new StaticContainerProperty<${element.getName()}, $containedType, $propertyType> (
+        new StaticContainerProperty<$containingClass, $containedType, $propertyType> (
         #elseif( $util.hasUnit( $property.getCharacteristic().get() ) )
             $codeGenerationConfig.importTracker().importExplicit( $StaticUnitProperty )
             $codeGenerationConfig.importTracker().importExplicit( $Unit )
-        new StaticUnitProperty<${element.getName()}, $propertyType>(
+        new StaticUnitProperty<$containingClass, $propertyType>(
         #else
-        new StaticProperty<${element.getName()}, $propertyType>(
+        new StaticProperty<$containingClass, $propertyType>(
         #end
     #end
 
@@ -140,7 +141,7 @@ Optional.of("$property.getPayloadName()"),
     #if ( $property.getExtends().isEmpty() )
         Optional.empty()
     #else
-        Optional.of( #staticProperty( $property.getExtends().get(), $codeGenerationConfig ) )
+        Optional.of( #staticProperty( $property.getExtends().get(), $containingClass, $codeGenerationConfig ) )
     #end
 ) {
 
@@ -175,8 +176,8 @@ public Class<$propertyType> getPropertyType() {
 }
 
     @Override
-    public Class<${element.getName()}> getContainingType() {
-    return ${element.getName()}.class;
+    public Class<$containingClass> getContainingType() {
+    return ${containingClass}.class;
     }
 
     #if( $util.hasContainerType( $property ) && !$propertyType.startsWith( "Map" ) )
@@ -188,14 +189,14 @@ public Class<$propertyType> getPropertyType() {
 
     #set( $getterName = $util.getterName( $property ) )
     @Override
-    public $propertyType getValue(${element.getName()} object) {
+    public $propertyType getValue($containingClass object) {
     return object.$getterName();
     }
 
     #if ( $codeGenerationConfig.enableSetters() )
     #set( $setterName = $util.setterName( $property, $codeGenerationConfig ) )
     @Override
-    public void setValue( ${element.getName()} object, $propertyType value ) {
+    public void setValue( $containingClass object, $propertyType value ) {
     object.$setterName( value );
     }
     #end

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
@@ -192,6 +192,14 @@ public Class<$propertyType> getPropertyType() {
     return object.$getterName();
     }
 
+    #if ( $codeGenerationConfig.enableSetters() )
+    #set( $setterName = $util.setterName( $property, $codeGenerationConfig ) )
+    @Override
+    public void setValue( ${element.getName()} object, $propertyType value ) {
+    object.$setterName( value );
+    }
+    #end
+
     #if( $util.hasUnit( $property.getCharacteristic().get() ) )
         $codeGenerationConfig.importTracker().importExplicit( $Unit )
         $codeGenerationConfig.importTracker().importExplicit( $Units )

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/ExtendedStaticMetaModelFunctionalityTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/ExtendedStaticMetaModelFunctionalityTest.java
@@ -35,7 +35,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testComputedProperties() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_EXTENDED_ENUMS;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithExtendedEnums" );
       final Class<?> metaAspectClass = findGeneratedClass( result, "MetaAspectWithExtendedEnums" );
@@ -67,7 +68,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testPropertyChain() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_NESTED_ENTITY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithNestedEntity" );
       final Class<?> entityClass = findGeneratedClass( result, "Entity" );
@@ -114,7 +116,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testCollectionPropertyChain() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY_WITH_NESTED_ENTITY_LIST_PROPERTY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithEntityWithNestedEntityListProperty" );
       final Class<?> entityClass = findGeneratedClass( result, "Entity" );
@@ -154,7 +157,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testCollectionPropertyChainWithNullCollectionInBetween() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_NESTED_ENTITY_LIST;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithNestedEntityList" );
       final Class<?> entityClass = findGeneratedClass( result, "TestFirstEntity" );
@@ -189,7 +193,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testSinglePropertyPredicates() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_NESTED_ENTITY_LIST;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithNestedEntityList" );
       final Class<?> entityClass = findGeneratedClass( result, "TestFirstEntity" );
@@ -245,7 +250,8 @@ public class ExtendedStaticMetaModelFunctionalityTest extends StaticMetaModelGen
    @Test
    void testCollectionPropertyPredicates() throws IOException, ReflectiveOperationException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_NESTED_ENTITY_LIST;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithNestedEntityList" );
       final Class<?> entityClass = findGeneratedClass( result, "TestFirstEntity" );

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/GenerationResult.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/GenerationResult.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import javax.annotation.processing.Generated;
 
 import com.github.javaparser.ParseResult;
@@ -46,7 +47,6 @@ import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
@@ -190,7 +190,7 @@ class GenerationResult {
    }
 
    void assertMethodBody( final String className, final String methodName, final boolean override,
-         final Optional<PrimitiveType> expectedReturnType,
+         final Optional<? extends com.github.javaparser.ast.type.Type> expectedReturnType,
          final int expectedNumberOfParameters, final List<String> expectedMethodBody ) {
       final Optional<MethodDeclaration> possibleMethodDeclaration = compilationUnits.get( className )
             .findAll( MethodDeclaration.class ).stream()
@@ -219,7 +219,7 @@ class GenerationResult {
    private TypeToken typeTokenToCheck( final Object fieldTypeOrTypeName ) {
       TypeToken typeToCheck;
       if ( fieldTypeOrTypeName instanceof TypeToken ) {
-         typeToCheck = ( (TypeToken) fieldTypeOrTypeName );
+         typeToCheck = ((TypeToken) fieldTypeOrTypeName);
       } else {
          typeToCheck = TypeToken.of( (Type) fieldTypeOrTypeName );
       }
@@ -240,11 +240,11 @@ class GenerationResult {
                      entry.getKey().toString().equals( toResolve.getClassNameToResolve() ) )
                .findAny().map( Map.Entry::getValue ).orElseThrow( () -> new RuntimeException( e ) );
       }
-      if ( !toResolve.getToResolve().isReferenceType() || ( (ResolvedReferenceType) toResolve.getToResolve() )
+      if ( !toResolve.getToResolve().isReferenceType() || ((ResolvedReferenceType) toResolve.getToResolve())
             .getTypeParametersMap().isEmpty() ) {
          return TypeResolution.resolved( rawType );
       }
-      final Type[] typeParameters = ( (ResolvedReferenceType) toResolve.getToResolve() )
+      final Type[] typeParameters = ((ResolvedReferenceType) toResolve.getToResolve())
             .getTypeParametersMap()
             .stream()
             .map( pair -> pair.b )

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
@@ -148,13 +148,13 @@ public class StaticClassGenerationResult extends GenerationResult {
 
    /**
     * Allows the assertion of method bodies for static meta properties in a generated meta class.
-    *
+    * <p>
     * Method bodies are asserted in a relaxed way:
     * <ul>
     *    <li>all whitespace is trimmed before comparing</li>
     *    <li>the given method body may also be just a part of the full method body, i.e. the check is performed using .contains()</li>
     * </ul>
-    *
+    * </p>
     * @param className the name of the meta class
     * @param propertyName the name of the property (given in CONSTANT_CASE)
     * @param expectedMethodBodies the expected (partial) contents of the static meta property methods, where the key is the method name
@@ -174,10 +174,12 @@ public class StaticClassGenerationResult extends GenerationResult {
                .stream()
                .map( VariableDeclarator::getInitializer )
                .flatMap( Optional::stream )
-               .filter( exp -> exp instanceof ObjectCreationExpr )
+               .filter( ObjectCreationExpr.class::isInstance )
                .map( ObjectCreationExpr.class::cast )
-               .flatMap(
-                     oc -> oc.getChildNodes().stream().filter( n -> n instanceof MethodDeclaration ).map( MethodDeclaration.class::cast ) )
+               .flatMap( oc -> oc.getChildNodes()
+                     .stream()
+                     .filter( MethodDeclaration.class::isInstance )
+                     .map( MethodDeclaration.class::cast ) )
                .anyMatch( md -> md.getBody()
                      .map( b -> b.getStatements().stream().anyMatch(
                            s -> expectedMethodBodies.containsKey( md.getName().toString() ) && s.toString().trim()

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticClassGenerationResult.java
@@ -155,6 +155,7 @@ public class StaticClassGenerationResult extends GenerationResult {
     *    <li>the given method body may also be just a part of the full method body, i.e. the check is performed using .contains()</li>
     * </ul>
     * </p>
+    *
     * @param className the name of the meta class
     * @param propertyName the name of the property (given in CONSTANT_CASE)
     * @param expectedMethodBodies the expected (partial) contents of the static meta property methods, where the key is the method name

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelBaseAttributesTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelBaseAttributesTest.java
@@ -27,7 +27,8 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    @Test
    void testMetaModelBaseAttributesOfGeneratedProperty() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BOOLEAN;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final ImmutableSet<String> expectedArguments = ImmutableSet.<String> builder()
@@ -42,7 +43,8 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    @Test
    void testMetaModelBaseAttributesOfGeneratedPropertyWithAllAttributes() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_ALL_BASE_ATTRIBUTES;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedMetaModelBaseAttributeBuilderCall = "MetaModelBaseAttributes.builder()"
@@ -62,7 +64,8 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    @Test
    void testMetaModelBaseAttributesOfGeneratedPropertyWithPreferredNames() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_PREFERRED_NAMES;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedMetaModelBaseAttributeBuilderCall = "MetaModelBaseAttributes.builder()"
@@ -79,7 +82,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testMetaModelBaseAttributesOfGeneratedPropertyWithDescriptions() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_DESCRIPTIONS;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedMetaModelBaseAttributeBuilderCall = "MetaModelBaseAttributes.builder()"
@@ -96,7 +99,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testMetaModelBaseAttributesOfGeneratedPropertyWithSee() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_SEE;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedMetaModelBaseAttributeBuilderCall = "MetaModelBaseAttributes.builder()"
@@ -113,7 +116,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testGeneratedMetaModelContainsRequiredMethods() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BOOLEAN;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final ImmutableMap<String, String> expectedMethodBodies = ImmutableMap.<String, String> builder()
@@ -135,7 +138,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testGeneratedMetaModelContainsOptionalMethods() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ALL_BASE_ATTRIBUTES;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String getPreferredNamesBody = "return new HashSet<>() {\n"
@@ -176,7 +179,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testGeneratedMetaModelContainsGetPreferredNamesMethod() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PREFERRED_NAMES;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String getPreferredNamesBody = "return new HashSet<>() {\n"
@@ -207,7 +210,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testGeneratedMetaModelContainsGetDescriptionsMethod() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_DESCRIPTIONS;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String getDescriptionsBody = "return new HashSet<>() {\n"
@@ -238,7 +241,7 @@ class StaticMetaModelBaseAttributesTest extends StaticMetaModelGeneratorTest {
    void testGeneratedMetaModelContainsGetSeeMethod() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_SEE;
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode()
-            .apply( getGenerators( aspect ) );
+            .apply( getGenerators( aspect, false, JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final ImmutableMap<String, String> expectedMethodBodies = ImmutableMap.<String, String> builder()

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelGeneratorTest.java
@@ -53,13 +53,16 @@ abstract class StaticMetaModelGeneratorTest {
       return List.of( pojoGenerator, staticGenerator );
    }
 
-   Collection<JavaGenerator> getGenerators( final TestAspect testAspect ) {
+   Collection<JavaGenerator> getGenerators( final TestAspect testAspect, final boolean enableSetters,
+         final JavaCodeGenerationConfig.SetterStyle setterStyle ) {
       final AspectModel aspectModel = TestResources.load( testAspect );
       final Aspect aspect = aspectModel.aspect();
       final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
             .enableJacksonAnnotations( false )
             .executeLibraryMacros( false )
             .packageName( aspect.urn().getNamespaceMainPart() )
+            .enableSetters( enableSetters )
+            .setterStyle( setterStyle )
             .build();
       final JavaGenerator pojoGenerator = new AspectModelJavaGenerator( aspect, config );
       final JavaGenerator staticGenerator = new StaticMetaModelJavaGenerator( aspect, config );

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -463,7 +464,7 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
       final String expectedTestPropertyCharacteristicConstructorCall =
             """
                   new DefaultEnumeration(MetaModelBaseAttributes.builder().withUrn(AspectModelUrn.fromUrn(NAMESPACE + "TestEnumeration")).build(), new DefaultScalar("http://www.w3.org/2001/XMLSchema#integer"), new ArrayList<Value>() {
-
+                  
                       {
                           add(new DefaultScalarValue(MetaModelBaseAttributes.builder().build(), new BigInteger("1"), new DefaultScalar("http://www.w3.org/2001/XMLSchema#integer")));
                           add(new DefaultScalarValue(MetaModelBaseAttributes.builder().build(), new BigInteger("2"), new DefaultScalar("http://www.w3.org/2001/XMLSchema#integer")));
@@ -680,7 +681,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, true,
             JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
-      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY", Map.of("setValue","object.setTestProperty(value)") );
+      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY",
+            Map.of( "setValue", "object.setTestProperty(value)" ) );
    }
 
    @Test
@@ -689,6 +691,6 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
       final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, true,
             JavaCodeGenerationConfig.SetterStyle.FLUENT_COMPACT ) );
 
-      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY", Map.of("setValue","object.testProperty(value)") );
+      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY", Map.of( "setValue", "object.testProperty(value)" ) );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/StaticMetaModelJavaGeneratorTest.java
@@ -55,7 +55,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @EnumSource( value = TestAspect.class )
    void testCodeGeneration( final TestAspect testAspect ) {
       assertThatCode( () -> {
-         final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( testAspect ) );
+         final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( testAspect, false,
+               JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
          final Pattern uninterpolatedTemplate = Pattern.compile( "\\$[a-zA-Z]" );
          result.compilationUnits.values().forEach( compilationUnit -> {
             // Check that all template variables have been replaced. If Velocity fails to insert a value (because evaluation of the
@@ -80,7 +81,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithOptionalProperties() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_OPTIONAL_PROPERTIES_WITH_ENTITY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithOptionalPropertiesWithEntity" );
       final Class<?> entityClass = findGeneratedClass( result, "TestEntity" );
@@ -108,7 +110,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithExtendedEnums() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_EXTENDED_ENUMS;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithExtendedEnums" );
       final Class<?> evaluationResultClass = findGeneratedClass( result, "EvaluationResult" );
@@ -139,7 +142,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithEither() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_EITHER_WITH_COMPLEX_TYPES;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> leftEntityClass = findGeneratedClass( result, "LeftEntity" );
       final Class<?> rightEntityClass = findGeneratedClass( result, "RightEntity" );
@@ -164,7 +168,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithMeasurement() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_MEASUREMENT;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
       result.assertFields( "MetaAspectWithMeasurement",
             fieldAssertions( "MetaAspectWithMeasurement" )
@@ -176,7 +181,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithExtendedEntityAssertProperties() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_EXTENDED_ENTITY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> testEntityClass = findGeneratedClass( result, "TestEntity" );
 
@@ -191,7 +197,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithRecursiveAspectWithOptional() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_RECURSIVE_PROPERTY_WITH_OPTIONAL;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithRecursivePropertyWithOptional" );
       final Class<?> testEntityClass = findGeneratedClass( result, "TestEntity" );
@@ -210,7 +217,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithDuration() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_DURATION;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
       result.assertFields( "MetaAspectWithDuration",
             fieldAssertions( "MetaAspectWithDuration" )
@@ -222,7 +230,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithCurie() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_CURIE;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithCurie" );
 
@@ -237,7 +246,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithBinary() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BINARY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
       result.assertFields( "MetaAspectWithBinary",
             fieldAssertions( "MetaAspectWithBinary" )
@@ -249,7 +259,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithState() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_STATE;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithState" );
       final Class<?> testStateClass = findGeneratedClass( result, "TestState" );
@@ -290,7 +301,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithConstraints() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_CONSTRAINTS;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithConstraints" );
 
@@ -324,7 +336,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithStructuredValue() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_NUMERIC_STRUCTURED_VALUE;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithNumericStructuredValue" );
 
@@ -342,7 +355,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithErrorCollection() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ERROR_COLLECTION;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithErrorCollection" );
       final Class<?> errorEntityClass = findGeneratedClass( result, "Error" );
@@ -367,7 +381,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithCollectionAndSimpleElementCharacteristic() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COLLECTION_AND_SIMPLE_ELEMENT_CHARACTERISTIC;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       result.assertFields( "MetaAspectWithCollectionAndSimpleElementCharacteristic",
@@ -380,7 +395,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithCollectionAndElementCharacteristic() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COLLECTION_AND_ELEMENT_CHARACTERISTIC;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithCollectionAndElementCharacteristic" );
       final Class<?> testEntityClass = findGeneratedClass( result, "TestEntity" );
@@ -397,7 +413,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithFixedPointConstraints() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_FIXED_POINT;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       result.assertFields( "MetaAspectWithFixedPoint",
@@ -410,7 +427,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithComplexEntityCollectionEnumeration() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENTITY_COLLECTION_ENUM;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       final Class<?> aspectClass = findGeneratedClass( result, "AspectWithComplexEntityCollectionEnum" );
       final Class<?> enumerationClass = findGeneratedClass( result, "MyEnumerationOne" );
@@ -438,7 +456,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testCharacteristicInstantiationForEnums() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ENUM_AND_OPTIONAL_ENUM_PROPERTIES;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 3 );
 
       final String expectedTestPropertyCharacteristicConstructorCall =
@@ -460,7 +479,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testAspectWithPropertyWithPayloadName() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_PROPERTY_WITH_PAYLOAD_NAME;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedPayloadNameArgument = "Optional.of(\"test\")";
@@ -472,7 +492,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testAspectWithBlankNode() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_BLANK_NODE;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       result.assertFields( "MetaAspectWithBlankNode",
@@ -484,7 +505,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testCharacteristicInstantiationForQuantifiableWithoutUnit() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_QUANTIFIABLE_WITHOUT_UNIT;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedTestPropertyCharacteristicConstructorCall =
@@ -503,7 +525,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testCharacteristicInstantiationForPropertyWithExampleValue() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COLLECTION;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       result.assertNumberOfFiles( 2 );
 
@@ -535,7 +558,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testCharacteristicInstantiationForQuantifiableWithUnit() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_QUANTIFIABLE_WITH_UNIT;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 2 );
 
       final String expectedTestPropertyCharacteristicConstructorCall =
@@ -550,7 +574,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelForAspectModelWithAbstractEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_ABSTRACT_ENTITY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 6 );
 
       final String expectedTestPropertyCharacteristicConstructorCall =
@@ -582,7 +607,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelForAspectModelWithCollectionWithAbstractEntity() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COLLECTION_WITH_ABSTRACT_ENTITY;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       result.assertNumberOfFiles( 6 );
 
       final String expectedTestPropertyCharacteristicConstructorCall =
@@ -604,7 +630,8 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithoutFileHeader() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_COMPLEX_ENUM;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
       final CompilationUnit aspectClass = result.compilationUnits.get( TestAspect.ASPECT_WITH_COMPLEX_ENUM.getName() );
       assertThat( aspectClass.getComment() ).isEmpty();
       final CompilationUnit enumeration = result.compilationUnits.get( "EvaluationResults" );
@@ -638,11 +665,30 @@ class StaticMetaModelJavaGeneratorTest extends StaticMetaModelGeneratorTest {
    @Test
    void testGenerateStaticMetaModelWithUmlauts() throws IOException {
       final TestAspect aspect = TestAspect.ASPECT_WITH_UMLAUT_DESCRIPTION;
-      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect ) );
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, false,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
 
       result.assertMethodBody( "MetaAspectWithUmlautDescription", "getDescriptions", true, Optional.empty(), 0,
             List.of(
                   "returnnewHashSet<>(){{add(newLangString(\"ImWortEntitätisteinUmlaut\",Locale.forLanguageTag(\"de\")));add(newLangString"
                         + "(\"Thisisatestdescription\",Locale.forLanguageTag(\"en\")));}};" ) );
+   }
+
+   @Test
+   void testStaticMetaModelWithSetters() throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, true,
+            JavaCodeGenerationConfig.SetterStyle.STANDARD ) );
+
+      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY", Map.of("setValue","object.setTestProperty(value)") );
+   }
+
+   @Test
+   void testStaticMetaModelWithFluentCompactSetters() throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
+      final StaticClassGenerationResult result = TestContext.generateStaticAspectCode().apply( getGenerators( aspect, true,
+            JavaCodeGenerationConfig.SetterStyle.FLUENT_COMPACT ) );
+
+      result.assertStaticMetaPropertyMethods( "MetaAspectWithEntity", "TEST_PROPERTY", Map.of("setValue","object.testProperty(value)") );
    }
 }

--- a/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/PropertyMutator.java
+++ b/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/PropertyMutator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.staticmetamodel;
+
+/**
+ * Interface for any class that can modify property values.
+ *
+ * @param <C> the type containing the property
+ * @param <T> the type of the property
+ * @see StaticProperty
+ */
+
+public interface PropertyMutator<C, T> {
+
+   /**
+    * Sets a new value for the property.
+    *
+    * @param object the instance containing the property
+    * @param value the new value to set
+    */
+   void setValue( C object, T value );
+}

--- a/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/StaticProperty.java
+++ b/core/esmf-aspect-static-meta-model-java/src/main/java/org/eclipse/esmf/staticmetamodel/StaticProperty.java
@@ -25,7 +25,8 @@ import org.eclipse.esmf.metamodel.impl.DefaultProperty;
 /**
  * Extends the SAMM {@link DefaultProperty} definition with a concrete type.
  */
-public abstract class StaticProperty<C, T> extends DefaultProperty implements PropertyTypeInformation<C, T>, PropertyAccessor<C, T> {
+public abstract class StaticProperty<C, T> extends DefaultProperty
+      implements PropertyTypeInformation<C, T>, PropertyAccessor<C, T>, PropertyMutator<C, T> {
 
    public StaticProperty(
          final MetaModelBaseAttributes metaModelBaseAttributes,
@@ -45,5 +46,10 @@ public abstract class StaticProperty<C, T> extends DefaultProperty implements Pr
       return getCharacteristic().flatMap( Characteristic::getDataType )
             .map( Type::isComplexType )
             .orElse( false );
+   }
+
+   @Override
+   public void setValue( final C object, final T value ) {
+      throw new UnsupportedOperationException( "No setter available." );
    }
 }

--- a/documentation/developer-guide/modules/static-metaclasses/pages/basic-usage.adoc
+++ b/documentation/developer-guide/modules/static-metaclasses/pages/basic-usage.adoc
@@ -116,6 +116,20 @@ The Java Class of the element contained _within_ the container.
 |`someStringValue` (using the getter, e.g. `object.getTestString()`)
 |===
 
+Mutating element instances is also possible if the code generator was run with setter creation enabled.
+Be aware of the fact, that the mutator methods are _always present_, but will throw an `UnsupportedOperationException` if no
+setters have been generated!
+
+[%autowidth]
+|===
+|Method |Description |Return Type |Sample call
+
+|`setValue(Movement object, PropertyType value)`
+|Updates the property value of the given element instance
+|`void`
+|`SPEED.setValue(movementInstance, 12.0f)`
+|===
+
 === Types of Static Properties
 
 Different kinds of Static Properties exist to reflect all possible elements within an Aspect Model:

--- a/documentation/developer-guide/modules/tooling-guide/examples/GenerateJavaPojo.java
+++ b/documentation/developer-guide/modules/tooling-guide/examples/GenerateJavaPojo.java
@@ -39,6 +39,8 @@ public class GenerateJavaPojo {
       final JavaCodeGenerationConfig config = JavaCodeGenerationConfigBuilder.builder()
             .enableJacksonAnnotations( true )
             .packageName( "com.example.mycompany" ) // if left out, package is taken from Aspect's namespace
+            .enableSetters( true ) // if left out, setters are not generated
+            .setterStyle( JavaCodeGenerationConfig.SetterStyle.FLUENT ) // if left out, "STANDARD" setter style is used
             .build();
       final AspectModelJavaGenerator generator = new AspectModelJavaGenerator( aspectModel.aspect(), config );
       generator.generate( qualifiedName -> {

--- a/documentation/developer-guide/modules/tooling-guide/pages/java-aspect-tooling.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/java-aspect-tooling.adoc
@@ -701,6 +701,19 @@ https://en.wikipedia.org/wiki/Jackson_(API)[Jackson] annotations should be gener
 mapping function passed to the generation method takes a `QualifiedName` instead of a String, so that you can decide how
 to handle the package structure of the class.
 
+By default, POJO classes are generated without setters. If setters are desired, use `enableSetters( true )` on the
+generator config. Three setter styles are supported:
+
+[width="100%", options="header", cols="33,67"]
+|===
+| Setter style | Example output
+| `STANDARD` (the default, if not explicitly set)  | `void setTheProperty( final String theProperty )`
+| `FLUENT`  | `TheClass setTheProperty( final String theProperty )`
+| `FLUENT_COMPACT`  | `TheClass theProperty( final String theProperty )`
+|===
+
+The `FLUENT_*` styles allow for method chaining, so that POJO instances can be written in a more compact way.
+
 ++++
 <details>
 <summary>Show used imports</summary>

--- a/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
@@ -171,6 +171,8 @@ are replaced using `packageName` | `String` | none | {nok}
 | `skip` | Skip execution of plugin and generation | `Boolean` | `false` | {nok}
 | `namePrefix` | Name prefix for generated Aspect, Entity Java classes | `String` | none | {nok}
 | `namePostfix` | Name postfix for generated Aspect, Entity Java classes | `String` | none | {nok}
+| `enableSetters` | Enable setters for generated Aspect, Entity Java classes | `Boolean` | `false` | {nok}
+| `setterStyle` | The desired style of the generated setters, one of `STANDARD`, `FLUENT` or `FLUENT_COMPACT`. | `String` | `STANDARD` | {nok}
 |===
 
 [[generate-static-meta-classes]]

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -107,7 +107,7 @@ of model resolution] for more information.
                                    | _--language, -l_ : the language from the model for which the diagram should be
                                        generated (default: en)                                                               |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements | `samm aspect AspectModel.ttl to svg --custom-resolver "java -jar resolver.jar"`
-.12+| [[aspect-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                 | `samm aspect AspectModel.ttl to java`
+.14+| [[aspect-to-java]] aspect <model> to java | Generate Java classes from an Aspect Model                                 | `samm aspect AspectModel.ttl to java`
                                    | _--output-directory, -d_ : output directory to write files to (default:
                                        current directory)                                                                    |
                                    | _--package-name, -pn_ : package to use for generated Java classes                       | `samm aspect AspectModel.ttl to java -pn org.company.product`
@@ -125,6 +125,8 @@ of model resolution] for more information.
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--name-prefix, -namePrefix_ : name prefix for generated Aspect, Entity Java classes    | `samm aspect AspectModel.ttl to java -namePrefix "Prefix"`
                                    | _--name-postfix, -namePostfix_ : name postfix for generated Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java -namePostfix "Postfix"`
+                                   | _--enable-setters, -enableSetters_ : whether setters should be generated for Aspect, Entity Java classes    | `samm aspect AspectModel.ttl to java --enable-setters`
+                                   | _--setter-style, -setterStyle_ : the style of setters to generate for Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java --enable-setters --setter-style "FLUENT"`
 .21+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
                                      for an Aspect Model                                                                     | `samm aspect AspectModel.ttl to openapi -j`
                                    | _--output, -o_ : output file path (default: stdout)                                     |

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/CodeGenerationMojo.java
@@ -15,12 +15,14 @@ package org.eclipse.esmf.aspectmodel;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.util.Optional;
 
 import org.eclipse.esmf.aspectmodel.java.QualifiedName;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.functions.ThrowingFunction;
 import org.eclipse.esmf.metamodel.Aspect;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 
@@ -74,5 +76,13 @@ public abstract class CodeGenerationMojo extends AspectModelMojo {
       return stripNamespace != null && !stripNamespace.isEmpty()
             ? interpolated.replaceAll( stripNamespace, "" )
             : interpolated;
+   }
+
+   protected static <T extends Enum<T>> T getEnumConstant( final Class<T> enumClass, final String constant, final String defaultConstant ) {
+      final var sanitizedConstant = Optional.ofNullable( constant )
+            .map( c -> c.toUpperCase().replace( "-", "_" ) )
+            .orElse( defaultConstant );
+
+      return EnumUtils.getEnum( enumClass, sanitizedConstant );
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Mojo( name = GenerateJavaClasses.MAVEN_GOAL, defaultPhase = LifecyclePhase.GENERATE_SOURCES )
-public class GenerateJavaClasses extends CodeGenerationMojo {
+public class GenerateJavaClasses extends JavaCodeGenerationMojo {
    public static final String MAVEN_GOAL = "generateJavaClasses";
    private static final Logger LOG = LoggerFactory.getLogger( GenerateJavaClasses.class );
 
@@ -42,12 +42,6 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
 
    @Parameter( defaultValue = "deduction" )
    protected String jsonTypeInfo;
-
-   @Parameter( defaultValue = "false" )
-   protected boolean enableSetters;
-
-   @Parameter( defaultValue = "standard" )
-   protected String setterStyle;
 
    /**
     * Default constructor used by Maven plugin instantiation

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJavaClasses.java
@@ -15,7 +15,6 @@ package org.eclipse.esmf.aspectmodel;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.esmf.aspectmodel.java.JavaCodeGenerationConfig;
@@ -23,7 +22,6 @@ import org.eclipse.esmf.aspectmodel.java.JavaCodeGenerationConfigBuilder;
 import org.eclipse.esmf.aspectmodel.java.pojo.AspectModelJavaGenerator;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -108,13 +106,5 @@ public class GenerateJavaClasses extends CodeGenerationMojo {
          }
       }
       LOG.info( "Successfully generated Java classes for Aspect Models." );
-   }
-
-   private static <T extends Enum<T>> T getEnumConstant( final Class<T> enumClass, final String constant, final String defaultConstant ) {
-      final var sanitizedConstant = Optional.ofNullable( constant )
-            .map( c -> c.toUpperCase().replace( "-", "_" ) )
-            .orElse( defaultConstant );
-
-      return EnumUtils.getEnum( enumClass, sanitizedConstant );
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
@@ -25,6 +25,7 @@ import org.eclipse.esmf.metamodel.Aspect;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,12 @@ import org.slf4j.LoggerFactory;
 public class GenerateStaticJavaClasses extends CodeGenerationMojo {
    public static final String MAVEN_GOAL = "generateStaticJavaClasses";
    private static final Logger LOG = LoggerFactory.getLogger( GenerateStaticJavaClasses.class );
+
+   @Parameter( defaultValue = "false" )
+   protected boolean enableSetters;
+
+   @Parameter( defaultValue = "standard" )
+   protected String setterStyle;
 
    @Override
    public void executeGeneration() throws MojoExecutionException {
@@ -45,6 +52,8 @@ public class GenerateStaticJavaClasses extends CodeGenerationMojo {
                .templateLibFile( templateLibFile )
                .namePrefix( namePrefix )
                .namePostfix( namePostfix )
+               .enableSetters( enableSetters )
+               .setterStyle( getEnumConstant( JavaCodeGenerationConfig.SetterStyle.class, setterStyle, "STANDARD" ) )
                .build();
          new StaticMetaModelJavaGenerator( aspect, config ).generateThrowing( javaFileNameMapper( outputDirectory ) );
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateStaticJavaClasses.java
@@ -25,20 +25,13 @@ import org.eclipse.esmf.metamodel.Aspect;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Mojo( name = GenerateStaticJavaClasses.MAVEN_GOAL, defaultPhase = LifecyclePhase.GENERATE_SOURCES )
-public class GenerateStaticJavaClasses extends CodeGenerationMojo {
+public class GenerateStaticJavaClasses extends JavaCodeGenerationMojo {
    public static final String MAVEN_GOAL = "generateStaticJavaClasses";
    private static final Logger LOG = LoggerFactory.getLogger( GenerateStaticJavaClasses.class );
-
-   @Parameter( defaultValue = "false" )
-   protected boolean enableSetters;
-
-   @Parameter( defaultValue = "standard" )
-   protected String setterStyle;
 
    @Override
    public void executeGeneration() throws MojoExecutionException {

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/JavaCodeGenerationMojo.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/JavaCodeGenerationMojo.java
@@ -1,0 +1,14 @@
+package org.eclipse.esmf.aspectmodel;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Base class for all Mojos that generate Java code.
+ */
+public abstract class JavaCodeGenerationMojo extends CodeGenerationMojo {
+   @Parameter( defaultValue = "false" )
+   protected boolean enableSetters;
+
+   @Parameter( defaultValue = "standard" )
+   protected String setterStyle;
+}

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJavaCommand.java
@@ -103,6 +103,19 @@ public class AspectToJavaCommand extends AbstractCommand {
          description = "Print detailed reports on errors" )
    private boolean details = false;
 
+   @SuppressWarnings( "FieldCanBeLocal" )
+   @CommandLine.Option(
+         names = { "--enable-setters", "-enableSetters" },
+         description = "Generate setter methods in Aspect, Entity Java classes" )
+   private boolean enableSetters = false;
+
+   @SuppressWarnings( "FieldCanBeLocal" )
+   @CommandLine.Option( names = { "--setter-style", "-setterStyle" },
+         description = "The style of setters to generate, one of STANDARD, FLUENT, FLUENT_COMPACT. Default: STANDARD",
+         converter = SetterStyleConverter.class
+   )
+   private JavaCodeGenerationConfig.SetterStyle setterStyle;
+
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
 
@@ -118,6 +131,15 @@ public class AspectToJavaCommand extends AbstractCommand {
          return value == null
                ? JavaCodeGenerationConfig.JsonTypeInfoType.DEDUCTION
                : JavaCodeGenerationConfig.JsonTypeInfoType.valueOf( value.toUpperCase() );
+      }
+   }
+
+   static class SetterStyleConverter implements CommandLine.ITypeConverter<JavaCodeGenerationConfig.SetterStyle> {
+      @Override
+      public JavaCodeGenerationConfig.SetterStyle convert( final String value ) throws Exception {
+         return value == null
+               ? JavaCodeGenerationConfig.SetterStyle.STANDARD
+               : JavaCodeGenerationConfig.SetterStyle.valueOf( value.toUpperCase() );
       }
    }
 
@@ -151,6 +173,8 @@ public class AspectToJavaCommand extends AbstractCommand {
             .packageName( pkgName )
             .namePrefix( namePrefix )
             .namePostfix( namePostfix )
+            .enableSetters( enableSetters )
+            .setterStyle( setterStyle )
             .build();
    }
 

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -697,7 +697,7 @@ class SammCliTest {
             file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
 
       final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
-      assertThat( sourceFile ).content().contains( "public void setTestProperty( final TestEntity testProperty )" );
+      assertThat( sourceFile ).content().contains( "public void setTestProperty(final TestEntity testProperty)" );
    }
 
    @Test
@@ -715,7 +715,7 @@ class SammCliTest {
             file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
 
       final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
-      assertThat( sourceFile ).content().contains( "public AspectWithEntity setTestProperty( final TestEntity testProperty )" );
+      assertThat( sourceFile ).content().contains( "public AspectWithEntity setTestProperty(final TestEntity testProperty)" );
    }
 
    @Test
@@ -733,7 +733,7 @@ class SammCliTest {
             file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
 
       final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
-      assertThat( sourceFile ).content().contains( "public AspectWithEntity testProperty( final TestEntity testProperty )" );
+      assertThat( sourceFile ).content().contains( "public AspectWithEntity testProperty(final TestEntity testProperty)" );
    }
 
    @Test

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -704,7 +704,8 @@ class SammCliTest {
    void testAspectToJavaWithFluentSetters() {
       final File outputDir = outputDirectory.toFile();
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",
-            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style", "FLUENT" );
+            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style",
+            "FLUENT" );
       assertThat( result.stdout() ).isEmpty();
       assertThat( result.stderr() ).isEmpty();
 
@@ -721,7 +722,8 @@ class SammCliTest {
    void testAspectToJavaWithFluentCompactSetters() {
       final File outputDir = outputDirectory.toFile();
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",
-            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style", "FLUENT_COMPACT" );
+            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style",
+            "FLUENT_COMPACT" );
       assertThat( result.stdout() ).isEmpty();
       assertThat( result.stderr() ).isEmpty();
 
@@ -1642,7 +1644,7 @@ class SammCliTest {
     * Returns the File object for a test model file
     */
    private File inputFile( final TestModel testModel ) {
-      final boolean isValid = !( testModel instanceof InvalidTestAspect );
+      final boolean isValid = !(testModel instanceof InvalidTestAspect);
       final String resourcePath = String.format(
             "%s/../../core/esmf-test-aspect-models/src/main/resources/%s/org.eclipse.esmf.test/1.0.0/%s.ttl",
             System.getProperty( "user.dir" ), isValid ? "valid" : "invalid", testModel.getName() );
@@ -1693,8 +1695,8 @@ class SammCliTest {
       // are not resolved to the file system but to the jar)
       try {
          final String resolverScript = new File(
-               System.getProperty( "user.dir" ) + "/target/test-classes/model_resolver" + ( OS.WINDOWS.isCurrentOs()
-                     ? ".bat" : ".sh" ) ).getCanonicalPath();
+               System.getProperty( "user.dir" ) + "/target/test-classes/model_resolver" + (OS.WINDOWS.isCurrentOs()
+                     ? ".bat" : ".sh") ).getCanonicalPath();
          final String modelsRoot = new File( System.getProperty( "user.dir" ) + "/target/classes/valid" ).getCanonicalPath();
          final String metaModelVersion = KnownVersion.getLatest().toString().toLowerCase();
          return resolverScript + " " + modelsRoot + " " + metaModelVersion;

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -684,6 +684,57 @@ class SammCliTest {
    }
 
    @Test
+   void testAspectToJavaWithSetters() {
+      final File outputDir = outputDirectory.toFile();
+      final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",
+            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).isEmpty();
+
+      final File directory = Paths.get( outputDir.getAbsolutePath(), "org", "eclipse", "esmf", "test" ).toFile();
+      assertThat( directory ).exists();
+      assertThat( directory ).isDirectoryContaining(
+            file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
+
+      final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
+      assertThat( sourceFile ).content().contains( "public void setTestProperty( final TestEntity testProperty )" );
+   }
+
+   @Test
+   void testAspectToJavaWithFluentSetters() {
+      final File outputDir = outputDirectory.toFile();
+      final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",
+            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style", "FLUENT" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).isEmpty();
+
+      final File directory = Paths.get( outputDir.getAbsolutePath(), "org", "eclipse", "esmf", "test" ).toFile();
+      assertThat( directory ).exists();
+      assertThat( directory ).isDirectoryContaining(
+            file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
+
+      final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
+      assertThat( sourceFile ).content().contains( "public AspectWithEntity setTestProperty( final TestEntity testProperty )" );
+   }
+
+   @Test
+   void testAspectToJavaWithFluentCompactSetters() {
+      final File outputDir = outputDirectory.toFile();
+      final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",
+            "--output-directory", outputDir.getAbsolutePath(), "--custom-resolver", resolverCommand(), "--enable-setters", "--setter-style", "FLUENT_COMPACT" );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).isEmpty();
+
+      final File directory = Paths.get( outputDir.getAbsolutePath(), "org", "eclipse", "esmf", "test" ).toFile();
+      assertThat( directory ).exists();
+      assertThat( directory ).isDirectoryContaining(
+            file -> file.getName().equals( "AspectWithEntity.java" ) || file.getName().equals( "TestEntity.java" ) );
+
+      final File sourceFile = directory.toPath().resolve( "AspectWithEntity.java" ).toFile();
+      assertThat( sourceFile ).content().contains( "public AspectWithEntity testProperty( final TestEntity testProperty )" );
+   }
+
+   @Test
    void testAspectToJavaStaticWithDefaultPackageName() {
       final File outputDir = outputDirectory.toFile();
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "java",


### PR DESCRIPTION
## Description

The code generators for Java artifacts are extended so that also mutable POJOs can be generated, i.e. they contain setter methods.
The style is configurable so that also fluent setters and fluent setters with a compact name can be used.

The change is backwards compatible, as by default setter generation is disabled.

Fixes #695 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

N/A
