### PR TITLE
Fix unformatted server URL for Aspect's operations

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -423,7 +423,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       if ( !aspect.getOperations().isEmpty() ) {
 
          final ObjectNode objectNode = FACTORY.objectNode();
-         setServers( objectNode, baseUrl, apiVersion, OPERATIONS_SERVER_PATH );
+         setServers( objectNode, baseUrl, apiVersion, OPERATIONS_SERVER_PATH.formatted( apiVersion ) );
          objectNode.set( "tags", FACTORY.arrayNode().add( aspect.getName() ) );
          objectNode.put( FIELD_OPERATION_ID, FIELD_POST + FIELD_OPERATION + aspect.getName() );
          objectNode.set( FIELD_PARAMETERS, getRequiredParameters( parameterNode, isEmpty( resourcePath ) ) );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -524,6 +524,8 @@ class AspectModelOpenApiGeneratorTest {
       final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
       final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
       final OpenAPI openApi = result.getOpenAPI();
+      assertThat( openApi.getPaths().get( "/" + TEST_RESOURCE_PATH + "/operations" ).getPost().getServers().getFirst()
+              .getUrl() ).isEqualTo( TEST_BASE_URL + "/rpc-api/v1.0.0" );
       assertThat( openApi.getComponents().getSchemas() ).containsKey( "AspectWithOperation" );
       assertThat( openApi.getComponents().getSchemas() ).containsKey( "Operation" );
       assertThat( openApi.getComponents().getSchemas() ).containsKey( "OperationResponse" );


### PR DESCRIPTION
## Description

Currently, running `aspect to openapi` against an Aspect with operations generates a OAS document with an unformatted server URL like `.../rpc-api/%s`. This PR fixes such a problem.

Fixes #951

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  No comment needed, since it's a simple and straightforward fix

- [ ] I have made corresponding changes to the documentation

  No documentation is affected by this fix

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
