### PR TITLE
Add the "decimalScale" configuration support to the Maven plugin

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/DatabricksSqlGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/DatabricksSqlGenerationConfig.java
@@ -31,6 +31,9 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  * @param decimalPrecision the precision to use for decimal columns, see <a href=
  *        "https://docs.databricks.com/en/sql/language-manual/data-types/decimal-type.html">DECIMAL
  *        type</a> for more info.
+ * @param decimalScale the scale to use for decimal columns, see <a href=
+ *        "https://docs.databricks.com/en/sql/language-manual/data-types/decimal-type.html">DECIMAL
+ *        type</a> for more info.
  * @param customColumns custom columns to add to the table
  */
 @RecordBuilder

--- a/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/maven-plugin.adoc
@@ -563,7 +563,9 @@ Configuration Properties:
 | `includeColumnComments` | Include column comments in the generated SQL script. | `Boolean` | `true` | {nok}
 | `tableCommandPrefix` | The prefix to use for Databricks table creation commands. | `String` | `CREATE TABLE IF NOT EXISTS` | {nok}
 | `decimalPrecision` | The precision to use for Databricks decimal columns, between 1 and 38. See also notes in
-  the xref:java-aspect-tooling.adoc#databricks-type-mapping[Databricks type mapping]. | `Integer` | 10 | {nok}
+  the xref:java-code-generation.adoc#databricks-type-mapping[Databricks type mapping]. | `Integer` | 10 | {nok}
+| `decimalScale` | The scale to use for Databricks decimal columns, between 0 and the precision. See also notes in
+the xref:java-code-generation.adoc#databricks-type-mapping[Databricks type mapping]. | `Integer` | 0 | {nok}
 | `customColumns` | Contains `<column>` elements, each of which defines a custom column to add. Column defintions follow the pattern `column_name DATATYPE [NOT NULL] [COMMENT 'custom']`. | `<column>`... | | {nok}
 |===
 

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateSql.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateSql.java
@@ -53,6 +53,9 @@ public class GenerateSql extends AspectModelMojo {
    @Parameter( defaultValue = "" + DatabricksSqlGenerationConfig.DECIMAL_DEFAULT_PRECISION )
    private int decimalPrecision = DatabricksSqlGenerationConfig.DECIMAL_DEFAULT_PRECISION;
 
+   @Parameter( defaultValue = "" + DatabricksSqlGenerationConfig.DECIMAL_DEFAULT_SCALE )
+   private int decimalScale = DatabricksSqlGenerationConfig.DECIMAL_DEFAULT_SCALE;
+
    @Parameter( defaultValue = "en" )
    private String language = DatabricksSqlGenerationConfig.DEFAULT_COMMENT_LANGUAGE.getLanguage();
 
@@ -82,6 +85,7 @@ public class GenerateSql extends AspectModelMojo {
                      .includeColumnComments( includeColumnComments )
                      .createTableCommandPrefix( tableCommandPrefix )
                      .decimalPrecision( decimalPrecision )
+                     .decimalScale( decimalScale )
                      .customColumns( customColumnDefinitions )
                      .build();
          final SqlGenerationConfig sqlConfig = new SqlGenerationConfig( SqlGenerationConfig.Dialect.valueOf( dialect.toUpperCase() ),

--- a/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateSqlTest.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/java/org/eclipse/esmf/aspectmodel/GenerateSqlTest.java
@@ -51,6 +51,6 @@ public class GenerateSqlTest extends AspectModelMojoTest {
 
       assertThat( sqlContent ).contains( "CREATE TABLE aspect_with_simple_types" );
       assertThat( sqlContent ).contains( "custom_column ARRAY<STRING> NOT NULL COMMENT 'Custom column'" );
-      assertThat( sqlContent ).contains( "DECIMAL(23)" );
+      assertThat( sqlContent ).contains( "DECIMAL(23,14)" );
    }
 }

--- a/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-sql-pom-valid-aspect-model-adjusted-settings/pom.xml
+++ b/tools/esmf-aspect-model-maven-plugin/src/test/resources/generate-sql-pom-valid-aspect-model-adjusted-settings/pom.xml
@@ -33,6 +33,7 @@
                </includes>
                <tableCommandPrefix>CREATE TABLE</tableCommandPrefix>
                <decimalPrecision>23</decimalPrecision>
+               <decimalScale>14</decimalScale>
                <customColumns>
                   <column>custom_column ARRAY&lt;STRING&gt; NOT NULL COMMENT 'Custom column'</column>
                </customColumns>


### PR DESCRIPTION
## Description

This PR makes the "decimalScale" functionality available through the Maven plugin.

Fixes #924 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
