### PR TITLE
Fixes broken aspect validate command

### DIFF
--- a/tools/samm-cli/pom.xml
+++ b/tools/samm-cli/pom.xml
@@ -192,6 +192,7 @@
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                            <manifestEntries>
                               <Main-Class>${main-class}</Main-Class>
+                              <Multi-Release>true</Multi-Release>
                            </manifestEntries>
                         </transformer>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/tools/samm-cli/scripts/linux/run.sh
+++ b/tools/samm-cli/scripts/linux/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 HERE="\${BASH_SOURCE%/*}"
-"\$HERE/jre/bin/java" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar "\$HERE/samm-cli-*.jar" "\$@"
+"\$HERE/jre/bin/java" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar -Dpolyglotimpl.DisableMultiReleaseCheck=true "\$HERE/samm-cli-*.jar" "\$@"

--- a/tools/samm-cli/scripts/macos/run.sh
+++ b/tools/samm-cli/scripts/macos/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 HERE="\${BASH_SOURCE%/*}"
-"\$HERE/jre/Contents/Home/bin/java" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar "\$HERE/samm-cli-*.jar" "\$@"
+"\$HERE/jre/Contents/Home/bin/java" --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dpolyglotimpl.DisableMultiReleaseCheck=true -jar "\$HERE/samm-cli-*.jar" "\$@"

--- a/tools/samm-cli/scripts/windows/run.bat
+++ b/tools/samm-cli/scripts/windows/run.bat
@@ -11,8 +11,8 @@ for /f "usebackq tokens=*" %%a in (`powershell -NoProfile -Command "(Get-CimInst
 
 if /i "%HostProcessName%"=="explorer.exe" (
   cd /d "%ExeWorkingDir%"
-  for %%i in (%~dp0samm-cli-*.jar) do %~dp0jre\bin\java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar "%%i"
+  for %%i in (%~dp0samm-cli-*.jar) do %~dp0jre\bin\java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dpolyglotimpl.DisableMultiReleaseCheck=true -jar "%%i"
   cmd /k
 ) else (
-  for %%i in (%~dp0samm-cli-*.jar) do %~dp0jre\bin\java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar "%%i" %*
+  for %%i in (%~dp0samm-cli-*.jar) do %~dp0jre\bin\java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dpolyglotimpl.DisableMultiReleaseCheck=true -jar "%%i" %*
 )


### PR DESCRIPTION
## Description

Fixes broken functionality for `samm aspect validate` that is due to GraalVM/truffle uber-jar configuration.

Fixes #906 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

This PR fixes the problem for samm-cli binaries. However, the problem still exists when executing the samm-cli executable jar; it can be fixed by providing the `-Dpolyglotimpl.DisableMultiReleaseCheck=true` flag. We need to investigate why the [documented](https://www.graalvm.org/latest/reference-manual/embed-languages/#uber-jar-file-creation) suggested `<Multi-Release>true</Multi-Release>` in maven-shade-plugin configuration is not sufficient.
