### PR TITLE
add undefined language tag validation for rdf:langString

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/AttributeValueRetriever.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/AttributeValueRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -75,17 +75,22 @@ public class AttributeValueRetriever {
     * the assertion on the current element will be on a lower list index. Duplicate attribute assertions are removed and only the assertion
     * with the highest precedence will be returned (bottom-most in the inheritance tree), this includes multiple assertions for the same
     * attribute with rdf:langString values with the same language tag. For example:
+    *
     * <p>
     * :SuperEntity a samm:AbstractEntity ;
     * samm:description "I'm abstract"@en ;
     * samm:description "Ich bin abstrakt"@de ;
     * samm:properties () .
-    * </p><p>
+    * </p>
+    *
+    * <p>
     * :MyEntity a samm:Entity ;
     * samm:extends :SuperEntity ;
     * samm:description "I'm concrete"@en ;
     * samm:properties () .
-    * </p><p>
+    * </p>
+    *
+    * <p>
     * Here, attributeValues( :MyEntity, samm:description ) will return:
     * List( Statement( :MyEntity samm:description "I'm contrete"@en ),
     * Statement( :SuperEntity samm:description "Ich bin abstrakt"@de ) )

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiator.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
  * information regarding authorship.
@@ -29,6 +29,9 @@ import org.apache.jena.vocabulary.RDF;
  * Creates new instances of {@link ScalarValue} from the value representation in RDF
  */
 public class ValueInstantiator {
+
+   public static final String UNDEFINED_LANGUAGE_TAG = "und";
+
    /**
     * Creates a new scalar value from a lexical value representation.
     *
@@ -45,7 +48,7 @@ public class ValueInstantiator {
       // .xsd.impl.RDFLangString but _not_ org.eclipse.esmf.metamodel.datatypes.LangString as we would like to.
       // 3. So we construct an instance of LangString here from the RDFLangString.
       if ( datatypeUri.equals( RDF.langString.getURI() ) ) {
-         return Optional.of( buildLanguageString( lexicalRepresentation, languageTag ) );
+         return buildLanguageString( lexicalRepresentation, languageTag );
       }
 
       return SammXsdType.ALL_TYPES.stream()
@@ -56,9 +59,13 @@ public class ValueInstantiator {
             .findAny();
    }
 
-   public ScalarValue buildLanguageString( final String lexicalRepresentation, final String languageTag ) {
-      final LangString langString = new LangString( lexicalRepresentation, Locale.forLanguageTag( languageTag ) );
+   private Optional<ScalarValue> buildLanguageString( final String lexicalRepresentation, final String languageTag ) {
+      final Locale locale = Locale.forLanguageTag( languageTag );
+      if ( UNDEFINED_LANGUAGE_TAG.equals( locale.toLanguageTag() ) ) {
+         return Optional.empty();
+      }
+      final LangString langString = new LangString( lexicalRepresentation, locale );
       final Scalar type = new DefaultScalar( RDF.langString.getURI() );
-      return new DefaultScalarValue( MetaModelBaseAttributes.builder().build(), langString, type );
+      return Optional.of( new DefaultScalarValue( MetaModelBaseAttributes.builder().build(), langString, type ) );
    }
 }

--- a/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiatorTest.java
+++ b/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiatorTest.java
@@ -22,6 +22,7 @@ import org.eclipse.esmf.metamodel.ScalarValue;
 import org.eclipse.esmf.metamodel.datatype.LangString;
 
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +38,7 @@ class ValueInstantiatorTest {
       // Arrange
       String lexicalRepresentation = "hello";
       String languageTag = "";
-      String datatypeUri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+      String datatypeUri = RDF.langString.getURI();
       ValueInstantiator valueInstantiator = new ValueInstantiator();
 
       // Act
@@ -52,7 +53,7 @@ class ValueInstantiatorTest {
       // Arrange
       String lexicalRepresentation = "hello";
       String languageTag = "en";
-      String datatypeUri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+      String datatypeUri = RDF.langString.getURI();
       ValueInstantiator valueInstantiator = new ValueInstantiator();
 
       // Act

--- a/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiatorTest.java
+++ b/core/esmf-aspect-meta-model-java/src/test/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.aspectmodel.loader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import org.eclipse.esmf.metamodel.ScalarValue;
+import org.eclipse.esmf.metamodel.datatype.LangString;
+
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ValueInstantiatorTest {
+
+   @BeforeAll
+   static void setupJena() {
+      ResourceFactory.createResource();
+   }
+
+   @Test
+   void testBuildLanguageStringEmptyLanguageTag() {
+      // Arrange
+      String lexicalRepresentation = "hello";
+      String languageTag = "";
+      String datatypeUri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+      ValueInstantiator valueInstantiator = new ValueInstantiator();
+
+      // Act
+      Optional<ScalarValue> result = valueInstantiator.buildScalarValue( lexicalRepresentation, languageTag, datatypeUri );
+
+      // Assert
+      assertThat( result ).isEmpty();
+   }
+
+   @Test
+   void testBuildLanguageStringNonEmptyLanguageTag() {
+      // Arrange
+      String lexicalRepresentation = "hello";
+      String languageTag = "en";
+      String datatypeUri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+      ValueInstantiator valueInstantiator = new ValueInstantiator();
+
+      // Act
+      Optional<ScalarValue> result = valueInstantiator.buildScalarValue( lexicalRepresentation, languageTag, datatypeUri );
+
+      // Assert
+      assertThat( result ).isPresent();
+      assertThat( result.get().getValue() ).isInstanceOf( LangString.class );
+      assertThat( result.get().getValue() )
+            .extracting( LangString.class::cast )
+            .extracting( LangString::getLanguageTag )
+            .isEqualTo( Locale.forLanguageTag( languageTag ) );
+   }
+}


### PR DESCRIPTION
## Description

This PR fixes the issue by throwing an AspectLoadingException with the message "Literal can not be parsed: " + literal when attempting to load rdf:langString literals with undefined language tags, ensuring proper validation and error handling.

Fixes #808

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
