### PR TITLE
Persist credentials in release build

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6.0.1
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       # Required to have Maven settings.xml set up correctly
       - name: Set up JDK 21


### PR DESCRIPTION
## Description

Fix release build pipeline: Revert the change that does not persist credentials on checkout (this is required for the release build action)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
