### PR TITLE
CLI AsyncAPI: Ensure application id is an absolute URI

### DIFF
--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -76,7 +77,7 @@ public class AspectToAsyncapiCommand extends AbstractCommand {
    @CommandLine.Option(
          names = { "--application-id", "-ai" },
          description = "Use this param for provide application id." )
-   private String applicationId;
+   private URI applicationId;
 
    @CommandLine.Option(
          names = { "--channel-address", "-ca" },
@@ -112,6 +113,10 @@ public class AspectToAsyncapiCommand extends AbstractCommand {
 
    @Override
    public void run() {
+      if ( applicationId != null && !applicationId.isAbsolute() ) {
+         throw new CommandException( "Application id must be an absolute URI." );
+      }
+
       setDetails( details );
       setResolverConfig( resolverConfiguration );
 
@@ -119,7 +124,7 @@ public class AspectToAsyncapiCommand extends AbstractCommand {
       final Aspect aspect = getInputHandler( parentCommand.parentCommand.getInput() ).loadAspect();
       final AsyncApiSchemaGenerationConfig config = AsyncApiSchemaGenerationConfigBuilder.builder()
             .useSemanticVersion( useSemanticApiVersion )
-            .applicationId( applicationId )
+            .applicationId( applicationId == null ? null : applicationId.toString() )
             .channelAddress( channelAddress )
             .locale( locale )
             .build();

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -1022,6 +1022,14 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
+   void testAspectToAsyncapiWithInvalidApplicationId() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile, "to", "asyncapi", "-ai", "test" );
+      assertThat( result.exitStatus() ).isOne();
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).contains( "Application id must be an absolute URI." );
+   }
+
+   @Test
    void testAspectToAsyncapiWithoutChannelAddress() {
       final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile, "to", "asyncapi" );
       assertThat( result.exitStatus() ).isZero();


### PR DESCRIPTION
## Description

This PR adds a validation to the AsyncAPI converter so that it can reject a relative URI for the `--application-id` option, which are rejected by the official AsyncAPI tools.

Fixes #890

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  No complicated logic newly introduced

- [ ] I have made corresponding changes to the documentation

  No corresponding documentation

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

No additional notes