### PR TITLE
Missing @Valid bean validation for nested object

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/serializer/RdfModelCreatorVisitorTest.java
+++ b/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/serializer/RdfModelCreatorVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -57,7 +57,8 @@ class RdfModelCreatorVisitorTest {
          "ASPECT_WITH_QUANTITY",
          "ASPECT_WITH_NAMESPACE_DESCRIPTION",
          "ASPECT_WITH_ANY_VALUE_DECLARATIONS",
-         "ASPECT_WITH_OPTIONAL_PROPERTIES_AND_ENTITY_WITH_SEPARATE_FILES"
+         "ASPECT_WITH_OPTIONAL_PROPERTIES_AND_ENTITY_WITH_SEPARATE_FILES",
+         "ASPECT_WITH_VALID_ANNOTATION_TEST"
    } )
    void testRdfModelCreatorVisitor( final TestAspect testAspect ) {
       final AspectModel aspectModel = TestResources.load( testAspect );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/DatabricksColumnDefinitionParserTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/DatabricksColumnDefinitionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -41,6 +41,7 @@ class DatabricksColumnDefinitionParserTest extends DatabricksTestBase {
             .collect( Collectors.joining( "\n" ) );
       assertThat( sql.lines()
             .filter( line -> line.startsWith( "  " ) )
+            .map( line -> "  " + line.trim() )
             .map( line -> line.replaceAll( ",$", "" ) )
             .collect( Collectors.joining( "\n" ) ) )
             .isEqualTo( parsedAndSerializedSql );

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/AspectModelJavaGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/AspectModelJavaGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -36,8 +36,9 @@ public class AspectModelJavaGenerator extends JavaGenerator {
 
    @Override
    public Stream<Artifact<QualifiedName, String>> generate() {
-      final Set<ComplexType> structureElements = elements( ComplexType.class ).filter( element ->
-            element.getExtends().isPresent() ).collect( Collectors.toSet() );
+      final Set<ComplexType> structureElements = elements( ComplexType.class )
+            .filter( element -> element.getExtends().isPresent() )
+            .collect( Collectors.toSet() );
       return Stream.of(
                   applyArtifactGenerator( Aspect.class, new StructureElementJavaArtifactGenerator<>(), config ),
                   applyArtifactGenerator( ComplexType.class, new StructureElementJavaArtifactGenerator<>( structureElements ), config ),

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -115,6 +116,7 @@ public class StructureElementJavaArtifactGenerator<E extends StructureElement> i
             .put( "localeEn", Locale.ENGLISH )
             .put( "Matcher", Matcher.class )
             .put( "NotNull", NotNull.class )
+            .put( "Valid", Valid.class )
             .put( "Object", Object.class )
             .put( "ResourceFactory", ResourceFactory.class )
             .put( "Scalar", Scalar.class )

--- a/core/esmf-aspect-model-java-generator/src/main/java/velocity_implicit.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/java/velocity_implicit.vm
@@ -76,6 +76,7 @@
 #* @vtlvariable name="modelVisitor" type="org.eclipse.esmf.aspectmodel.java.metamodel.StaticMetaModelVisitor" *#
 #* @vtlvariable name="nonNegativeInteger" type="org.eclipse.esmf.metamodel.Scalar" *#
 #* @vtlvariable name="NotNull" type="java.lang.Class<jakarta.validation.constraints.NotNull>" *#
+#* @vtlvariable name="Valid" type="java.lang.Class<jakarta.validation.Valid>" *#
 #* @vtlvariable name="Object" type="java.lang.Class<java.lang.Object>" *#
 #* @vtlvariable name="Optional" type="java.lang.Class<java.util.Optional>" *#
 #* @vtlvariable name="Pattern" type="java.lang.Class<java.util.regex.Pattern>" *#

--- a/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
+++ b/core/esmf-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
@@ -13,6 +13,10 @@
 #macro( javaPojoProperty $property )
     #if( !$property.isAbstract() )
         #set( $propertyType = $util.getPropertyType( $property, true, $codeGenerationConfig ) )
+        #if( $util.needsValidAnnotation( $property ) )
+            $codeGenerationConfig.importTracker().importExplicit( $Valid )
+        @Valid
+        #end
         #if( !$property.isOptional() && !$property.isNotInPayload() )
             $codeGenerationConfig.importTracker().importExplicit( $NotNull )
         @NotNull

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -259,13 +258,13 @@ class AspectModelJavaGeneratorTest {
       result.assertFields( "AspectWithOptionalPropertiesAndEntityWithSeparateFiles", expectedFieldsForAspectClass, new HashMap<>() );
       assertConstructor( result, "AspectWithOptionalPropertiesAndEntityWithSeparateFiles", expectedFieldsForAspectClass );
 
-      CompilationUnit unit = result.compilationUnits.get( "ProductionPeriodEntity" );
-      ConstructorDeclaration constructor = unit.findFirst( ConstructorDeclaration.class )
+      final CompilationUnit unit = result.compilationUnits.get( "ProductionPeriodEntity" );
+      final ConstructorDeclaration constructor = unit.findFirst( ConstructorDeclaration.class )
             .orElseThrow( () -> new AssertionError( "Constructor not found in ProductionPeriodEntity" ) );
-      String constructorBody = constructor.getBody().toString();
-      assertThat( constructorBody ).contains( "Optional.ofNullable(" );
-      assertThat( constructorBody ).contains( ".filter(v -> !v.isEmpty())" );
-      assertThat( constructorBody ).contains( "_datatypeFactory.newXMLGregorianCalendarDate(" );
+      final String constructorBody = constructor.getBody().toString();
+      assertThat( constructorBody ).contains( "Optional.ofNullable(" )
+            .contains( ".filter(v -> !v.isEmpty())" )
+            .contains( "_datatypeFactory.newXMLGregorianCalendarDate(" );
    }
 
    @Test
@@ -345,9 +344,7 @@ class AspectModelJavaGeneratorTest {
 
       result.assertFields( "EvaluationResult", expectedFieldsForEvaluationResults, ImmutableMap.<String, String> builder()
             .put( "average", "" )
-            .put( "numericCode", "@NotNull" )
-            .put( "description", "" )
-            .put( "nestedResult", "@NotNull" )
+            .put( "numericCode", "@NotNull" ).put( "description", "" ).put( "nestedResult", "@Valid@NotNull" )
             .build()
       );
       result.assertConstructor( "EvaluationResult", expectedFieldsForEvaluationResults, new HashMap<>() );
@@ -1247,5 +1244,31 @@ class AspectModelJavaGeneratorTest {
             List.of( "this.testProperty=testProperty;", "returnthis;" ) );
       result.assertMethodBody( "TestEntity", "entityProperty", false, Optional.of( new ClassOrInterfaceType( "TestEntity" ) ), 1,
             List.of( "this.entityProperty=entityProperty;", "returnthis;" ) );
+   }
+
+   @Test
+   void testValidAnnotationRules() throws IOException {
+      final ImmutableMap<String, Object> expectedFieldsForEvaluationResults = ImmutableMap.<String, Object> builder()
+            .put( "entity", "TestEntity" )
+            .put( "collectionEntity", "Collection<TestEntity>" )
+            .put( "optionalEntity", "Optional<TestEntity>" )
+            .put( "testProperty", String.class )
+            .put( "collectionTestProperty", "Collection<String>" )
+            .put( "optionalTestProperty", "Optional<String>" )
+            .build();
+
+      final TestAspect aspect = TestAspect.ASPECT_WITH_VALID_ANNOTATION_TEST;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect ) );
+
+      result.assertNumberOfFiles( 2 );
+      result.assertFields( "AspectWithValidAnnotationTest", expectedFieldsForEvaluationResults,
+            ImmutableMap.<String, String> builder()
+                  .put( "entity", "@Valid@NotNull" )
+                  .put( "collectionEntity", "@Valid@NotNull" )
+                  .put( "optionalEntity", "@Valid" )
+                  .put( "testProperty", "@NotNull" )
+                  .put( "collectionTestProperty", "@NotNull" )
+                  .put( "optionalTestProperty", "" )
+                  .build() );
    }
 }

--- a/core/esmf-test-aspect-models/src/main/java/org/eclipse/esmf/test/TestAspect.java
+++ b/core/esmf-test-aspect-models/src/main/java/org/eclipse/esmf/test/TestAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -204,7 +204,8 @@ public enum TestAspect implements TestModel {
    ENTITY_INSTANCE_TEST4,
    MODEL_WITH_BLANK_AND_ADDITIONAL_NODES,
    MODEL_WITH_BROKEN_CYCLES,
-   ASPECT_WITH_ANY_VALUE_DECLARATIONS;
+   ASPECT_WITH_ANY_VALUE_DECLARATIONS,
+   ASPECT_WITH_VALID_ANNOTATION_TEST;
 
    @Override
    public String getName() {

--- a/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithValidAnnotationTest.ttl
+++ b/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithValidAnnotationTest.ttl
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+#
+# See the AUTHORS file(s) distributed with this work for additional
+# information regarding authorship.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+
+@prefix : <urn:samm:org.eclipse.esmf.test:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+
+:AspectWithValidAnnotationTest a samm:Aspect ;
+   samm:preferredName "Aspect with Valid Annotation Test"@en ;
+   samm:description "This aspect is used to test the @Valid annotation rules."@en ;
+   samm:properties (
+         :entity
+         :collectionEntity
+       [ samm:property :optionalEntity ; samm:optional "true"^^xsd:boolean ]
+         :testProperty
+         :collectionTestProperty
+       [ samm:property :optionalTestProperty ; samm:optional "true"^^xsd:boolean ]
+   ) ;
+   samm:operations ( ) .
+
+:testProperty a samm:Property ;
+   samm:characteristic samm-c:Text .
+
+:optionalTestProperty a samm:Property ;
+   samm:characteristic samm-c:Text .
+
+:collectionTestProperty a samm:Property ;
+   samm:characteristic [
+         a samm-c:Collection ;
+         samm:preferredName "Collection Test Property"@en ;
+         samm:dataType xsd:string ;
+      ] .
+
+:entity a samm:Property ;
+   samm:characteristic :EntityCharacteristic .
+
+:optionalEntity a samm:Property ;
+   samm:characteristic :EntityCharacteristic .
+
+:collectionEntity a samm:Property ;
+   samm:characteristic :TestCollection .
+
+:EntityCharacteristic a samm-c:SingleEntity ;
+   samm:preferredName "Test Entity Characteristic"@en ;
+   samm:dataType :TestEntity .
+
+:TestCollection a samm-c:Collection ;
+   samm:preferredName "Test Collection"@en ;
+   samm:dataType :TestEntity .
+
+:TestEntity a samm:Entity ;
+   samm:preferredName "Test Entity"@en ;
+   samm:properties ( :entityProperty ) .
+
+:entityProperty a samm:Property ;
+   samm:preferredName "Entity Property"@en ;
+   samm:characteristic samm-c:Text .

--- a/esmf-intellij-codestyle.xml
+++ b/esmf-intellij-codestyle.xml
@@ -1,3 +1,16 @@
+<!--
+  ~ Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
 <code_scheme name="esmf-codestyle" version="173">
   <option name="LINE_SEPARATOR" value="&#10;" />
   <option name="RIGHT_MARGIN" value="160" />
@@ -28,7 +41,6 @@
         <package name="" withSubpackages="true" static="true" />
         <emptyLine />
         <package name="java" withSubpackages="true" static="false" />
-        <emptyLine />
         <package name="javax" withSubpackages="true" static="false" />
         <emptyLine />
         <package name="org.eclipse.esmf" withSubpackages="true" static="false" />


### PR DESCRIPTION
## Description

Added a @Valid annotation for generated POJO files. The @Valid annotation is added in the following cases:
- Collection of Entity
- Optional of Entity
- Entity
- Either with Entity

Fixes #734 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Change Codestyle config

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
