### PR TITLE
Patch: Documentation for generated openAPI-files

### DIFF
--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -302,8 +302,8 @@ will not know where to find the corresonding file(s).
 
 Every specification is based on one Aspect, which needs a separately defined server URL where the given aspect will be.
 The URL will be defined as string with the `-b` option, i.e.: https://www.example.org. The default URL, using the above
-defined `--api-base-url`, would result in https://www.example.org/api/v1/\{tenantId}/<aspectName>. By default,
-`\{tenantId}` followed by the Aspect's name is used as path, with the aspect name converted from CamelCase to
+defined `--api-base-url`, would result in https://www.example.org/api/v1/\{tenant-id}/<aspectName>. By default,
+`\{tenant-id}` followed by the Aspect's name is used as path, with the aspect name converted from CamelCase to
 kebab-case. The default path can be changed with the `--resource-path` switch. If the path is defined further, for
 example using `--resource-path "/resources/\{resourceId}"`, the resulting URL would be:
 https://www.example.org/resources/\{resourceId}.


### PR DESCRIPTION
Corrected the formatting of tenantId to tenant-id in the documentation for the generation of openAPI-files.

## Description

I'm not sure and maybe just got the documentation wrong. The documentation uses camelCase for the attribute `tenantId` while the actual generated openAPI-specification generates `tenant-id` and seems to use kebab-case. However, as the tenant-id is only a placeholder, this patch only serves the consistency and might not be necessary.

Fixes #(number of issue in GitHub)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Not applicable.

## Additional notes:

Add any other notes or comments here.
