### PR TITLE
Fix Incorrect Namespace Reference in Properties After Increasing Major Version 

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/edit/change/RenameNamespace.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/edit/change/RenameNamespace.java
@@ -128,8 +128,10 @@ public class RenameNamespace extends EditAspectModel {
          if ( statement.getObject().isURIResource() ) {
             final String objectUri = statement.getObject().asResource().getURI();
             if ( objectUri.startsWith( from + "#" ) ) {
-               addObject = addModel.createResource( to.toString() + objectUri.substring( from.toString().length() ) );
-               removeObject = addModel.createResource( objectUri );
+               addObject = addModel.createResource(
+                     to.toString() + objectUri.substring( from.toString().length() ) );
+               removeObject = removeModel.createResource( objectUri );
+               updateTriple = true;
             } else {
                addObject = statement.getObject();
                removeObject = statement.getObject();


### PR DESCRIPTION
## Description

Ensure copied files with increased namespace versions exclude old namespace IRIs

Fixes #816 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works

## Additional notes
