### PR TITLE
Fix Parquet generator to output a single payload

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetFileWriter.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetFileWriter.java
@@ -114,13 +114,6 @@ class ParquetFileWriter {
 
       // Generate denormalized rows based on collections
       final List<Map<String, Object>> denormalizedRows = createDenormalizedRows( aspect, flattenedExampleData );
-      final Map<String, List<Map.Entry<String, Object>>> propertyNameKeyValueMap = new HashMap<>();
-
-      denormalizedRows.stream().flatMap( map -> map.entrySet().stream() )
-            .forEach( entrySet -> {
-               final String mapKey = getFirstPartBeforeDoubleUnderscore( entrySet.getKey() );
-               propertyNameKeyValueMap.computeIfAbsent( mapKey, k -> new ArrayList<>() ).add( entrySet );
-            } );
 
       try ( final ParquetWriter<Group> writer = ExampleParquetWriter.builder( outputFile )
             .withType( messageTypeSchema )
@@ -128,12 +121,10 @@ class ParquetFileWriter {
 
          final SimpleGroupFactory simpleGroupFactory = new SimpleGroupFactory( messageTypeSchema );
 
-         propertyNameKeyValueMap.forEach( ( key, entryList ) -> {
+         denormalizedRows.forEach( denormalizedRow -> {
             final Group groupNew = simpleGroupFactory.newGroup();
 
-            entryList.forEach( entry -> {
-               final String fieldName = entry.getKey();
-               final Object value = entry.getValue();
+            denormalizedRow.forEach( ( fieldName, value ) -> {
                if ( value != null && flattenedExampleData.containsKey( fieldName ) ) {
                   final PrimitiveType parquetType = flattenedExampleData.get( fieldName )._2;
                   addGroup( value, parquetType, fieldName, groupNew );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/parquet/AspectModelParquetPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/parquet/AspectModelParquetPayloadGeneratorTest.java
@@ -100,6 +100,7 @@ class AspectModelParquetPayloadGeneratorTest {
             final MessageType schema = reader.getFooter().getFileMetaData().getSchema();
             assertThat( schema ).isNotNull();
             assertThat( schema.getFields() ).isNotEmpty();
+            assertThat( reader.getRecordCount() ).isEqualTo( 1 );
          }
       } ).doesNotThrowAnyException();
    }


### PR DESCRIPTION
## Description

Currently, the Parquet generator outputs a lot of sparse records against an Aspect. This PR fixes that behavior.

Fixes #961

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  - No additional comments, because this fix only removes unnecessary logic.

- [ ] I have made corresponding changes to the documentation

  - No documentation fix. I've read the following documents, but I couldn't find anything to be fixed.

    - https://eclipse-esmf.github.io/samm-specification/snapshot/payloads-parquet.html
    - https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/java-documentation-generation.html#generating-sample-apache-parquet-payload

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works