### PR TITLE
Fix warp setup in build workflow

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -150,6 +150,7 @@ jobs:
             exit 1
           fi
           chmod +x warp-packer
+          xattr -d com.apple.quarantine warp-packer || true
 
           ./warp-packer pack --arch macos-x64 --input-dir ${bundle} --exec run.sh --output samm --prefix samm-cli-${RELEASE_VERSION}
           chmod a+x samm

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -198,11 +198,12 @@ jobs:
           chmod +x ./${bundle}/run.sh
 
           curl -Lo warp-packer https://github.com/kirbylink/warp/releases/download/v1.3.0/macos-x64.warp-packer
-          if [ "$(sha256sum warp-packer | cut -d' ' -f1)" != "311bd238d087ea92f486d3d754a0f11826d9bd49d6f8ae849e5d6f6089a2e9c9" ]; then
+          if [ "$(shasum -a 256 warp-packer | cut -d' ' -f1)" != "311bd238d087ea92f486d3d754a0f11826d9bd49d6f8ae849e5d6f6089a2e9c9" ]; then
             echo "Warp packer checksum does not match"
             exit 1
           fi
           chmod +x warp-packer
+          xattr -d com.apple.quarantine warp-packer || true
 
           ./warp-packer pack --arch macos-x64 --input-dir ${bundle} --exec run.sh --output samm --prefix samm-cli-${RELEASE_VERSION}
           chmod a+x samm
@@ -278,7 +279,7 @@ jobs:
           cp tools/samm-cli/scripts/windows/run.bat ./${bundle}/
 
           curl -Lo warp-packer.exe https://github.com/kirbylink/warp/releases/download/v1.3.0/windows-x64.warp-packer.exe
-          if [ "$(sha256sum warp-packer | cut -d' ' -f1)" != "483726e0eb10a43167c03c8e4f27a2901741affd245e5ec8ed45509f9dcd7a8a" ]; then
+          if [ "$(sha256sum warp-packer.exe | cut -d' ' -f1)" != "483726e0eb10a43167c03c8e4f27a2901741affd245e5ec8ed45509f9dcd7a8a" ]; then
             echo "Warp packer checksum does not match"
             exit 1
           fi


### PR DESCRIPTION
## Description

Fixes the setup of warp-packer in the build workflow for MacOS by clearing the quarantine attribute

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

