### PR TITLE
Fix - JRE path in macOS bundle scripts

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -90,7 +90,7 @@ jobs:
           mkdir ${bundle}
           curl -Lo jre.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jre_x64_mac_hotspot_21.0.7_6.tar.gz
           tar -xvf jre.tar.gz
-          cp -r ./jdk-21.0.7+6-jre/Contents/Home ./${bundle}/jre
+          cp -r ./jdk-21.0.7+6-jre ./${bundle}/jre
           cp tools/samm-cli/target/samm-cli-DEV-SNAPSHOT.jar ./${bundle}/
 
           cat <<EOF > ./${bundle}/run.sh
@@ -98,7 +98,7 @@ jobs:
 
           HERE=\${BASH_SOURCE%/*}
 
-          "\$HERE/jre/bin/java" -jar "\$HERE/samm-cli-DEV-SNAPSHOT.jar" "\$@"
+          "\$HERE/jre/Contents/Home/bin/java" -jar "\$HERE/samm-cli-DEV-SNAPSHOT.jar" "\$@"
           EOF
           chmod +x ./${bundle}/run.sh
 

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -202,7 +202,7 @@ jobs:
           mkdir ${bundle}
           curl -Lo jre.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jre_x64_mac_hotspot_21.0.7_6.tar.gz
           tar -xvf jre.tar.gz
-          cp -r ./jdk-21.0.7+6-jre/Contents/Home ./${bundle}/jre
+          cp -r ./jdk-21.0.7+6-jre ./${bundle}/jre
           cp tools/samm-cli/target/samm-cli-${{ github.event.inputs.release_version }}.jar ./${bundle}/
 
           cat <<EOF > ./${bundle}/run.sh
@@ -210,7 +210,7 @@ jobs:
 
           HERE=\${BASH_SOURCE%/*}
 
-          "\$HERE/jre/bin/java" -jar "\$HERE/samm-cli-${{ github.event.inputs.release_version }}.jar" "\$@"
+          "\$HERE/jre/Contents/Home/bin/java" -jar "\$HERE/samm-cli-${{ github.event.inputs.release_version }}.jar" "\$@"
           EOF
           chmod +x ./${bundle}/run.sh
 


### PR DESCRIPTION
## Description

Update the workflow scripts to copy the full JRE directory and adjust the run script to use the correct Java binary path for macOS. This ensures the bundled CLI uses the intended JRE location.

Fixes #802 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Add any other notes or comments here.
