### PR TITLE
Make OpenAPI default and query paths configurable

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/StreamUtil.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/StreamUtil.java
@@ -13,8 +13,16 @@
 
 package org.eclipse.esmf.aspectmodel;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -44,5 +52,48 @@ public class StreamUtil {
       return Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue, ( v1, v2 ) -> {
          throw new RuntimeException( String.format( "Duplicate key for values %s and %s", v1, v2 ) );
       }, LinkedHashMap::new );
+   }
+
+   /**
+    * Returns a collector that turns a stream of objects into a set. This collector automatically removes 'null' objects.
+    *
+    * @param <T> the type of the set
+    * @return the set of elements
+    */
+   public static <T> Collector<T, ?, Set<T>> asSet() {
+      return new CollectorImpl<>(
+            HashSet::new,
+            ( set, object ) -> {
+               if ( object != null ) {
+                  set.add( object );
+               }
+            }, ( left, right ) -> {
+         if ( left.size() < right.size() ) {
+            right.addAll( left );
+            return right;
+         } else {
+            left.addAll( right );
+            return left;
+         }
+      },
+            castingIdentity(),
+            Collections.unmodifiableSet( EnumSet.of( Collector.Characteristics.UNORDERED, Collector.Characteristics.IDENTITY_FINISH ) ) );
+   }
+
+   /**
+    * Simple implementation of a {@link Collector}
+    */
+   public record CollectorImpl<T, A, R>(
+         Supplier<A> supplier,
+         BiConsumer<A, T> accumulator,
+         BinaryOperator<A> combiner,
+         Function<A, R> finisher,
+         Set<Characteristics> characteristics
+   ) implements Collector<T, A, R> {
+   }
+
+   @SuppressWarnings( "unchecked" )
+   private static <I, R> Function<I, R> castingIdentity() {
+      return i -> (R) i;
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.esmf.aspectmodel.generator.openapi;
 
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.eclipse.esmf.aspectmodel.StreamUtil.asSet;
 import static org.eclipse.esmf.aspectmodel.generator.openapi.AspectModelOpenApiGenerator.ObjectNodeExtension.merge;
 
 import java.io.IOException;
@@ -36,6 +34,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaVisitor;
@@ -141,7 +140,9 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
                .put( "title", aspect().getPreferredName( config.locale() ) )
                .put( "version", apiVersion )
                .put( AspectModelJsonSchemaGenerator.SAMM_EXTENSION, aspect().urn().toString() );
-         setServers( rootNode, config.baseUrl(), apiVersion, READ_SERVER_PATH );
+         final String apiPath = Optional.ofNullable( config.readApiPath() )
+               .orElse( READ_SERVER_PATH.formatted( apiVersion ) );
+         setServers( rootNode, config.baseUrl(), apiVersion, apiPath );
          final boolean includePaging = includePaging( aspect(), config.pagingOption() );
          setOptionalSchemas( aspect(), config, includePaging, rootNode );
          setAspectSchemas( aspect(), config, rootNode );
@@ -160,7 +161,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       final ArrayNode arrayNode = objectNode.putArray( "servers" );
       final ObjectNode node = FACTORY.objectNode();
       final ObjectNode variables = FACTORY.objectNode();
-      node.put( "url", baseUrl + format( endPointPath, apiVersion ) );
+      node.put( "url", baseUrl + endPointPath );
       node.set( "variables", variables );
       variables.set( "api-version", FACTORY.objectNode().put( "default", apiVersion ) );
       arrayNode.add( node );
@@ -181,7 +182,8 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
          final List<String> dynamicParameters = Pattern.compile( "[{]\\S+?[}]" ).matcher( resourcePath ).results()
                .map( match -> match.group( 0 ) ).toList();
          if ( !dynamicParameters.isEmpty() && properties == null ) {
-            final String errorString = format( "Resource path contains properties %s, but has no properties map.", dynamicParameters );
+            final String errorString = String.format( "Resource path contains properties %s, but has no properties map.",
+                  dynamicParameters );
             LOG.error( errorString );
             throw new IllegalArgumentException( errorString );
          }
@@ -191,7 +193,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
                validateParameterName( nodeName );
                final JsonNode node = properties.get( nodeName );
                if ( node == null ) {
-                  final String errorString = format( "Resource path contains property %s, but can't be found in properties map.%s",
+                  final String errorString = String.format( "Resource path contains property %s, but can't be found in properties map.%s",
                         nodeName, properties );
                   LOG.error( errorString );
                   throw new IllegalArgumentException( errorString );
@@ -206,7 +208,8 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
    private void validateParameterName( final String nodeName ) {
       final Matcher a = Pattern.compile( PARAMETER_CONVENTION ).matcher( nodeName );
       if ( !a.matches() ) {
-         final String errorString = format( "The parameter name %s is not in the correct form. A valid form is described as: %s", nodeName,
+         final String errorString = String.format( "The parameter name %s is not in the correct form. A valid form is described as: %s",
+               nodeName,
                PARAMETER_CONVENTION );
          LOG.error( errorString );
          throw new IllegalArgumentException( errorString );
@@ -237,15 +240,10 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       }
    }
 
-   @SuppressWarnings( "squid:S3655" ) // An Aspect always has a URN
    private String getApiVersion( final Aspect aspect, final boolean useSemanticVersion ) {
-      final String aspectVersion = aspect.urn().getVersion();
-      if ( useSemanticVersion ) {
-         return format( "v%s", aspectVersion );
-      }
-      final int endIndexOfMajorVersion = aspectVersion.indexOf( '.' );
-      final String majorAspectVersion = aspectVersion.substring( 0, endIndexOfMajorVersion );
-      return format( "v%s", majorAspectVersion );
+      return useSemanticVersion
+            ? "v" + aspect.urn().getVersion()
+            : "v" + VersionNumber.parse( aspect.urn().getVersion() ).getMajor();
    }
 
    private void setResponseBodies( final Aspect aspect, final ObjectNode jsonNode, final boolean includePaging ) {
@@ -380,13 +378,15 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
          includeQueryPathNode.set( FIELD_POST,
                merge( getRequestEndpointFilter( aspect, propertiesNode, config.baseUrl(), apiVersion, config.resourcePath() ),
                      queriesTemplate, FIELD_POST ) );
-         endpointPathsNode.set( String.format( QUERY_SERVER_PATH, apiVersion ) + finalResourcePath,
+         final String queryApiPath = Optional.ofNullable( config.queryApiPath() )
+               .orElse( QUERY_SERVER_PATH.formatted( apiVersion ) ) + finalResourcePath;
+         endpointPathsNode.set( queryApiPath, //String.format( QUERY_SERVER_PATH, apiVersion ) + finalResourcePath,
                includeQueryPathNode );
       }
 
       final Optional<ObjectNode> operationsNode = getRequestEndpointOperations( aspect, propertiesNode, config.baseUrl(), apiVersion,
             config.resourcePath(), queriesTemplate );
-      operationsNode.ifPresent( ops -> endpointPathsNode.set( format( OPERATIONS_ENDPOINT_PATH, finalResourcePath ), ops ) );
+      operationsNode.ifPresent( ops -> endpointPathsNode.set( String.format( OPERATIONS_ENDPOINT_PATH, finalResourcePath ), ops ) );
       return endpointPathsNode;
    }
 
@@ -469,10 +469,10 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
    }
 
    private ObjectNode getRequestEndpointFilter( final Aspect aspect, final ObjectNode parameterNode, final String baseUrl,
-         final String apiVersion,
-         final String resourcePath ) {
+         final String apiVersion, final String resourcePath ) {
       final ObjectNode objectNode = FACTORY.objectNode();
-      setServers( objectNode, baseUrl, apiVersion, QUERY_SERVER_PATH );
+      final String queryServerPath = Optional.ofNullable( config.queryApiPath() ).orElse( QUERY_SERVER_PATH.formatted( apiVersion ) );
+      setServers( objectNode, baseUrl, apiVersion, queryServerPath );
       objectNode.set( "tags", FACTORY.arrayNode().add( aspect.getName() ) );
       objectNode.put( FIELD_OPERATION_ID, FIELD_POST + "Base" + aspect.getName() );
       objectNode.set( FIELD_PARAMETERS, getRequiredParameters( parameterNode, isEmpty( resourcePath ) ) );
@@ -613,7 +613,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       }
 
       public static ObjectNode merge( final ObjectNode node, final ObjectNode extension, final String field ) {
-         return ofNullable( extension ).map( getter( field ) ).map( ext -> merge( node.deepCopy(), ext ) ).orElse( node );
+         return Optional.ofNullable( extension ).map( getter( field ) ).map( ext -> merge( node.deepCopy(), ext ) ).orElse( node );
       }
 
       private static ObjectNode mergeObjectNode( final ObjectNode node, final ObjectNode extension ) {
@@ -653,7 +653,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
                || IterableUtils.matchesAny( extension, nd -> !nd.isValueNode() ) ) {
             return node;
          }
-         final Set<JsonNode> original = Streams.of( node ).collect( toSet() );
+         final Set<JsonNode> original = Streams.of( node ).collect( asSet() );
          final ArrayNode result = node.deepCopy();
          extension.forEach( nd -> {
             if ( !original.contains( nd ) ) {
@@ -670,14 +670,14 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
          }
 
          final Function<String, Function<JsonNode, String>> getText = fieldName -> objNode ->
-               ofNullable( objNode.get( fieldName ) )
+               Optional.ofNullable( objNode.get( fieldName ) )
                      .filter( Predicate.not( JsonNode::isNull ) )
                      .map( JsonNode::asText )
                      .orElse( null );
 
-         final Set<JsonNode> original = Streams.of( node ).collect( toSet() );
-         final Set<String> originalNames = original.stream().map( getText.apply( "name" ) ).filter( Objects::nonNull ).collect( toSet() );
-         final Set<String> originalUrls = original.stream().map( getText.apply( "url" ) ).filter( Objects::nonNull ).collect( toSet() );
+         final Set<JsonNode> original = Streams.of( node ).collect( asSet() );
+         final Set<String> originalNames = original.stream().map( getText.apply( "name" ) ).collect( asSet() );
+         final Set<String> originalUrls = original.stream().map( getText.apply( "url" ) ).collect( asSet() );
 
          final ArrayNode result = node.deepCopy();
          extension.forEach( nd -> {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
@@ -44,6 +44,8 @@ public record OpenApiSchemaGenerationConfig(
       boolean generateCommentForSeeAttributes,
       boolean useSemanticVersion,
       String baseUrl,
+      String readApiPath,
+      String queryApiPath,
       String resourcePath,
       ObjectNode properties,
       PagingOption pagingOption,

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -151,6 +151,21 @@ public class AspectModelOpenApiGeneratorTest {
    }
 
    @Test
+   void testSetCustomReadApiPath() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_PROPERTY ).aspect();
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .baseUrl( TEST_BASE_URL )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .readApiPath( "/custom/path" )
+            .build();
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
+      final OpenAPI openApi = result.getOpenAPI();
+
+      assertThat( openApi.getServers() ).allMatch( server -> server.getUrl().endsWith( "/custom/path" ) );
+   }
+
+   @Test
    void testIncludeQueryApiWithSemanticVersion() {
       final Aspect aspect = TestResources.load( TestAspect.ASPECT ).aspect();
       final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
@@ -165,6 +180,23 @@ public class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getPaths().get( "/query-api/v1.0.0/" + TEST_RESOURCE_PATH ).getPost().getServers()
             .get( 0 ).getUrl() )
             .isEqualTo( "https://test-aspect.example.com/query-api/v1.0.0" );
+   }
+
+   @Test
+   void testSetCustomQueryApiPath() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT ).aspect();
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .baseUrl( TEST_BASE_URL )
+            .queryApiPath( "/custom/query-path" )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .includeQueryApi( true )
+            .build();
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
+      final OpenAPI openApi = result.getOpenAPI();
+      assertThat( openApi.getPaths().get( "/custom/query-path/" + TEST_RESOURCE_PATH ).getPost().getServers()
+            .get( 0 ).getUrl() )
+            .isEqualTo( "https://test-aspect.example.com/custom/query-path" );
    }
 
    @Test

--- a/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
@@ -326,6 +326,8 @@ Configuration Properties:
 | `includes` | A list of Aspect Model URNs identifying the Aspect Models to be included in the plugin execution. | `String` | none | {ok}
 | `outputDirectory` | The path to the directory where the generated OpenAPI Specification will be written to. | `String` | none | {ok}
 | `aspectApiBaseUrl` | The base URL for the Aspect API OpenAPI specification. | `String` | none | {ok}
+| `readApiPath` | The path for the default endpoint. | `String` | `/api/vX`, where X is the Aspect major version | {nok}
+| `queryApiPath` | The path for the query endpoint. | `String` | `/query-api/vX`, where X is the Aspect major version | {nok}
 | `aspectParameterFile` | The path to a file including the schema description for the resource. For JSON the description has to be in json, for YAML it has to be in YAML. | `String` | none | {nok}
 | `useSemanticApiVersion` | Use the complete semantic version of the Aspect Model as the version of the Aspect API. | `Boolean` | `false` | {nok}
 | `aspectResourcePath` | The `resource-path` for the Aspect API endpoints. | `String` | none | {nok}

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -127,7 +127,7 @@ of model resolution] for more information.
                                    | _--name-postfix, -namePostfix_ : name postfix for generated Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java -namePostfix "Postfix"`
                                    | _--enable-setters, -enableSetters_ : whether setters should be generated for Aspect, Entity Java classes    | `samm aspect AspectModel.ttl to java --enable-setters`
                                    | _--setter-style, -setterStyle_ : the style of setters to generate for Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java --enable-setters --setter-style "FLUENT"`
-.21+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
+.23+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
                                      for an Aspect Model                                                                     | `samm aspect AspectModel.ttl to openapi -j`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--api-base-url, -b_ : the base url for the Aspect API used in the
@@ -140,6 +140,10 @@ of model resolution] for more information.
                                        API endpoints                                                                         | For detailed description, see the section below
                                    | _--semantic-version, -sv_ : use the full semantic version from the Aspect Model as the
                                        version for the Aspect API                                                            |
+                                   | _--read-api-path_, _-rap_ : Set the path for the default endpoint (default: `/api/vX`,
+                                       where X is the Aspect Model major version)                                            |
+                                   | _--query-api-path_, _-qap_ : Set the path for the query endpoint (default:
+                                     `/query-api/vX`, where X is the Aspect Model major version)                             |
                                    | _--resource-path, -r_ : the resource path for the Aspect API endpoints                  | For detailed description, see the section below
                                    | _--include-query-api, -q_ : include the path for the Query Aspect API Endpoint in the
                                        https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification                           |

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpec.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpec.java
@@ -49,6 +49,12 @@ public class GenerateOpenApiSpec extends AspectModelMojo {
    private String aspectApiBaseUrl = "";
 
    @Parameter
+   private String readApiPath;
+
+   @Parameter
+   private String queryApiPath;
+
+   @Parameter
    private String aspectParameterFile;
 
    @Parameter( defaultValue = "false" )
@@ -107,6 +113,8 @@ public class GenerateOpenApiSpec extends AspectModelMojo {
       final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
             .useSemanticVersion( useSemanticApiVersion )
             .baseUrl( aspectApiBaseUrl )
+            .readApiPath( readApiPath )
+            .queryApiPath( queryApiPath )
             .resourcePath( aspectResourcePath )
             .properties( readFile( aspectParameterFile ) )
             .template( readFile( templateFilePath ) )

--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpecTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpecTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.maven.api.plugin.testing.InjectMojo;
@@ -32,17 +31,14 @@ public class GenerateOpenApiSpecTest extends AspectModelMojoTest {
          goal = GenerateOpenApiSpec.MAVEN_GOAL,
          pom = "src/test/resources/generate-openapi-spec-json-pom-valid-aspect-model/pom.xml"
    )
-   public void testGenerateOpenApiSpecJsonValidAspectModel( final GenerateOpenApiSpec generateOpenApiSpec ) throws IOException {
+   public void testGenerateOpenApiSpecJsonValidAspectModel( final GenerateOpenApiSpec generateOpenApiSpec ) {
       assertThatCode( generateOpenApiSpec::execute ).doesNotThrowAnyException();
-
       final Path generatedFile = generatedFilePath( "Aspect.oai.json" );
-      assertThat( generatedFile ).exists();
-
-      final String yamlContent = new String( Files.readAllBytes( generatedFile ) );
-
-      assertThat( yamlContent ).contains( "postAspect" );
-      assertThat( yamlContent ).contains( "putAspect" );
-      assertThat( yamlContent ).contains( "patchAspect" );
+      assertThat( generatedFile ).exists()
+            .content()
+            .contains( "postAspect" )
+            .contains( "putAspect" )
+            .contains( "patchAspect" );
    }
 
    @Test
@@ -50,18 +46,14 @@ public class GenerateOpenApiSpecTest extends AspectModelMojoTest {
          goal = GenerateOpenApiSpec.MAVEN_GOAL,
          pom = "src/test/resources/generate-openapi-spec-json-pom-valid-aspect-model-with-crud-parameters/pom.xml"
    )
-   public void testGenerateOpenApiSpecJsonValidAspectModelWithCrudParameters( final GenerateOpenApiSpec generateOpenApiSpec )
-         throws IOException {
+   public void testGenerateOpenApiSpecJsonValidAspectModelWithCrudParameters( final GenerateOpenApiSpec generateOpenApiSpec ) {
       assertThatCode( generateOpenApiSpec::execute ).doesNotThrowAnyException();
-
       final Path generatedFile = generatedFilePath( "Aspect.oai.json" );
-      assertThat( generatedFile ).exists();
-
-      final String yamlContent = new String( Files.readAllBytes( generatedFile ) );
-
-      assertThat( yamlContent ).contains( "postAspect" );
-      assertThat( yamlContent ).contains( "putAspect" );
-      assertThat( yamlContent ).contains( "patchAspect" );
+      assertThat( generatedFile ).exists()
+            .content()
+            .contains( "postAspect" )
+            .contains( "putAspect" )
+            .contains( "patchAspect" );
    }
 
    /**
@@ -121,5 +113,18 @@ public class GenerateOpenApiSpecTest extends AspectModelMojoTest {
             .isInstanceOf( MojoExecutionException.class )
             .hasMessage( "Invalid output format." );
       assertThat( generatedFilePath( "Aspect.oai.json" ) ).doesNotExist();
+   }
+
+   @Test
+   @InjectMojo(
+         goal = GenerateOpenApiSpec.MAVEN_GOAL,
+         pom = "src/test/resources/generate-openapi-spec-json-pom-custom-api-path/pom.xml"
+   )
+   public void testGenerateOpenApiSpecCustomApiPath( final GenerateOpenApiSpec generateOpenApiSpec ) throws IOException {
+      assertThatCode( generateOpenApiSpec::execute ).doesNotThrowAnyException();
+
+      final Path generatedFile = generatedFilePath( "Aspect.oai.json" );
+      assertThat( generatedFile ).exists()
+            .content().contains( "http://example.com/custom/path" );
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-openapi-spec-json-pom-custom-api-path/pom.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-openapi-spec-json-pom-custom-api-path/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <groupId>org.eclipse.esmf</groupId>
+   <artifactId>test-generate-openapi-spec-mojo</artifactId>
+   <version>1.0</version>
+   <packaging>jar</packaging>
+   <name>Test Generate OpenApi Spec Mojo</name>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>esmf-aspect-model-maven-plugin</artifactId>
+            <configuration>
+               <modelsRootDirectory>${basedir}/../../core/esmf-test-aspect-models/src/main/resources/valid</modelsRootDirectory>
+               <includes>
+                  <include>urn:samm:org.eclipse.esmf.test:1.0.0#Aspect</include>
+               </includes>
+               <aspectApiBaseUrl>http://example.com</aspectApiBaseUrl>
+               <outputDirectory>${basedir}/target/test-artifacts</outputDirectory>
+               <includeFullCrud>true</includeFullCrud>
+               <outputFormat>json</outputFormat>
+               <readApiPath>/custom/path</readApiPath>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToOpenapiCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToOpenapiCommand.java
@@ -69,7 +69,17 @@ public class AspectToOpenapiCommand extends AbstractCommand {
          names = { "--api-base-url", "-b" },
          description = "The base url for the Aspect API used in the OpenAPI specification.",
          required = true )
-   private String aspectApiBaseUrl = "";
+   private String aspectApiBaseUrl = null;
+
+   @CommandLine.Option(
+         names = { "--read-api-path", "-rap" },
+         description = "The path for the default endpoint, default '/api/vX', where X is the Aspect Model major version." )
+   private String readApiPath = null;
+
+   @CommandLine.Option(
+         names = { "--query-api-path", "-qap" },
+         description = "The path for the query endpoint, default '/query-api/vX', where X is the Aspect Model major version." )
+   private String queryApiPath = "";
 
    @CommandLine.Option(
          names = { "--json", "-j" },
@@ -201,6 +211,8 @@ public class AspectToOpenapiCommand extends AbstractCommand {
       final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
             .useSemanticVersion( useSemanticApiVersion )
             .baseUrl( aspectApiBaseUrl )
+            .readApiPath( readApiPath )
+            .queryApiPath( queryApiPath )
             .resourcePath( aspectResourcePath )
             .properties( readFile( aspectParameterFile ) )
             .template( readFile( templateFilePath ) )


### PR DESCRIPTION
## Description

Make default API path and query path configurable in generated OpenAPI specs.

Fixes #851.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

