### PR TITLE
Fix the Put and Patch methods for the OpenAPI generator

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -535,10 +535,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       objectNode.put( FIELD_OPERATION_ID, ( isPut ? FIELD_PUT : FIELD_PATCH ) + aspect.getName() );
       objectNode.set( FIELD_PARAMETERS, getRequiredParameters( parameterNode, isEmpty( resourcePath ) ) );
       final ObjectNode requestBody = FACTORY.objectNode();
-      requestBody.put( FIELD_REQUIRED, true );
-
-      generateAllOfObjectForRef( requestBody, aspect.getName() );
-
+      requestBody.put( REF, COMPONENTS_REQUESTS + aspect.getName() );
       objectNode.set( FIELD_REQUEST_BODY, requestBody );
       objectNode.set( FIELD_RESPONSES, getResponsesForGet( aspect ) );
       return objectNode;
@@ -621,20 +618,6 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
             rootSchemaNode.set( nodeName, node );
          }
       }
-   }
-
-   private void generateAllOfObjectForRef( final ObjectNode requestBody, final String ref ) {
-      final ObjectNode contentNode = FACTORY.objectNode();
-      final ObjectNode appJsonNode = FACTORY.objectNode();
-      final ObjectNode schemaNode = FACTORY.objectNode();
-      final ArrayNode allOfArray = FACTORY.arrayNode();
-      final ObjectNode refNode = FACTORY.objectNode();
-      refNode.put( REF, COMPONENTS_REQUESTS + ref );
-      allOfArray.add( refNode );
-      schemaNode.set( FIELD_ALL_OF, allOfArray );
-      appJsonNode.set( FIELD_SCHEMA, schemaNode );
-      contentNode.set( APPLICATION_JSON, appJsonNode );
-      requestBody.set( FIELD_CONTENT, contentNode );
    }
 
    static final class ObjectNodeExtension {

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -571,11 +571,14 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }
@@ -597,7 +600,8 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNull();
       assertThat( openApi.getPaths().keySet() ).anyMatch(
@@ -624,7 +628,8 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNull();
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
@@ -649,7 +654,8 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }
@@ -672,10 +678,12 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
-      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() )
+            .isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -571,8 +571,11 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }
@@ -594,6 +597,7 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNull();
       assertThat( openApi.getPaths().keySet() ).anyMatch(
@@ -620,6 +624,7 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPut().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNull();
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
@@ -644,6 +649,7 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }
@@ -666,8 +672,10 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getPaths().get( apiEndpoint ).getGet() ).isNotNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPost() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPost().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().get( apiEndpoint ).getPut() ).isNull();
       assertThat( openApi.getPaths().get( apiEndpoint ).getPatch() ).isNotNull();
+      assertThat( openApi.getPaths().get( apiEndpoint ).getPatch().getRequestBody().get$ref() ).isEqualTo( "#/components/requestBodies/" + aspect.getName() );
       assertThat( openApi.getPaths().keySet() ).anyMatch(
             path -> path.equals( "/query-api/v1.0.0" + apiEndpoint ) );
    }


### PR DESCRIPTION
## Description

This PR fixes the structure of the OpenAPI document generated with the put and/or patch method.
Currently, the OpenAPI generator outputs the following document. Each method has a requestBody node, and its direct child should be a reference to a RequestBody object (or to a Reference object, [according to the specification](https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/schemas/v3.0/schema.yaml#L553-L556)), as the post method does so. The put and patch methods have wrong child nodes here.

```
$ java -jar samm-cli-2.14.2.jar aspect https://github.com/eclipse-tractusx/sldt-semantic-models/blob/main/io.catenax.shared.business_partner_number/2.0.0/BusinessPartnerNumber.ttl to openapi -b http://example.com -cr

---
openapi: 3.0.3                                                                                 

...

paths:                                                                                         

  ...

    post:

      ...

      requestBody:
        $ref: "#/components/requestBodies/BusinessPartnerNumber"

      ...

    put:

      ...

      requestBody:
        required: true
        content:
          application/json:
            schema:
              allOf:
              - $ref: "#/components/requestBodies/BusinessPartnerNumber"

      ...

    patch:

      ...

      requestBody:
        required: true
        content:
          application/json:
            schema:
              allOf:
              - $ref: "#/components/requestBodies/BusinessPartnerNumber"

      ...
```

Fixes #921

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  - No comment required, since it's a very straightforward fix

- [ ] I have made corresponding changes to the documentation

  - No corresponding documentation

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
