### PR TITLE
OAS generator: fix the cursor-based paging to generate a valid specification

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/resources/openapi/CursorBasedPaging.json
+++ b/core/esmf-aspect-model-document-generators/src/main/resources/openapi/CursorBasedPaging.json
@@ -24,9 +24,6 @@
   "response": {
     "type": "object",
     "properties": {
-      "items": {
-        "type": "array"
-      },
       "cursor": {
         "type": "object",
         "properties": {

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -467,7 +467,7 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( pagingSchema ).isNotNull();
 
       final Map<String, ?> props = pagingSchema.getProperties();
-      assertThat( props ).containsKeys( "items", "cursor", "_links" );
+      assertThat( props ).containsKeys( "testProperty", "cursor", "_links" );
    }
 
    @Test


### PR DESCRIPTION
## Description

Fixes #918 

This PR removes an unnecessary element from the OpenAPI specification generated by the OAS generator with the `--paging-cursor-based` option so that validation passes.
In the following example, `components.schemas.PagingSchema.items` is incomplete, because it's an array but doesn't have the "items" property specifying its elements' schema.
That node seems unnecessary, because the generated OAS already has an array to contain the results. In the example below, `components.schemas.PagingSchema.testProperty` is that.

```
$ java -jar samm-cli-2.14.2.jar aspect https://github.com/eclipse-esmf/esmf-sdk/blob/v2.14.2/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithCollection.ttl to openapi -b http://example.com -pc

(snip)

components:
  schemas:

    (snip)

    PagingSchema:
      type: object
      properties:
        items:
          type: array
        cursor:
          type: object
          properties:
            before:
              type: string
              format: uuid
              description: The cursor that points to the start of the page of items
                that has been returned. An empty value indicates there are no previous
                items.
            after:
              type: string
              format: uuid
              description: The cursor that points to the end of items that has been
                returned. An empty value indicates there are no other items.
        _links:
          type: object
          properties:
            previous:
              type: string
              format: uri
              description: URL to request the previous items. An empty value indicates
                there are no previous items.
            next:
              type: string
              format: uri
              description: URL to request the the next items. An empty value indicates
                there are no other items.
        testProperty:
          type: array
          items:
            $ref: "#/components/schemas/AspectWithCollection"

(snip)
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  - No comment needed since it's just a small modification.

- [ ] I have made corresponding changes to the documentation

  - No corresponding documentation

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:
