### PR TITLE
SVG generator: fix the `--details` option to show detailed error messages

### DIFF
--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToSvgCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToSvgCommand.java
@@ -62,7 +62,7 @@ public class AspectToSvgCommand extends AbstractCommand {
 
    @Override
    public void run() {
-      setResolverConfig( resolverConfiguration );
+      setDetails( details );
       setResolverConfig( resolverConfiguration );
 
       try {

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -33,6 +33,7 @@ import org.eclipse.esmf.aspectmodel.resolver.process.ProcessLauncher;
 import org.eclipse.esmf.aspectmodel.resolver.process.ProcessLauncher.ExecutionResult;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.aspectmodel.validation.InvalidSyntaxViolation;
+import org.eclipse.esmf.aspectmodel.validation.ProcessingViolation;
 import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.test.InvalidTestAspect;
 import org.eclipse.esmf.test.OrderingTestAspect;
@@ -1189,6 +1190,15 @@ class SammCliTest extends SammCliAbstractTest {
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "svg",
             "--custom-resolver", resolverCommand() );
       assertThat( result.stdout() ).contains( "<svg" );
+      assertThat( result.stderr() ).isEmpty();
+   }
+
+   @Test
+   void testAspectToSvgWithDetails() {
+      final File invalidModel = inputFile( InvalidTestAspect.INVALID_ENCODING );
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", invalidModel.getAbsolutePath(), "to", "svg", "--details" );
+      assertThat( result.exitStatus() ).isEqualTo( 1 );
+      assertThat( result.stdout() ).contains( ProcessingViolation.ERROR_CODE );
       assertThat( result.stderr() ).isEmpty();
    }
 


### PR DESCRIPTION
## Description

This PR fixes the `aspect to svg` command to show the detailed error messages when the `--details` option is specified.

Fixes #916 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  - No comment needed since it's just a single line fix

- [ ] I have made corresponding changes to the documentation

  - No corresponding documentation

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:


