### PR TITLE
Fix broken table layout in the SAMM-CLI documentation

### DIFF
--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -127,7 +127,7 @@ of model resolution] for more information.
                                    | _--name-postfix, -namePostfix_ : name postfix for generated Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java -namePostfix "Postfix"`
                                    | _--enable-setters, -enableSetters_ : whether setters should be generated for Aspect, Entity Java classes    | `samm aspect AspectModel.ttl to java --enable-setters`
                                    | _--setter-style, -setterStyle_ : the style of setters to generate for Aspect, Entity Java classes | `samm aspect AspectModel.ttl to java --enable-setters --setter-style "FLUENT"`
-.25+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
+.23+| [[aspect-to-openapi]] aspect <model> to openapi | Generate https://spec.openapis.org/oas/v3.0.3[OpenAPI] specification
                                      for an Aspect Model                                                                     | `samm aspect AspectModel.ttl to openapi -j`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--api-base-url, -b_ : the base url for the Aspect API used in the


### PR DESCRIPTION
## Description

Currently, the samm-cli's command list table is broken as follows. This PR fixes its layout.

<img width="2000" height="1616" alt="image" src="https://github.com/user-attachments/assets/7627de72-78a2-4d04-b9c4-bebbf480b35f" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
