### PR TITLE
Update to Jackson 3

### DIFF
--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/edit/AspectChangeManager.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/edit/AspectChangeManager.java
@@ -152,7 +152,7 @@ public class AspectChangeManager implements ChangeContext {
          final AspectModelFile file = stateEntry.getKey();
          final FileState state = stateEntry.getValue();
 
-         if ( file instanceof final RawAspectModelFile rawFile ) {
+         if ( file instanceof RawAspectModelFile ) {
             final Optional<AspectModelFile> updatedAspectModelFile = aspectModel.files().stream()
                   .filter( f -> f.sourceLocation().isPresent() )
                   .filter( f -> f.sourceLocation().equals( file.sourceLocation() ) )

--- a/core/esmf-aspect-model-aas-generator/pom.xml
+++ b/core/esmf-aspect-model-aas-generator/pom.xml
@@ -43,6 +43,10 @@
          <artifactId>poi</artifactId>
       </dependency>
       <dependency>
+         <groupId>tools.jackson.core</groupId>
+         <artifactId>jackson-core</artifactId>
+      </dependency>
+      <dependency>
          <groupId>io.soabase.record-builder</groupId>
          <artifactId>record-builder-processor</artifactId>
          <scope>provided</scope>

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AasGenerationConfig.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AasGenerationConfig.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import io.soabase.recordbuilder.core.RecordBuilder;
 
 @RecordBuilder

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
@@ -26,34 +26,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
-import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
-import org.eclipse.esmf.metamodel.Aspect;
-import org.eclipse.esmf.metamodel.Characteristic;
-import org.eclipse.esmf.metamodel.CollectionValue;
-import org.eclipse.esmf.metamodel.Entity;
-import org.eclipse.esmf.metamodel.EntityInstance;
-import org.eclipse.esmf.metamodel.ModelElement;
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Scalar;
-import org.eclipse.esmf.metamodel.ScalarValue;
-import org.eclipse.esmf.metamodel.Type;
-import org.eclipse.esmf.metamodel.characteristic.Code;
-import org.eclipse.esmf.metamodel.characteristic.Collection;
-import org.eclipse.esmf.metamodel.characteristic.Duration;
-import org.eclipse.esmf.metamodel.characteristic.Either;
-import org.eclipse.esmf.metamodel.characteristic.Enumeration;
-import org.eclipse.esmf.metamodel.characteristic.Measurement;
-import org.eclipse.esmf.metamodel.characteristic.Quantifiable;
-import org.eclipse.esmf.metamodel.characteristic.SingleEntity;
-import org.eclipse.esmf.metamodel.characteristic.SortedSet;
-import org.eclipse.esmf.metamodel.characteristic.State;
-import org.eclipse.esmf.metamodel.characteristic.StructuredValue;
-import org.eclipse.esmf.metamodel.characteristic.Trait;
-import org.eclipse.esmf.metamodel.datatype.LangString;
-
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -102,8 +74,39 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementCollect
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueList;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueReferencePair;
+
+import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
+import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
+import org.eclipse.esmf.metamodel.Aspect;
+import org.eclipse.esmf.metamodel.Characteristic;
+import org.eclipse.esmf.metamodel.CollectionValue;
+import org.eclipse.esmf.metamodel.Entity;
+import org.eclipse.esmf.metamodel.EntityInstance;
+import org.eclipse.esmf.metamodel.ModelElement;
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Scalar;
+import org.eclipse.esmf.metamodel.ScalarValue;
+import org.eclipse.esmf.metamodel.Type;
+import org.eclipse.esmf.metamodel.characteristic.Code;
+import org.eclipse.esmf.metamodel.characteristic.Collection;
+import org.eclipse.esmf.metamodel.characteristic.Duration;
+import org.eclipse.esmf.metamodel.characteristic.Either;
+import org.eclipse.esmf.metamodel.characteristic.Enumeration;
+import org.eclipse.esmf.metamodel.characteristic.Measurement;
+import org.eclipse.esmf.metamodel.characteristic.Quantifiable;
+import org.eclipse.esmf.metamodel.characteristic.SingleEntity;
+import org.eclipse.esmf.metamodel.characteristic.SortedSet;
+import org.eclipse.esmf.metamodel.characteristic.State;
+import org.eclipse.esmf.metamodel.characteristic.StructuredValue;
+import org.eclipse.esmf.metamodel.characteristic.Trait;
+import org.eclipse.esmf.metamodel.datatype.LangString;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+
+import tools.jackson.databind.node.ArrayNode;
 
 public class AspectModelAasVisitor implements AspectVisitor<Environment, Context> {
    private static final Logger LOG = LoggerFactory.getLogger( AspectModelAasVisitor.class );

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
@@ -263,7 +263,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
       final String submodelId = aspect.urn().getUrn().toString() + "/submodel";
 
       final Submodel submodel = usedContext.getSubmodel();
-      submodel.setIdShort( aspect.getName() );
+      submodel.setIdShort( DEFAULT_MAPPER.determineIdShortFor( aspect ) );
       submodel.setId( submodelId );
       submodel.setSemanticId( buildAspectReferenceToGlobalReference( aspect ) );
       submodel.setSupplementalSemanticIds( buildGlobalReferenceForSeeReferences( aspect ) );
@@ -316,14 +316,13 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
          // property will be excluded from generation.
          recursiveProperty.remove( property );
          if ( property.isOptional() ) {
-            LOG.warn(
-                  String.format( "Having a recursive Property %s which is optional. Will be excluded from AAS mapping.", property.urn() ) );
+            LOG.warn( "Having a recursive Property {} which is optional. Will be excluded from AAS mapping.", property.urn() );
             return defaultResultForProperty;
          } else {
-            LOG.error( String.format(
-                  "Having a recursive property: %s which is not optional is not valid. Check the model. Property will be excluded from "
+            LOG.error(
+                  "Having a recursive property: {} which is not optional is not valid. Check the model. Property will be excluded from "
                         + "AAS mapping.",
-                  property.urn() ) );
+                  property.urn() );
          }
          return defaultResultForProperty;
       }
@@ -349,7 +348,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
       }
 
       if ( !property.getPayloadName().isEmpty() ) {
-         element.setIdShort( property.getPayloadName() );
+         element.setIdShort( DEFAULT_MAPPER.determineIdShortFor( property, true ) );
       }
 
       recursiveProperty.remove( property );
@@ -376,7 +375,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
          final Context context ) {
       final List<SubmodelElement> submodelElements = visitProperties( entity.getAllProperties(), context );
       return new DefaultSubmodelElementCollection.Builder()
-            .idShort( entity.getName() )
+            .idShort( DEFAULT_MAPPER.determineIdShortFor( entity ) )
             .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
             .description( LangStringMapper.TEXT.map( property.getDescriptions() ) )
             .value( submodelElements )
@@ -391,7 +390,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
             .displayName( LangStringMapper.NAME.map( operation.getPreferredNames() ) )
             .description( LangStringMapper.TEXT.map( operation.getDescriptions() ) )
             .semanticId( buildReferenceToOperation( operation ) )
-            .idShort( operation.getName() )
+            .idShort( DEFAULT_MAPPER.determineIdShortFor( operation ) )
             .inputVariables( operation.getInput().stream()
                   .map( input -> mapOperationVariable( input, context ) )
                   .collect( Collectors.toList() ) )
@@ -494,7 +493,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
       if ( !context.hasEnvironmentConceptDescription( property.urn().toString() ) ) {
          final ConceptDescription conceptDescription =
                new DefaultConceptDescription.Builder()
-                     .idShort( property.getName() )
+                     .idShort( DEFAULT_MAPPER.determineIdShortFor( property ) )
                      .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
                      .embeddedDataSpecifications( extractEmbeddedDataSpecification( property ) )
                      .id( DEFAULT_MAPPER.determineIdentifierFor( property ) )
@@ -508,7 +507,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
       if ( !context.hasEnvironmentConceptDescription( operation.urn().toString() ) ) {
          final ConceptDescription conceptDescription =
                new DefaultConceptDescription.Builder()
-                     .idShort( operation.getName() )
+                     .idShort( DEFAULT_MAPPER.determineIdShortFor( operation ) )
                      .displayName( LangStringMapper.NAME.map( operation.getPreferredNames() ) )
                      .embeddedDataSpecifications( extractEmbeddedDataSpecification( operation ) )
                      .id( DEFAULT_MAPPER.determineIdentifierFor( operation ) )
@@ -522,7 +521,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
       if ( !context.hasEnvironmentConceptDescription( aspect.urn().toString() ) ) {
          final ConceptDescription conceptDescription =
                new DefaultConceptDescription.Builder()
-                     .idShort( aspect.getName() )
+                     .idShort( DEFAULT_MAPPER.determineIdShortFor( aspect ) )
                      .displayName( LangStringMapper.NAME.map( aspect.getPreferredNames() ) )
                      .embeddedDataSpecifications( extractEmbeddedDataSpecification( aspect ) )
                      .id( DEFAULT_MAPPER.determineIdentifierFor( aspect ) )
@@ -659,7 +658,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
    private <T extends Collection> Environment visitCollectionProperty( final T collection, final Context context ) {
       final String listIdShort = collection.getDataType()
             .filter( Entity.class::isInstance )
-            .map( ModelElement::getName )
+            .map( DEFAULT_MAPPER::determineIdShortFor )
             .orElse( null );
       final Optional<Reference> semanticIdListElement = collection.getDataType()
             .filter( Entity.class::isInstance )
@@ -668,7 +667,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
 
       final SubmodelElementBuilder defaultBuilder = property -> {
          final DefaultSubmodelElementList.Builder submodelBuilder = new DefaultSubmodelElementList.Builder()
-               .idShort( listIdShort != null ? listIdShort : property.getName() )
+               .idShort( listIdShort != null ? listIdShort : DEFAULT_MAPPER.determineIdShortFor( property ) )
                .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
                .description( LangStringMapper.TEXT.map( property.getDescriptions() ) )
                .value( List.of( decideOnMapping( property, context ) ) )
@@ -697,7 +696,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
                            final List<SubmodelElement> values = getValues( collection, property, context, arrayNode );
                            final String propertyUrn = DEFAULT_MAPPER.determineIdentifierFor( property );
                            return new DefaultSubmodelElementList.Builder()
-                                 .idShort( listIdShort != null ? listIdShort : property.getName() )
+                                 .idShort( listIdShort != null ? listIdShort : DEFAULT_MAPPER.determineIdShortFor( property ) )
                                  .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
                                  .description( LangStringMapper.TEXT.map( property.getDescriptions() ) )
                                  .value( values )
@@ -754,7 +753,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
 
       final SubmodelElementList eitherSubModelElements =
             new DefaultSubmodelElementList.Builder()
-                  .idShort( either.getName() )
+                  .idShort( DEFAULT_MAPPER.determineIdShortFor( either ) )
                   .typeValueListElement( AasSubmodelElements.DATA_ELEMENT )
                   .displayName( LangStringMapper.NAME.map( either.getPreferredNames() ) )
                   .description( LangStringMapper.TEXT.map( either.getDescriptions() ) )

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
@@ -154,18 +154,14 @@ public class Context {
    }
 
    public <T extends SubmodelElement> String getPropertyIdShort( final PropertyMapper<T> mapper ) {
-      final String idShort;
       if ( ModellingKind.TEMPLATE.equals( getModelingKind() ) ) {
-         idShort = mapper.determineIdShortFor( property );
-      } else {
-         idShort = mapper.determineIdShortFor( property ) + propertyPath.stream()
-               .map( indices::get )
-               .filter( Objects::nonNull )
-               .map( Objects::toString )
-               .collect( Collectors.joining( "_" ) );
+         return mapper.determineIdShortFor( property );
       }
-
-      return idShort;
+      return mapper.determineIdShortFor( property ) + propertyPath.stream()
+            .map( indices::get )
+            .filter( Objects::nonNull )
+            .map( Objects::toString )
+            .collect( Collectors.joining( "_" ) );
    }
 
    @Deprecated( forRemoval = true )

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
@@ -21,15 +21,16 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.eclipse.esmf.metamodel.Property;
-
-import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.ModellingKind;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+
+import org.eclipse.esmf.metamodel.Property;
+
+import tools.jackson.databind.JsonNode;
 
 /**
  * Contains and tracks the context while the {@link AspectModelAasVisitor} traverses the metamodel.

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/Context.java
@@ -35,7 +35,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
  * Contains and tracks the context while the {@link AspectModelAasVisitor} traverses the metamodel.
  */
 public class Context {
-
    Environment environment;
    final Submodel submodel;
    Property property;
@@ -153,6 +152,22 @@ public class Context {
       return AssetKind.INSTANCE;
    }
 
+   public <T extends SubmodelElement> String getPropertyIdShort( final PropertyMapper<T> mapper ) {
+      final String idShort;
+      if ( ModellingKind.TEMPLATE.equals( getModelingKind() ) ) {
+         idShort = mapper.determineIdShortFor( property );
+      } else {
+         idShort = mapper.determineIdShortFor( property ) + propertyPath.stream()
+               .map( indices::get )
+               .filter( Objects::nonNull )
+               .map( Objects::toString )
+               .collect( Collectors.joining( "_" ) );
+      }
+
+      return idShort;
+   }
+
+   @Deprecated( forRemoval = true )
    public String getPropertyShortId() {
       final String shortId;
       if ( ModellingKind.TEMPLATE.equals( getModelingKind() ) ) {

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/DefaultPropertyMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/DefaultPropertyMapper.java
@@ -24,7 +24,7 @@ public class DefaultPropertyMapper implements PropertyMapper<Property> {
    @Override
    public Property mapToAasProperty( final Type type, final org.eclipse.esmf.metamodel.Property property, final Context context ) {
       final DefaultProperty defaultProperty = new DefaultProperty();
-      defaultProperty.setIdShort( context.getPropertyShortId() );
+      defaultProperty.setIdShort( context.getPropertyIdShort( this ) );
       defaultProperty.setValueType( AasDataTypeMapper.mapAspectTypeToAasXsdDataType( mapType( type ) ) );
       defaultProperty.setDisplayName( LangStringMapper.NAME.map( property.getPreferredNames() ) );
       defaultProperty.setSemanticId( buildPropertyReferenceToGlobalReference( property ) );

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
@@ -33,7 +33,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultMultiLanguageProperty;
  * multiple localized strings.
  */
 public class LangStringPropertyMapper implements PropertyMapper<MultiLanguageProperty> {
-
    @Override
    public boolean canHandle( final Property property ) {
       return property.getDataType()
@@ -44,15 +43,16 @@ public class LangStringPropertyMapper implements PropertyMapper<MultiLanguagePro
 
    @Override
    public MultiLanguageProperty mapToAasProperty( final Type type, final Property property, final Context context ) {
-      return new DefaultMultiLanguageProperty.Builder().idShort( context.getPropertyShortId() )
+      return new DefaultMultiLanguageProperty.Builder()
+            .idShort( context.getPropertyIdShort( this ) )
             .description( LangStringMapper.TEXT.map( property.getDescriptions() ) )
             .displayName( LangStringMapper.NAME.map( property.getPreferredNames() ) )
             .semanticId( buildPropertyReferenceToGlobalReference( property ) )
-            .value( extractLangStrings( property, context ) )
+            .value( extractLangStrings( context ) )
             .build();
    }
 
-   private List<LangStringTextType> extractLangStrings( final Property property, final Context context ) {
+   private List<LangStringTextType> extractLangStrings( final Context context ) {
       return context.getRawPropertyValue().stream()
             .flatMap( node -> node.isArray() ? StreamSupport.stream( node.spliterator(), false ) : Stream.of( node ) )
             .filter( JsonNode::isObject )

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
@@ -12,21 +12,20 @@
  */
 package org.eclipse.esmf.aspectmodel.aas;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Type;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultMultiLanguageProperty;
+
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Type;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Special mapper to create {@link MultiLanguageProperty}s from Aspect Model properties that carry
@@ -57,12 +56,8 @@ public class LangStringPropertyMapper implements PropertyMapper<MultiLanguagePro
             .flatMap( node -> node.isArray() ? StreamSupport.stream( node.spliterator(), false ) : Stream.of( node ) )
             .filter( JsonNode::isObject )
             .map( ObjectNode.class::cast )
-            .flatMap( node -> {
-               final Map<String, String> entries = new HashMap<>();
-               node.fields().forEachRemaining( field -> entries.put( field.getKey(), field.getValue().asText() ) );
-               return entries.entrySet().stream();
-            } )
-            .map( entry -> LangStringMapper.TEXT.createLangString( entry.getValue(), entry.getKey() ) )
+            .flatMap( node -> node.properties().stream()
+                  .map( entry -> LangStringMapper.TEXT.createLangString( entry.getValue().asString(), entry.getKey() ) ) )
             .toList();
    }
 }

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/PropertyMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/PropertyMapper.java
@@ -12,10 +12,6 @@
  */
 package org.eclipse.esmf.aspectmodel.aas;
 
-import org.eclipse.esmf.metamodel.ModelElement;
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Type;
-
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
@@ -23,6 +19,10 @@ import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
+
+import org.eclipse.esmf.metamodel.ModelElement;
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Type;
 
 /**
  * Base interface for any class that can map a property to a {@link SubmodelElement}.
@@ -101,5 +101,32 @@ public interface PropertyMapper<T extends SubmodelElement> extends Comparable<Pr
     */
    default String determineIdentifierFor( final ModelElement element ) {
       return element.urn().toString();
+   }
+
+   /**
+    * Determines the idShort for the given {@link ModelElement}
+    *
+    * @param element the element to get the idShort fo
+    * @return the idShort
+    */
+   default String determineIdShortFor( final ModelElement element ) {
+      return escapeIdShort( element.getName() );
+   }
+
+   /**
+    * Similar to {@link #determineIdShortFor(ModelElement)} specifically for Properties, but can base
+    * the
+    * idShort on the payloadName
+    *
+    * @param property the property
+    * @param usePayloadName whether to use the Property's payloadName
+    * @return the idShort
+    */
+   default String determineIdShortFor( final Property property, final boolean usePayloadName ) {
+      return usePayloadName ? escapeIdShort( property.getPayloadName() ) : determineIdShortFor( property );
+   }
+
+   private String escapeIdShort( final String idShort ) {
+      return idShort.length() == 1 ? idShort + "_" : idShort;
    }
 }

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectConverter.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectConverter.java
@@ -26,6 +26,32 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.iri.IRIFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.XSD;
+import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
+import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
+import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
+import org.eclipse.digitaltwin.aas4j.v3.model.EventElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.File;
+import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
+import org.eclipse.digitaltwin.aas4j.v3.model.Identifiable;
+import org.eclipse.digitaltwin.aas4j.v3.model.Key;
+import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
+import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import org.eclipse.digitaltwin.aas4j.v3.model.Range;
+import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+
 import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
 import org.eclipse.esmf.aspectmodel.loader.ValueInstantiator;
@@ -56,31 +82,6 @@ import org.eclipse.esmf.metamodel.impl.DefaultProperty;
 import org.eclipse.esmf.metamodel.impl.DefaultScalar;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.iri.IRI;
-import org.apache.jena.iri.IRIFactory;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
-import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
-import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
-import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
-import org.eclipse.digitaltwin.aas4j.v3.model.EventElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.File;
-import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
-import org.eclipse.digitaltwin.aas4j.v3.model.Identifiable;
-import org.eclipse.digitaltwin.aas4j.v3.model.Key;
-import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
-import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
-import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
-import org.eclipse.digitaltwin.aas4j.v3.model.Range;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -575,7 +576,7 @@ class SubmodelToAspectConverter {
       final Function<Reference, String> describeReference = ref -> switch ( ref.getType() ) {
          case MODEL_REFERENCE -> "Model reference ";
          case EXTERNAL_REFERENCE -> "External reference ";
-      } + ref.getKeys().stream().map( Key::getValue ).collect( Collectors.joining( "/" ) );
+      } + Optional.ofNullable( ref.getKeys() ).orElse( List.of() ).stream().map( Key::getValue ).collect( Collectors.joining( "/" ) );
 
       final String characteristicDescription = "First reference: %s, second reference: %s".formatted(
             describeReference.apply( relationshipElement.getFirst() ), describeReference.apply( relationshipElement.getSecond() ) );
@@ -672,7 +673,7 @@ class SubmodelToAspectConverter {
       final MetaModelBaseAttributes entityMetaModelBaseAttributes = namedBaseAttributes( entity, entityNamePrefix );
       final MetaModelBaseAttributes characteristicMetaModelBaseAttributes = baseAttributes( entity,
             new DetermineAutomatically( entityMetaModelBaseAttributes.urn().getName() + "Characteristic", false ), true, false );
-      final List<Property> entityProperties = entity.getStatements().stream()
+      final List<Property> entityProperties = Optional.ofNullable( entity.getStatements() ).orElse( List.of() ).stream()
             .map( this::createProperty )
             .toList();
       final Entity entityType = new DefaultEntity( entityMetaModelBaseAttributes, entityProperties );

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectUtils.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectUtils.java
@@ -103,12 +103,12 @@ final class SubmodelToAspectUtils {
          for ( final Class<?> iface : clazz.getInterfaces() ) {
             final Optional<AasSubmodelElements> match = findEnumForClass( iface );
             if ( match.isPresent() ) {
-               return match.orElse( null );
+               return match.get();
             }
          }
          final Optional<AasSubmodelElements> match = findEnumForClass( clazz );
          if ( match.isPresent() ) {
-            return match.orElse( null );
+            return match.get();
          }
          clazz = clazz.getSuperclass();
       }

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectUtils.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectUtils.java
@@ -24,17 +24,19 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.esmf.metamodel.datatype.LangString;
-
-import com.google.common.base.CaseFormat;
 import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+
+import org.eclipse.esmf.metamodel.datatype.LangString;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.CaseFormat;
 
 final class SubmodelToAspectUtils {
    private static final Logger LOG = LoggerFactory.getLogger( SubmodelToAspectUtils.class );
@@ -98,15 +100,15 @@ final class SubmodelToAspectUtils {
    static AasSubmodelElements submodelElementType( final SubmodelElement element ) {
       Class<?> clazz = element.getClass();
       while ( clazz != null ) {
-         for ( Class<?> iface : clazz.getInterfaces() ) {
-            final AasSubmodelElements match = findEnumForClass( iface );
-            if ( match != null ) {
-               return match;
+         for ( final Class<?> iface : clazz.getInterfaces() ) {
+            final Optional<AasSubmodelElements> match = findEnumForClass( iface );
+            if ( match.isPresent() ) {
+               return match.orElse( null );
             }
          }
-         final AasSubmodelElements match = findEnumForClass( clazz );
-         if ( match != null ) {
-            return match;
+         final Optional<AasSubmodelElements> match = findEnumForClass( clazz );
+         if ( match.isPresent() ) {
+            return match.orElse( null );
          }
          clazz = clazz.getSuperclass();
       }
@@ -118,14 +120,13 @@ final class SubmodelToAspectUtils {
       return value.replace( "/ ", "/" );
    }
 
-   private static AasSubmodelElements findEnumForClass( final Class<?> clazz ) {
+   private static Optional<AasSubmodelElements> findEnumForClass( final Class<?> clazz ) {
       final String className = clazz.getSimpleName();
       return Arrays.stream( AasSubmodelElements.values() )
             .filter( entry -> {
                final String enumClassName = CaseFormat.UPPER_UNDERSCORE.to( CaseFormat.UPPER_CAMEL, entry.toString() );
                return className.equals( enumClassName );
             } )
-            .findFirst()
-            .orElse( null );
+            .findFirst();
    }
 }

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
@@ -121,7 +121,7 @@ class AasToAspectModelGeneratorTest {
       } catch ( final IOException exception ) {
          fail( exception );
       } catch ( final AspectModelGenerationException aspectModelGenerationException ) {
-         if ( aspectModelGenerationException.getCause() instanceof final DeserializationException cause ) {
+         if ( aspectModelGenerationException.getCause() instanceof DeserializationException ) {
             System.err.println( "Could not load AASX file: " + aasxFile.getName() + ". Consider reporting to IDTA or AAS4J project." );
          } else {
             fail( aspectModelGenerationException );

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -32,7 +32,7 @@ import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import io.vavr.control.Try;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/IntegerCollectionMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/IntegerCollectionMapper.java
@@ -19,8 +19,8 @@ import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.metamodel.Property;
 import org.eclipse.esmf.metamodel.Type;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;

--- a/core/esmf-aspect-model-document-generators/pom.xml
+++ b/core/esmf-aspect-model-document-generators/pom.xml
@@ -42,10 +42,6 @@
          <artifactId>esmf-aspect-model-generator</artifactId>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.datatype</groupId>
-         <artifactId>jackson-datatype-jsr310</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.jeasy</groupId>
          <artifactId>easy-random-core</artifactId>
       </dependency>
@@ -78,7 +74,7 @@
          <artifactId>vavr</artifactId>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.dataformat</groupId>
+         <groupId>tools.jackson.dataformat</groupId>
          <artifactId>jackson-dataformat-yaml</artifactId>
       </dependency>
       <dependency>

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/AbstractSchemaArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/AbstractSchemaArtifact.java
@@ -15,7 +15,6 @@ package org.eclipse.esmf.aspectmodel.generator;
 
 import java.io.Serial;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -24,18 +23,16 @@ import java.util.stream.Collectors;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
+
 import io.vavr.control.Try;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
+import tools.jackson.dataformat.yaml.util.StringQuotingChecker;
 
 /**
  * The result of a schema generation where the schema is represented as a JSON document.
@@ -43,8 +40,6 @@ import org.slf4j.LoggerFactory;
  * @param <T> the concrete type of node of this artifact
  */
 public abstract class AbstractSchemaArtifact<T extends JsonNode> extends JsonArtifact<T> {
-   private static final Logger LOG = LoggerFactory.getLogger( AbstractSchemaArtifact.class );
-
    public AbstractSchemaArtifact( final String id, final T content ) {
       super( id, content );
    }
@@ -79,13 +74,12 @@ public abstract class AbstractSchemaArtifact<T extends JsonNode> extends JsonArt
       final Function<String, String> newSchemaReference = schemaName -> schemaName + "." + fileExtension;
 
       // Add separate entry in result map for each schema
-      for ( final Iterator<Map.Entry<String, JsonNode>> it = schemas.fields(); it.hasNext(); ) {
-         final Map.Entry<String, JsonNode> schema = it.next();
+      for ( final Map.Entry<String, JsonNode> schema : schemas.properties() ) {
          builder.put( Path.of( newSchemaReference.apply( schema.getKey() ) ), schema.getValue() );
       }
 
       // Update each $ref in root schema
-      final Map<String, String> oldToNew = Streams.stream( schemas.fieldNames() ).collect(
+      final Map<String, String> oldToNew = schemas.propertyNames().stream().collect(
             Collectors.toMap( schemaName -> "#/components/schemas/" + schemaName, newSchemaReference ) );
       final JsonNode updatedRoot = updateRefValues( json, oldToNew );
       builder.put( Path.of( aspectName + mainSpec.map( s -> "." + s ).orElse( "" ) + "." + fileExtension ), updatedRoot );
@@ -105,23 +99,29 @@ public abstract class AbstractSchemaArtifact<T extends JsonNode> extends JsonArt
     * @return the original node with the updated values
     */
    private JsonNode updateRefValues( final JsonNode node, final Map<String, String> oldToNew ) {
-      if ( node == null ) {
-         return null;
-      } else if ( node instanceof ArrayNode ) {
-         for ( final JsonNode child : node ) {
-            updateRefValues( child, oldToNew );
+      switch ( node ) {
+         case null -> {
+            return null;
          }
-      } else if ( node instanceof final ObjectNode objectNode ) {
-         for ( final Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
-            final String fieldName = it.next();
-            final JsonNode updatedChild = updateRefValues( node.get( fieldName ), oldToNew );
-            if ( fieldName.equals( "$ref" ) && updatedChild instanceof final TextNode updatedTextNode ) {
-               objectNode.replace( "$ref", updatedTextNode );
+         case final ArrayNode _ -> {
+            for ( final JsonNode child : node ) {
+               updateRefValues( child, oldToNew );
             }
          }
-      } else if ( node instanceof final TextNode textNode ) {
-         return JsonNodeFactory.instance.textNode(
-               Optional.ofNullable( oldToNew.get( textNode.textValue() ) ).orElse( textNode.textValue() ) );
+         case final ObjectNode objectNode -> {
+            for ( final String fieldName : node.propertyNames() ) {
+               final JsonNode updatedChild = updateRefValues( node.get( fieldName ), oldToNew );
+               if ( fieldName.equals( "$ref" ) && updatedChild instanceof final StringNode updatedTextNode ) {
+                  objectNode.replace( "$ref", updatedTextNode );
+               }
+            }
+         }
+         case final StringNode stringNode -> {
+            return JsonNodeFactory.instance.stringNode(
+                  Optional.ofNullable( oldToNew.get( stringNode.stringValue() ) ).orElse( stringNode.stringValue() ) );
+         }
+         default -> {
+         }
       }
       return node;
    }
@@ -129,14 +129,14 @@ public abstract class AbstractSchemaArtifact<T extends JsonNode> extends JsonArt
    protected Map<Path, JsonNode> getContentWithSeparateSchemasAsJson( final Optional<String> mainSpec ) {
       final JsonNode jsonContent = getContent();
       final String aspectName = AspectModelUrn.fromUrn(
-            jsonContent.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asText() ).getName();
+            jsonContent.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asString() ).getName();
       return getSeparateSchemas( aspectName, "json", mainSpec );
    }
 
    protected Map<Path, String> getContentWithSeparateSchemasAsYaml( final Optional<String> mainSpec ) {
       final JsonNode jsonContent = getContent();
       final String aspectName = AspectModelUrn.fromUrn(
-            jsonContent.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asText() ).getName();
+            jsonContent.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asString() ).getName();
       return getSeparateSchemas( aspectName, "yaml", mainSpec ).entrySet().stream().collect( Collectors.toMap(
             Map.Entry::getKey, entry -> jsonToYaml( entry.getValue() ) ) );
    }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/JsonArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/JsonArtifact.java
@@ -15,13 +15,13 @@ package org.eclipse.esmf.aspectmodel.generator;
 
 import java.nio.charset.StandardCharsets;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 public class JsonArtifact<T extends JsonNode> implements Artifact<String, T> {
    private static final Logger LOG = LoggerFactory.getLogger( JsonArtifact.class );
@@ -56,10 +56,11 @@ public class JsonArtifact<T extends JsonNode> implements Artifact<String, T> {
    protected String jsonToYaml( final JsonNode json ) {
       try {
          final YAMLFactory yamlFactory = YAMLFactory.builder()
-               .stringQuotingChecker( new AbstractSchemaArtifact.OpenApiStringQuotingChecker() ).build();
-         return new YAMLMapper( yamlFactory ).enable( YAMLGenerator.Feature.MINIMIZE_QUOTES )
-               .writeValueAsString( json );
-      } catch ( final JsonProcessingException exception ) {
+               .stringQuotingChecker( new AbstractSchemaArtifact.OpenApiStringQuotingChecker() )
+               .enable( YAMLWriteFeature.MINIMIZE_QUOTES )
+               .build();
+         return new YAMLMapper( yamlFactory ).writeValueAsString( json );
+      } catch ( final Exception exception ) {
          LOG.error( "JSON could not be converted to YAML", exception );
          return json.toString();
       }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/JsonGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/JsonGenerator.java
@@ -20,10 +20,10 @@ import java.util.function.Function;
 import org.eclipse.esmf.aspectmodel.jackson.AspectModelJacksonModule;
 import org.eclipse.esmf.metamodel.StructureElement;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Base class for generators that create JSON
@@ -41,11 +41,10 @@ public abstract class JsonGenerator<S extends StructureElement, C extends JsonGe
    public JsonGenerator( final S element, final C config ) {
       super( element, config );
 
-      objectMapper = new ObjectMapper();
-      objectMapper.registerModule( new JavaTimeModule() );
-      objectMapper.registerModule( new AspectModelJacksonModule() );
-      objectMapper.configure( SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false );
-      objectMapper.configure( SerializationFeature.FAIL_ON_EMPTY_BEANS, false );
+      objectMapper = JsonMapper.builder()
+            .addModule( new AspectModelJacksonModule() )
+            .configure( SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
+            .build();
    }
 
    /**

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/XsdToJsonTypeMapping.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/XsdToJsonTypeMapping.java
@@ -14,12 +14,14 @@ package org.eclipse.esmf.aspectmodel.generator;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.collect.ImmutableMap;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
+
+import com.google.common.collect.ImmutableMap;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 public class XsdToJsonTypeMapping {
    public enum JsonType {
@@ -27,10 +29,10 @@ public class XsdToJsonTypeMapping {
 
       public JsonNode toJsonNode() {
          return switch ( this ) {
-            case NUMBER -> JsonNodeFactory.instance.textNode( "number" );
-            case BOOLEAN -> JsonNodeFactory.instance.textNode( "boolean" );
-            case OBJECT -> JsonNodeFactory.instance.textNode( "object" );
-            default -> JsonNodeFactory.instance.textNode( "string" );
+            case NUMBER -> JsonNodeFactory.instance.stringNode( "number" );
+            case BOOLEAN -> JsonNodeFactory.instance.stringNode( "boolean" );
+            case OBJECT -> JsonNodeFactory.instance.stringNode( "object" );
+            default -> JsonNodeFactory.instance.stringNode( "string" );
          };
       }
    }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGenerator.java
@@ -19,6 +19,9 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
@@ -31,14 +34,13 @@ import org.eclipse.esmf.metamodel.Event;
 import org.eclipse.esmf.metamodel.Operation;
 import org.eclipse.esmf.metamodel.Property;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 public class AspectModelAsyncApiGenerator extends JsonGenerator<Aspect, AsyncApiSchemaGenerationConfig, JsonNode, AsyncApiSchemaArtifact> {
    public static final AsyncApiSchemaGenerationConfig DEFAULT_CONFIG = AsyncApiSchemaGenerationConfigBuilder.builder().build();
@@ -159,7 +161,7 @@ public class AspectModelAsyncApiGenerator extends JsonGenerator<Aspect, AsyncApi
                   FACTORY.objectNode().put( "$ref", ref( COMPONENTS_MESSAGES_REF, requestMessageName ) ) );
          }
 
-         operation.getOutput().ifPresent( output -> {
+         operation.getOutput().ifPresent( _ -> {
             final String responseMessageName = operation.getName() + RESPONSE;
             messagesNode.set( responseMessageName,
                   FACTORY.objectNode().put( "$ref", ref( COMPONENTS_MESSAGES_REF, responseMessageName ) ) );
@@ -298,7 +300,7 @@ public class AspectModelAsyncApiGenerator extends JsonGenerator<Aspect, AsyncApi
       final ObjectNode requestComponentSchema = schemasNode.putObject( requestComponentName );
       requestComponentSchema.put( TITLE_FIELD, operation.getPreferredName( locale ) );
       final ArrayNode messageArrayNode = requestComponentSchema.putArray( "allOf" );
-      for ( Property input : operation.getInput() ) {
+      for ( final Property input : operation.getInput() ) {
          messageArrayNode.add( input.accept( schemaVisitor, null ) );
       }
    }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AsyncApiSchemaArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AsyncApiSchemaArtifact.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.esmf.aspectmodel.generator.AbstractSchemaArtifact;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * The result of generating an AsyncAPI specification from an Aspect Model. The result can be

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadArtifact.java
@@ -15,7 +15,7 @@ package org.eclipse.esmf.aspectmodel.generator.json;
 
 import org.eclipse.esmf.aspectmodel.generator.JsonArtifact;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class JsonPayloadArtifact extends JsonArtifact<JsonNode> {
    public JsonPayloadArtifact( final String id, final JsonNode content ) {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
@@ -70,12 +70,13 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.curiousoddman.rgxgen.RgxGen;
 import com.github.curiousoddman.rgxgen.parsing.dflt.RgxGenParseException;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Generator for random JSON payloads corresponding to a given StructureElement (e.g.,
@@ -319,7 +320,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
                .put( langString.getLanguageTag().toLanguageTag(), langString.getValue() );
       }
       if ( scalarValue.getValue() instanceof Curie( final String value ) ) {
-         return JsonNodeFactory.instance.textNode( value );
+         return JsonNodeFactory.instance.stringNode( value );
       }
       return objectMapper.valueToTree( scalarValue.getValue() );
    }
@@ -402,7 +403,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
             .newXMLGregorianCalendar( now.getYear(), now.getMonthValue(), now.getDayOfMonth(),
                   DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED,
                   DatatypeConstants.FIELD_UNDEFINED, 0 );
-      return JsonNodeFactory.instance.textNode( calendar.toXMLFormat() );
+      return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
    }
 
    @Override
@@ -412,7 +413,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
             .newXMLGregorianCalendar( DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED,
                   DatatypeConstants.FIELD_UNDEFINED,
                   now.getHour(), now.getMinute(), now.getSecond(), 0, 0 );
-      return JsonNodeFactory.instance.textNode( calendar.toXMLFormat() );
+      return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
    }
 
    @Override
@@ -421,7 +422,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
       final XMLGregorianCalendar calendar = DatatypeFactory.newDefaultInstance()
             .newXMLGregorianCalendar( now.getYear(), now.getMonthValue(), now.getDayOfMonth(),
                   now.getHour(), now.getMinute(), now.getSecond(), 0, 0 );
-      return JsonNodeFactory.instance.textNode( calendar.toXMLFormat() );
+      return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
    }
 
    @Override
@@ -431,44 +432,44 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
    @Override
    public JsonNode visitXsdGYear( final SammType.XsdGYear gYear, final Context context ) {
-      return JsonNodeFactory.instance.textNode( "" + LocalDateTime.now().getYear() );
+      return JsonNodeFactory.instance.stringNode( "" + LocalDateTime.now().getYear() );
    }
 
    @Override
    public JsonNode visitXsdGMonth( final SammType.XsdGMonth gMonth, final Context context ) {
-      return JsonNodeFactory.instance.textNode( "--%02d".formatted( LocalDateTime.now().getMonthValue() ) );
+      return JsonNodeFactory.instance.stringNode( "--%02d".formatted( LocalDateTime.now().getMonthValue() ) );
    }
 
    @Override
    public JsonNode visitXsdGDay( final SammType.XsdGDay gDay, final Context context ) {
-      return JsonNodeFactory.instance.textNode( "---%02d".formatted( LocalDateTime.now().getDayOfMonth() ) );
+      return JsonNodeFactory.instance.stringNode( "---%02d".formatted( LocalDateTime.now().getDayOfMonth() ) );
    }
 
    @Override
    public JsonNode visitXsdGYearMonth( final SammType.XsdGYearMonth gYearMonth, final Context context ) {
       final LocalDateTime now = LocalDateTime.now();
-      return JsonNodeFactory.instance.textNode( "%04d-%02d".formatted( now.getYear(), now.getMonthValue() ) );
+      return JsonNodeFactory.instance.stringNode( "%04d-%02d".formatted( now.getYear(), now.getMonthValue() ) );
    }
 
    @Override
    public JsonNode visitXsdGMonthDay( final SammType.XsdMonthDay monthDay, final Context context ) {
       final LocalDateTime now = LocalDateTime.now();
-      return JsonNodeFactory.instance.textNode( "--%02d-%02d".formatted( now.getMonthValue(), now.getDayOfMonth() ) );
+      return JsonNodeFactory.instance.stringNode( "--%02d-%02d".formatted( now.getMonthValue(), now.getDayOfMonth() ) );
    }
 
    @Override
    public JsonNode visitXsdDuration( final SammType.XsdDuration duration, final Context context ) {
-      return JsonNodeFactory.instance.textNode( "P%02dD".formatted( randomInt( 1, 10 ) ) );
+      return JsonNodeFactory.instance.stringNode( "P%02dD".formatted( randomInt( 1, 10 ) ) );
    }
 
    @Override
    public JsonNode visitXsdYearMonthDuration( final SammType.XsdYearMonthDuration yearMonthDuration, final Context context ) {
-      return JsonNodeFactory.instance.textNode( randomValueOf( "P10M", "P5Y2M" ) );
+      return JsonNodeFactory.instance.stringNode( randomValueOf( "P10M", "P5Y2M" ) );
    }
 
    @Override
    public JsonNode visitXsdDayTimeDuration( final SammType.XsdDayTimeDuration dayTimeDuration, final Context context ) {
-      return JsonNodeFactory.instance.textNode( randomValueOf( "P30D", "P1DT5H", "PT1H5M0S" ) );
+      return JsonNodeFactory.instance.stringNode( randomValueOf( "P30D", "P1DT5H", "PT1H5M0S" ) );
    }
 
    @Override
@@ -578,7 +579,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
       final byte[] bytes = randomBytes( Optional.ofNullable( range.min() ).map( BigDecimal::intValue ).orElse( 0 ),
             Optional.ofNullable( range.max() ).map( BigDecimal::intValue ).orElse( 0 ) );
       final String value = hexBinary.serialize( bytes );
-      return JsonNodeFactory.instance.textNode( value );
+      return JsonNodeFactory.instance.stringNode( value );
    }
 
    @Override
@@ -588,19 +589,19 @@ public class JsonPayloadGenerator<S extends StructureElement>
       final byte[] bytes = randomBytes( Optional.ofNullable( range.min() ).map( BigDecimal::intValue ).orElse( 0 ),
             Optional.ofNullable( range.max() ).map( BigDecimal::intValue ).orElse( 0 ) );
       final String value = base64Binary.serialize( bytes );
-      return JsonNodeFactory.instance.textNode( value );
+      return JsonNodeFactory.instance.stringNode( value );
    }
 
    @Override
    public JsonNode visitXsdAnyUri( final SammType.XsdAnyUri anyUri, final Context context ) {
       final String value = "https://example.com/" + randomString( 5, 10 );
-      return JsonNodeFactory.instance.textNode( value );
+      return JsonNodeFactory.instance.stringNode( value );
    }
 
    @Override
    public JsonNode visitCurieType( final CurieType curieType, final Context context ) {
       final String value = randomValueOf( "unit:kilometre", "unit:hectopascal", "unit:newton" );
-      return JsonNodeFactory.instance.textNode( value );
+      return JsonNodeFactory.instance.stringNode( value );
    }
 
    @Override
@@ -629,7 +630,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
                return randomString( Optional.ofNullable( range.min() ).map( BigDecimal::intValue ).orElse( 0 ),
                      Optional.ofNullable( range.max() ).map( BigDecimal::intValue ).orElse( 0 ) );
             } );
-      return JsonNodeFactory.instance.textNode( value );
+      return JsonNodeFactory.instance.stringNode( value );
    }
 
    @Override

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonld/AspectModelToJsonLdGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonld/AspectModelToJsonLdGenerator.java
@@ -19,8 +19,8 @@ import java.util.stream.Stream;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 import org.apache.jena.riot.RDFLanguages;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ public class AspectModelToJsonLdGenerator extends JsonGenerator<Aspect, JsonLdGe
       final String content = stringWriter.toString();
       try {
          return Stream.of( new JsonLdArtifact( aspect().getName() + ".json", objectMapper.readTree( content ) ) );
-      } catch ( final JsonProcessingException exception ) {
+      } catch ( final JacksonException exception ) {
          LOG.error( "Could not parse JSON-LD for {}", aspect().getName() );
       }
       return Stream.empty();

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonld/JsonLdArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonld/JsonLdArtifact.java
@@ -15,7 +15,7 @@ package org.eclipse.esmf.aspectmodel.generator.jsonld;
 
 import org.eclipse.esmf.aspectmodel.generator.JsonArtifact;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class JsonLdArtifact extends JsonArtifact<JsonNode> {
    public JsonLdArtifact( final String id, final JsonNode content ) {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGenerator.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Generator that generates a JSON Schema for payloads corresponding to a given Aspect model.

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
@@ -25,6 +25,12 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.XSD;
+
 import org.eclipse.esmf.aspectmodel.generator.DocumentGenerationException;
 import org.eclipse.esmf.aspectmodel.generator.XsdToJsonTypeMapping;
 import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
@@ -58,22 +64,18 @@ import org.eclipse.esmf.metamodel.datatype.CurieType;
 import org.eclipse.esmf.metamodel.datatype.LangString;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NumericNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
+
 import io.vavr.control.Try;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.NumericNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, ObjectNode> {
    private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
@@ -93,34 +95,36 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
     */
    public static final Map<Resource, Map<String, JsonNode>> OPEN_API_TYPE_DATA =
          ImmutableMap.<Resource, Map<String, JsonNode>>builder()
-               .put( XSD.date, Map.of( "format", FACTORY.textNode( "date" ) ) )
-               .put( XSD.time, Map.of( "format", FACTORY.textNode( "time" ) ) )
+               .put( XSD.date, Map.of( "format", FACTORY.stringNode( "date" ) ) )
+               .put( XSD.time, Map.of( "format", FACTORY.stringNode( "time" ) ) )
                // Time offset (time zone) is optional in XSD dateTime.
                // Source: https://www.w3.org/TR/xmlschema11-2/#dateTime
-               .put( XSD.dateTime, Map.of( "pattern", FACTORY.textNode(
+               .put( XSD.dateTime, Map.of( "pattern", FACTORY.stringNode(
                      "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])"
                            + "T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))"
                            + "(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
                // JSON Schema format "date-time" corresponds to RFC 3339 production "date-time", which
                // includes mandatory time offset (time zone)
-               .put( XSD.dateTimeStamp, Map.of( "format", FACTORY.textNode( "date-time" ) ) )
+               .put( XSD.dateTimeStamp, Map.of( "format", FACTORY.stringNode( "date-time" ) ) )
                // Source: https://www.w3.org/TR/xmlschema11-2/#gYear
                .put( XSD.gYear,
-                     Map.of( "pattern", FACTORY.textNode( "-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
+                     Map.of( "pattern",
+                           FACTORY.stringNode( "-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
                // Source: https://www.w3.org/TR/xmlschema11-2/#gMonth
                .put( XSD.gMonth,
-                     Map.of( "pattern", FACTORY.textNode( "--(0[1-9]|1[0-2])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
+                     Map.of( "pattern", FACTORY.stringNode( "--(0[1-9]|1[0-2])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
                // Source https://www.w3.org/TR/xmlschema11-2/#gDay
                .put( XSD.gDay,
-                     Map.of( "pattern", FACTORY.textNode( "---(0[1-9]|[12][0-9]|3[01])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
+                     Map.of( "pattern",
+                           FACTORY.stringNode( "---(0[1-9]|[12][0-9]|3[01])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
                // Source: https://www.w3.org/TR/xmlschema11-2/#gYearMonth
-               .put( XSD.gYearMonth, Map.of( "pattern", FACTORY.textNode(
+               .put( XSD.gYearMonth, Map.of( "pattern", FACTORY.stringNode(
                      "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ) ) )
-               .put( XSD.duration, Map.of( "format", FACTORY.textNode( "duration" ) ) )
+               .put( XSD.duration, Map.of( "format", FACTORY.stringNode( "duration" ) ) )
                // Source: https://www.w3.org/TR/xmlschema11-2/#yearMonthDuration
-               .put( XSD.yearMonthDuration, Map.of( "pattern", FACTORY.textNode( "-?P[0-9]+(Y([0-9]+M)?|M)" ) ) )
+               .put( XSD.yearMonthDuration, Map.of( "pattern", FACTORY.stringNode( "-?P[0-9]+(Y([0-9]+M)?|M)" ) ) )
                // Source: https://www.w3.org/TR/xmlschema11-2/#dayTimeDuration
-               .put( XSD.dayTimeDuration, Map.of( "pattern", FACTORY.textNode( "[^YM]*[DT].*" ) ) )
+               .put( XSD.dayTimeDuration, Map.of( "pattern", FACTORY.stringNode( "[^YM]*[DT].*" ) ) )
                .put( XSD.xbyte, Map.of( "minimum", FACTORY.numberNode( Byte.MIN_VALUE ), "maximum", FACTORY.numberNode( Byte.MAX_VALUE ) ) )
                .put( XSD.xshort,
                      Map.of( "minimum", FACTORY.numberNode( Short.MIN_VALUE ), "maximum", FACTORY.numberNode( Short.MAX_VALUE ) ) )
@@ -136,8 +140,8 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
                .put( XSD.nonNegativeInteger, Map.of( "minimum", FACTORY.numberNode( 0 ) ) )
                .put( XSD.negativeInteger, Map.of( "maximum", FACTORY.numberNode( -1 ) ) )
                .put( XSD.nonPositiveInteger, Map.of( "maximum", FACTORY.numberNode( 0 ) ) )
-               .put( XSD.hexBinary, Map.of( "pattern", FACTORY.textNode( "([0-9a-fA-F])([0-9a-fA-F])*" ) ) )
-               .put( XSD.anyURI, Map.of( "format", FACTORY.textNode( "uri" ) ) )
+               .put( XSD.hexBinary, Map.of( "pattern", FACTORY.stringNode( "([0-9a-fA-F])([0-9a-fA-F])*" ) ) )
+               .put( XSD.anyURI, Map.of( "format", FACTORY.stringNode( "uri" ) ) )
                .build();
 
    /**
@@ -151,7 +155,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
                Map.of( "patternProperties",
                      FACTORY.objectNode()
                            .set( "^.*$", FACTORY.objectNode().set( "type", XsdToJsonTypeMapping.JsonType.STRING.toJsonNode() ) ) ) )
-         .put( XSD.base64Binary, Map.of( "contentEncoding", FACTORY.textNode( "base64" ) ) )
+         .put( XSD.base64Binary, Map.of( "contentEncoding", FACTORY.stringNode( "base64" ) ) )
          .build();
 
    public AspectModelJsonSchemaVisitor( final JsonSchemaGenerationConfig config ) {
@@ -224,12 +228,12 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
                      return propertyContext.set( property.getPayloadName(), jsonNode );
                   } );
       context.set( "properties", properties );
-      final List<TextNode> requiredProperties =
+      final List<StringNode> requiredProperties =
             io.vavr.collection.Stream.ofAll( element.getProperties() )
                   .filter( property -> !property.isNotInPayload() )
                   .filter( property -> !property.isOptional() )
                   .filter( property -> !property.isAbstract() ).toList()
-                  .map( property -> FACTORY.textNode( property.getPayloadName() ) )
+                  .map( property -> FACTORY.stringNode( property.getPayloadName() ) )
                   .toJavaList();
       if ( !requiredProperties.isEmpty() ) {
          final ArrayNode required = FACTORY.arrayNode();
@@ -298,7 +302,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
    private Map<String, JsonNode> getAdditionalFieldsForType( final Resource type ) {
       final Map<Resource, Map<String, JsonNode>> typeDates = ImmutableMap.<Resource, Map<String, JsonNode>>builder()
             .putAll( typeData )
-            .put( SammNs.SAMM.curie(), Map.of( "pattern", FACTORY.textNode( CurieType.CURIE_REGEX ) ) )
+            .put( SammNs.SAMM.curie(), Map.of( "pattern", FACTORY.stringNode( CurieType.CURIE_REGEX ) ) )
             .build();
       return typeDates.getOrDefault( type, Map.of() );
    }
@@ -361,7 +365,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
    @Override
    public JsonNode visitLengthConstraint( final LengthConstraint lengthConstraint, final ObjectNode context ) {
       addDescription( context, lengthConstraint, config.locale() );
-      final String itemsOrLength = "array".equals( context.get( "type" ).asText() ) ? "Items" : "Length";
+      final String itemsOrLength = "array".equals( context.get( "type" ).asString() ) ? "Items" : "Length";
       lengthConstraint.getMaxValue().ifPresent( maxValue -> context.put( "max" + itemsOrLength, maxValue ) );
       lengthConstraint.getMinValue().ifPresent( minValue -> context.put( "min" + itemsOrLength, minValue ) );
       return context;
@@ -379,7 +383,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
    public JsonNode visitRegularExpressionConstraint( final RegularExpressionConstraint regularExpressionConstraint,
          final ObjectNode context ) {
       addDescription( context, regularExpressionConstraint, config.locale() );
-      context.set( "pattern", FACTORY.textNode( regularExpressionConstraint.getValue() ) );
+      context.set( "pattern", FACTORY.stringNode( regularExpressionConstraint.getValue() ) );
       return context;
    }
 
@@ -418,7 +422,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
 
       final ObjectNode result = addDescription( FACTORY.objectNode(), either, config.locale() )
             .put( "additionalProperties", false )
-            .<ObjectNode>set( "properties", properties )
+            .set( "properties", properties )
             .set( "oneOf",
                   FACTORY.arrayNode()
                         .add( FACTORY.objectNode().set( "required", FACTORY.arrayNode().add( "left" ) ) )
@@ -494,13 +498,13 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
       if ( typeResource.equals( RDF.langString ) ) {
          final ObjectNode result = FACTORY.objectNode();
          final LangString langString = (LangString) value.getValue();
-         result.set( langString.getLanguageTag().toLanguageTag(), FACTORY.textNode( langString.getValue() ) );
+         result.set( langString.getLanguageTag().toLanguageTag(), FACTORY.stringNode( langString.getValue() ) );
          return result;
       }
 
       return switch ( getSchemaTypeForAspectType( typeResource ) ) {
          case NUMBER -> getNumberNode( value.getValue() ).getOrElse( FACTORY.numberNode( 0 ) );
-         case STRING -> FACTORY.textNode( value.getValue().toString() );
+         case STRING -> FACTORY.stringNode( value.getValue().toString() );
          case BOOLEAN -> FACTORY.booleanNode( (boolean) value.getValue() );
          default -> throw new DocumentGenerationException( "Could not convert value " + value + " to JSON" );
       };

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/JsonSchemaArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/JsonSchemaArtifact.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.esmf.aspectmodel.generator.AbstractSchemaArtifact;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class JsonSchemaArtifact extends AbstractSchemaArtifact<JsonNode> {
    public JsonSchemaArtifact( final String id, final JsonNode content ) {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -20,7 +20,6 @@ import static org.eclipse.esmf.aspectmodel.generator.openapi.AspectModelOpenApiG
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -34,6 +33,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections4.IterableUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.stream.Streams;
+
 import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
@@ -45,16 +48,15 @@ import org.eclipse.esmf.metamodel.ModelElement;
 import org.eclipse.esmf.metamodel.Operation;
 import org.eclipse.esmf.metamodel.Property;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.CaseFormat;
-import org.apache.commons.collections4.IterableUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.stream.Streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.CaseFormat;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 @SuppressWarnings( "OptionalUsedAsFieldOrParameterType" )
 public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSchemaGenerationConfig, ObjectNode, OpenApiSchemaArtifact> {
@@ -345,8 +347,8 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
                      responseArrayNode.add( FACTORY.objectNode().put( REF, COMPONENTS_SCHEMAS + key + "Response" ) );
                   } );
          }
-         SCHEMA_VISITOR.getRootNode().get( FIELD_COMPONENTS ).get( FIELD_SCHEMAS ).fields()
-               .forEachRemaining( field -> schemas.set( field.getKey(), field.getValue() ) );
+         SCHEMA_VISITOR.getRootNode().get( FIELD_COMPONENTS ).get( FIELD_SCHEMAS ).properties()
+               .forEach( field -> schemas.set( field.getKey(), field.getValue() ) );
       }
    }
 
@@ -614,8 +616,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
       if ( aspectSchema.has( FIELD_COMPONENTS ) ) {
          final JsonNode definitionsNode = aspectSchema.get( FIELD_COMPONENTS ).get( FIELD_SCHEMAS );
          aspectSchema.remove( FIELD_COMPONENTS );
-         for ( final Iterator<String> it = definitionsNode.fieldNames(); it.hasNext(); ) {
-            final String nodeName = it.next();
+         for ( final String nodeName : definitionsNode.propertyNames() ) {
             final JsonNode node = definitionsNode.get( nodeName );
             rootSchemaNode.set( nodeName, node );
          }
@@ -646,7 +647,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
             return node;
          }
          // cycle for result.fields()
-         extension.fields().forEachRemaining( entry -> {
+         extension.properties().forEach( entry -> {
             final String key = entry.getKey();
             final JsonNode value = entry.getValue();
 
@@ -697,7 +698,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
          final Function<String, Function<JsonNode, String>> getText =
                fieldName -> objNode -> Optional.ofNullable( objNode.get( fieldName ) )
                      .filter( Predicate.not( JsonNode::isNull ) )
-                     .map( JsonNode::asText )
+                     .map( JsonNode::asString )
                      .orElse( null );
 
          final Set<JsonNode> original = Streams.of( node ).collect( asSet() );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelPagingGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelPagingGenerator.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.IOUtils;
+
 import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
 import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.metamodel.Characteristic;
@@ -33,23 +35,23 @@ import org.eclipse.esmf.metamodel.Property;
 import org.eclipse.esmf.metamodel.characteristic.Collection;
 import org.eclipse.esmf.metamodel.characteristic.TimeSeries;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.vavr.collection.Stream;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.vavr.collection.Stream;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 class AspectModelPagingGenerator {
    private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
    private static final Logger LOG = LoggerFactory.getLogger( AspectModelPagingGenerator.class );
 
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-   private static final String UNSPECIFIC_PAGING_TYPE = "There is more than one option for paging. %s will be used.";
+   private static final String UNSPECIFIC_PAGING_TYPE = "There is more than one option for paging. {} will be used.";
    private static final String NO_PAGING_POSSIBLE = "There is no possible paging type defined in the aspect.";
-   private static final String WRONG_TYPE_CHOSEN = "The specified paging type %s is not possible for the given aspect.";
+   private static final String WRONG_TYPE_CHOSEN = "The specified paging type {} is not possible for the given aspect.";
 
    /**
     * Sets the paging properties for an aspect to a given ObjectNode.
@@ -59,11 +61,8 @@ class AspectModelPagingGenerator {
     * @param objectNode The ObjectNode where the properties shall be inserted.
     * @throws IOException In case, the root property file can't be loaded.
     */
-   public void setPagingProperties(
-         final Aspect aspect,
-         final PagingOption selectedPagingOption,
-         final ObjectNode objectNode ) throws IOException {
-
+   public void setPagingProperties( final Aspect aspect, final PagingOption selectedPagingOption, final ObjectNode objectNode )
+         throws IOException {
       final PagingOption resolved = resolvePagingOption( aspect, selectedPagingOption );
 
       if ( resolved == PagingOption.NO_PAGING ) {
@@ -74,7 +73,7 @@ class AspectModelPagingGenerator {
    }
 
    /**
-    * Sets the paging schema for an aspect to an given ObjectNode.
+    * Sets the paging schema for an aspect to a given ObjectNode.
     *
     * @param aspect The related aspect for the paging schema.
     * @param selectedPagingOption The selected paging option.
@@ -108,7 +107,7 @@ class AspectModelPagingGenerator {
       if ( selectedPagingOption == null ) {
          final PagingOption pagingOption = pickOneOfManyPagingOptions( possiblePagingOptions );
          if ( possiblePagingOptions.size() > 1 ) {
-            LOG.info( String.format( UNSPECIFIC_PAGING_TYPE, pagingOption ) );
+            LOG.info( UNSPECIFIC_PAGING_TYPE, pagingOption );
          }
          setSchemaInformation( aspect, pagingOption, schemaNode );
          return;
@@ -156,7 +155,7 @@ class AspectModelPagingGenerator {
       final ObjectNode node = (ObjectNode) getPathRootNode( resolved ).get( "response" );
       schemaNode.set( AspectModelOpenApiGenerator.FIELD_PAGING_SCHEMA, node );
 
-      final Property property = aspect.getProperties().get( 0 );
+      final Property property = aspect.getProperties().getFirst();
       final String propertyName = property.getName();
 
       final ObjectNode propertiesNode = (ObjectNode) node.get( "properties" );
@@ -195,7 +194,7 @@ class AspectModelPagingGenerator {
       if ( option == PagingOption.AUTO ) {
          final PagingOption resolved = pickOneOfManyPagingOptions( possiblePagingOptions );
          if ( possiblePagingOptions.size() > 1 ) {
-            LOG.info( String.format( UNSPECIFIC_PAGING_TYPE, resolved ) );
+            LOG.info( UNSPECIFIC_PAGING_TYPE, resolved );
          }
          return resolved;
       }
@@ -226,9 +225,8 @@ class AspectModelPagingGenerator {
 
       // If a concrete paging type was chosen, it must be supported by the aspect.
       if ( !possiblePagingOptions.contains( definedPagingOption ) ) {
-         final String errorMessage = String.format( WRONG_TYPE_CHOSEN, definedPagingOption );
-         LOG.error( errorMessage );
-         throw new IllegalArgumentException( errorMessage );
+         LOG.error( WRONG_TYPE_CHOSEN, definedPagingOption );
+         throw new IllegalArgumentException( WRONG_TYPE_CHOSEN.replace( "{}", definedPagingOption.toString() ) );
       }
    }
 

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaArtifact.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaArtifact.java
@@ -19,8 +19,8 @@ import java.util.Optional;
 
 import org.eclipse.esmf.aspectmodel.generator.AbstractSchemaArtifact;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * The result of generating an OpenAPI specification from an Aspect Model. The result can be

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/OpenApiSchemaGenerationConfig.java
@@ -20,8 +20,8 @@ import java.util.Locale;
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerationConfig;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.soabase.recordbuilder.core.RecordBuilder;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * A {@link GenerationConfig} for OpenAPI schema. Note that for providing additional properties, you

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
@@ -21,9 +21,8 @@ import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 class AspectModelAsyncApiGeneratorTest {
@@ -80,7 +79,7 @@ class AspectModelAsyncApiGeneratorTest {
    }
 
    @Test
-   void testAsyncApiGeneratorWithoutApplicationIdDoesNotAddEmptyId() throws JsonProcessingException {
+   void testAsyncApiGeneratorWithoutApplicationIdDoesNotAddEmptyId() {
       final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_EVENT ).aspect();
       final AsyncApiSchemaGenerationConfig config = AsyncApiSchemaGenerationConfigBuilder.builder()
             .useSemanticVersion( false )

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -101,11 +101,10 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.type.TypeFactory;
 
 class AspectModelJsonPayloadGeneratorTest {
    private static final String PACKAGE = "org.eclipse.esmf.test.generatedtestclasses";
@@ -140,8 +139,7 @@ class AspectModelJsonPayloadGeneratorTest {
          final String payload = new AspectModelJsonPayloadGenerator( aspect,
                AspectModelJsonPayloadGenerator.DEFAULT_CONFIG ).generateJson();
          assertThat( payload ).doesNotContain( "\"@type\"" );
-         final ObjectMapper mapper = objectMapper();
-         mapper.setTypeFactory( mapper.getTypeFactory().withClassLoader( compilationResult.classLoader() ) );
+         final ObjectMapper mapper = objectMapperWithTypeMapper( compilationResult.classLoader() );
          mapper.readValue( payload, aspectClass );
       } ).doesNotThrowAnyException();
    }
@@ -173,8 +171,7 @@ class AspectModelJsonPayloadGeneratorTest {
                .build();
          final String payload = new AspectModelJsonPayloadGenerator( aspect, jsonPayloadGenerationConfig ).generateJson();
          assertThat( payload ).contains( "\"@type\"" );
-         final ObjectMapper mapper = objectMapper();
-         mapper.setTypeFactory( mapper.getTypeFactory().withClassLoader( compilationResult.classLoader() ) );
+         final ObjectMapper mapper = objectMapperWithTypeMapper( compilationResult.classLoader() );
          mapper.readValue( payload, aspectClass );
       } ).doesNotThrowAnyException();
    }
@@ -192,7 +189,7 @@ class AspectModelJsonPayloadGeneratorTest {
    private JavaCompiler.CompilationResult compile( final Aspect aspect, final JavaCodeGenerationConfig config ) {
       final AspectModelJavaGenerator codeGenerator = new AspectModelJavaGenerator( aspect, config );
       final Map<QualifiedName, ByteArrayOutputStream> outputs = new LinkedHashMap<>();
-      codeGenerator.generate( name -> outputs.computeIfAbsent( name, name2 -> new ByteArrayOutputStream() ) );
+      codeGenerator.generate( name -> outputs.computeIfAbsent( name, _ -> new ByteArrayOutputStream() ) );
 
       final Map<QualifiedName, String> sources = new LinkedHashMap<>();
       final List<QualifiedName> loadOrder = new ArrayList<>();
@@ -218,21 +215,17 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithCollectionOfEntities() throws IOException {
+   void testGenerateJsonForAspectWithCollectionOfEntities() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_ENTITY_LIST );
-
       final AspectWithEntityCollection aspectWithEntityCollection = parseJson( generatedJson, AspectWithEntityCollection.class );
-
       assertThat( aspectWithEntityCollection.getTestList() ).hasSizeBetween( 1, 5 );
-
-      final TestEntityWithSimpleTypes testEntityWithSimpleTypes = aspectWithEntityCollection.getTestList().get( 0 );
-
+      final TestEntityWithSimpleTypes testEntityWithSimpleTypes = aspectWithEntityCollection.getTestList().getFirst();
       assertThat( generatedJson ).contains( "[" ).contains( "]" );
       assertTestEntityWithSimpleTypes( testEntityWithSimpleTypes );
    }
 
    @Test
-   void testGenerateJsonForAspectWithSimpleProperties() throws IOException {
+   void testGenerateJsonForAspectWithSimpleProperties() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES );
 
       final AspectWithSimpleProperties aspectWithSimpleProperties = parseJson( generatedJson, AspectWithSimpleProperties.class );
@@ -250,7 +243,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithStateType() throws IOException {
+   void testGenerateJsonForAspectWithStateType() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES_AND_STATE );
 
       final AspectWithSimpleTypesAndState aspectWithSimpleTypes = parseJson( generatedJson, AspectWithSimpleTypesAndState.class );
@@ -264,7 +257,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithEntity() throws IOException {
+   void testGenerateJsonForAspectWithEntity() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_ENTITY_WITH_MULTIPLE_PROPERTIES );
 
       final AspectWithEntity aspectWithEntity = parseJson( generatedJson, AspectWithEntity.class );
@@ -272,7 +265,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithRecursivePropertyWithOptional() throws IOException {
+   void testGenerateJsonForAspectWithRecursivePropertyWithOptional() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_RECURSIVE_PROPERTY_WITH_OPTIONAL );
       final AspectWithRecursivePropertyWithOptional aspectWithRecursivePropertyWithOptional = parseJson( generatedJson,
             AspectWithRecursivePropertyWithOptional.class );
@@ -280,7 +273,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithMultipleEntities() throws IOException {
+   void testGenerateJsonForAspectWithMultipleEntities() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_MULTIPLE_ENTITIES );
 
       final AspectWithMultipleEntities aspectWithMultipleEntities = parseJson( generatedJson, AspectWithMultipleEntities.class );
@@ -289,7 +282,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithNestedEntity() throws IOException {
+   void testGenerateJsonForAspectWithNestedEntity() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_NESTED_ENTITY );
 
       final AspectWithNestedEntity aspectWithNestedEntity = parseJson( generatedJson, AspectWithNestedEntity.class );
@@ -302,14 +295,14 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithMultipleCollectionsOfSimpleType() throws IOException {
+   void testGenerateJsonForAspectWithMultipleCollectionsOfSimpleType() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_MULTIPLE_COLLECTIONS_OF_SIMPLE_TYPE );
       parseJson( generatedJson, AspectWithMultipleCollectionsOfSimpleType.class );
       assertThat( generatedJson ).contains( "[" ).contains( "]" );
    }
 
    @Test
-   void testGenerateJsonForAspectWithCollectionOfSimpleType() throws IOException {
+   void testGenerateJsonForAspectWithCollectionOfSimpleType() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_COLLECTION_OF_SIMPLE_TYPE );
 
       final AspectWithCollectionOfSimpleType aspectWithCollectionOfSimpleType = parseJson( generatedJson,
@@ -320,7 +313,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithEitherType() throws IOException {
+   void testGenerateJsonForAspectWithEitherType() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_EITHER );
       final AspectWithEither aspectWithEither = parseJson( generatedJson, AspectWithEither.class );
       final Condition<AspectWithEither> isLeft = new Condition<>( x -> x.getEither().getLeft() != null, "left is present" );
@@ -342,13 +335,11 @@ class AspectModelJsonPayloadGeneratorTest {
                   .build() )
             .build();
 
-      assertThatCode( () -> {
-         generateJsonForModel( aspect );
-      } ).doesNotThrowAnyException();
+      assertThatCode( () -> generateJsonForModel( aspect ) ).doesNotThrowAnyException();
    }
 
    @Test
-   void testGenerateJsonForAspectWithComplexCollectionOfMinSize2AndExampleValue() throws IOException {
+   void testGenerateJsonForAspectWithComplexCollectionOfMinSize2AndExampleValue() {
       // We generate a payload for the set of entities, where the Entity's single property has an example
       // value and the set has a minimum size of 2. This means that the exampleValue may not be reused for
       // every entry.
@@ -363,7 +354,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithEnumHavingNestedEntities() throws IOException {
+   void testGenerateJsonForAspectWithEnumHavingNestedEntities() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_ENUM_HAVING_NESTED_ENTITIES );
 
       final AspectWithEnumHavingNestedEntities aspectWithEnum = parseJson( generatedJson, AspectWithEnumHavingNestedEntities.class );
@@ -376,7 +367,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithEntityEnumerationAndLangString() throws IOException {
+   void testGenerateJsonForAspectWithEntityEnumerationAndLangString() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_ENTITY_ENUMERATION_AND_LANG_STRING );
 
       final AspectWithEntityEnumerationAndLangString aspectWithEnum = parseJson( generatedJson,
@@ -386,7 +377,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithComplexEnum() throws IOException {
+   void testGenerateJsonForAspectWithComplexEnum() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_COMPLEX_ENUM );
 
       final AspectWithEnum aspectWithEnum = parseJson( generatedJson, AspectWithEnum.class );
@@ -397,7 +388,7 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    @Test
-   void testGenerateJsonForAspectWithComplextEntityCollectionEnum() throws IOException {
+   void testGenerateJsonForAspectWithComplextEntityCollectionEnum() {
       final String generatedJson = generateJsonForModel( TestAspect.ASPECT_WITH_COMPLEX_ENTITY_COLLECTION_ENUM );
 
       final AspectWithComplexEntityCollectionEnum aspectWithComplexEntityCollectionEnum = parseJson( generatedJson,
@@ -407,7 +398,7 @@ class AspectModelJsonPayloadGeneratorTest {
             .getEntityPropertyOne();
       assertThat( generatedJson ).contains( "[" ).contains( "]" );
       assertThat( myEntityTwoList ).hasSize( 1 );
-      assertThat( myEntityTwoList.get( 0 ).getEntityPropertyTwo() ).isEqualTo( "foo" );
+      assertThat( myEntityTwoList.getFirst().getEntityPropertyTwo() ).isEqualTo( "foo" );
    }
 
    @Test
@@ -433,10 +424,10 @@ class AspectModelJsonPayloadGeneratorTest {
       assertThat( aspectWithEntityCollection.getTestListOne() ).hasSizeBetween( 1, 5 );
       assertThat( aspectWithEntityCollection.getTestListTwo() ).hasSizeBetween( 1, 5 );
 
-      TestEntityWithSimpleTypes testEntityWithSimpleTypes = aspectWithEntityCollection.getTestListOne().get( 0 );
+      TestEntityWithSimpleTypes testEntityWithSimpleTypes = aspectWithEntityCollection.getTestListOne().getFirst();
       assertTestEntityWithSimpleTypes( testEntityWithSimpleTypes );
 
-      testEntityWithSimpleTypes = aspectWithEntityCollection.getTestListTwo().get( 0 );
+      testEntityWithSimpleTypes = aspectWithEntityCollection.getTestListTwo().getFirst();
       assertTestEntityWithSimpleTypes( testEntityWithSimpleTypes );
    }
 
@@ -595,9 +586,7 @@ class AspectModelJsonPayloadGeneratorTest {
       // Entries are pair-wise non-equal
       IntStream.range( 1, list.size() )
             .mapToObj( i -> Map.entry( list.get( i - 1 ), list.get( i ) ) )
-            .forEach( entry -> {
-               assertThat( entry.getKey() ).isNotEqualTo( entry.getValue() );
-            } );
+            .forEach( entry -> assertThat( entry.getKey() ).isNotEqualTo( entry.getValue() ) );
    }
 
    @Test
@@ -635,17 +624,24 @@ class AspectModelJsonPayloadGeneratorTest {
    }
 
    private ObjectMapper objectMapper() {
-      final ObjectMapper mapper = new ObjectMapper();
-      mapper.registerModule( new JavaTimeModule() );
-      mapper.registerModule( new Jdk8Module() );
-      mapper.registerModule( new AspectModelJacksonModule() );
-      mapper.configure( JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION, true );
-      mapper.configure( SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false );
-      mapper.configure( SerializationFeature.FAIL_ON_EMPTY_BEANS, false );
-      return mapper;
+      return JsonMapper.builder()
+            .addModule( new AspectModelJacksonModule() )
+            .configure( StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true )
+            .configure( tools.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
+            .build();
    }
 
-   private <T> T parseJson( final String json, final Class<T> targetClass ) throws IOException {
+   private ObjectMapper objectMapperWithTypeMapper( final ClassLoader typeMapper ) {
+      final TypeFactory defaultTypeFactory = JsonMapper.builder().build().getTypeFactory();
+      return JsonMapper.builder()
+            .addModule( new AspectModelJacksonModule() )
+            .configure( StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true )
+            .configure( tools.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
+            .typeFactory( defaultTypeFactory.withClassLoader( typeMapper ) )
+            .build();
+   }
+
+   private <T> T parseJson( final String json, final Class<T> targetClass ) {
       return objectMapper().readValue( json, targetClass );
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -104,7 +104,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import tools.jackson.core.StreamReadFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.type.TypeFactory;
 
 class AspectModelJsonPayloadGeneratorTest {
    private static final String PACKAGE = "org.eclipse.esmf.test.generatedtestclasses";
@@ -139,7 +138,10 @@ class AspectModelJsonPayloadGeneratorTest {
          final String payload = new AspectModelJsonPayloadGenerator( aspect,
                AspectModelJsonPayloadGenerator.DEFAULT_CONFIG ).generateJson();
          assertThat( payload ).doesNotContain( "\"@type\"" );
-         final ObjectMapper mapper = objectMapperWithTypeMapper( compilationResult.classLoader() );
+         final ObjectMapper mapper = objectMapper()
+               .rebuild()
+               .typeFactory( JsonMapper.builder().build().getTypeFactory().withClassLoader( compilationResult.classLoader() ) )
+               .build();
          mapper.readValue( payload, aspectClass );
       } ).doesNotThrowAnyException();
    }
@@ -171,7 +173,10 @@ class AspectModelJsonPayloadGeneratorTest {
                .build();
          final String payload = new AspectModelJsonPayloadGenerator( aspect, jsonPayloadGenerationConfig ).generateJson();
          assertThat( payload ).contains( "\"@type\"" );
-         final ObjectMapper mapper = objectMapperWithTypeMapper( compilationResult.classLoader() );
+         final ObjectMapper mapper = objectMapper()
+               .rebuild()
+               .typeFactory( JsonMapper.builder().build().getTypeFactory().withClassLoader( compilationResult.classLoader() ) )
+               .build();
          mapper.readValue( payload, aspectClass );
       } ).doesNotThrowAnyException();
    }
@@ -628,16 +633,6 @@ class AspectModelJsonPayloadGeneratorTest {
             .addModule( new AspectModelJacksonModule() )
             .configure( StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true )
             .configure( tools.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
-            .build();
-   }
-
-   private ObjectMapper objectMapperWithTypeMapper( final ClassLoader typeMapper ) {
-      final TypeFactory defaultTypeFactory = JsonMapper.builder().build().getTypeFactory();
-      return JsonMapper.builder()
-            .addModule( new AspectModelJacksonModule() )
-            .configure( StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION, true )
-            .configure( tools.jackson.databind.SerializationFeature.FAIL_ON_EMPTY_BEANS, false )
-            .typeFactory( defaultTypeFactory.withClassLoader( typeMapper ) )
             .build();
    }
 

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGeneratorTest.java
@@ -17,10 +17,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+
+import org.assertj.core.data.Percentage;
 
 import org.eclipse.esmf.aspectmodel.generator.json.AspectModelJsonPayloadGenerator;
 import org.eclipse.esmf.metamodel.Aspect;
@@ -29,13 +30,13 @@ import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestModel;
 import org.eclipse.esmf.test.TestResources;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
@@ -43,21 +44,31 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
-import org.assertj.core.data.Percentage;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 class AspectModelJsonSchemaGeneratorTest {
    private final ObjectMapper objectMapper = new ObjectMapper();
+   final com.fasterxml.jackson.databind.ObjectMapper legacyObjectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
    final Configuration config = Configuration.defaultConfiguration().addOptions( Option.SUPPRESS_EXCEPTIONS );
+
+   private com.fasterxml.jackson.databind.JsonNode toLegacyJsonNode( final JsonNode node ) {
+      final String jsonString = objectMapper.writeValueAsString( node );
+      try {
+         return legacyObjectMapper.readTree( jsonString );
+      } catch ( final JsonProcessingException exception ) {
+         throw new RuntimeException( exception );
+      }
+   }
 
    private JsonNode parseJson( final String json ) {
       try {
          return objectMapper.readTree( json );
-      } catch ( final JsonProcessingException e ) {
+      } catch ( final Exception e ) {
          e.printStackTrace();
          fail();
       }
@@ -68,7 +79,7 @@ class AspectModelJsonSchemaGeneratorTest {
       final ByteArrayOutputStream out = new ByteArrayOutputStream();
       try {
          objectMapper.writerWithDefaultPrettyPrinter().writeValue( out, node );
-      } catch ( final IOException e ) {
+      } catch ( final Exception e ) {
          e.printStackTrace();
          fail();
       }
@@ -91,8 +102,8 @@ class AspectModelJsonSchemaGeneratorTest {
    private JsonSchema parseSchema( final JsonNode jsonSchema ) {
       final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
       try {
-         return factory.getJsonSchema( jsonSchema );
-      } catch ( final ProcessingException e ) {
+         return factory.getJsonSchema( toLegacyJsonNode( jsonSchema ) );
+      } catch ( final Exception e ) {
          e.printStackTrace();
          fail();
       }
@@ -101,7 +112,7 @@ class AspectModelJsonSchemaGeneratorTest {
 
    private void assertPayloadIsValid( final JsonNode schema, final JsonNode payload ) {
       try {
-         final ProcessingReport report = parseSchema( schema ).validate( payload );
+         final ProcessingReport report = parseSchema( schema ).validate( toLegacyJsonNode( payload ) );
          if ( !report.isSuccess() ) {
             System.out.println( report );
          }

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -44,16 +43,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.google.common.collect.Streams;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
@@ -71,6 +60,16 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 class AspectModelOpenApiGeneratorTest {
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -84,6 +83,7 @@ class AspectModelOpenApiGeneratorTest {
          "$id", "patternProperties", "propertyNames" );
    private final Configuration config = Configuration.defaultConfiguration().addOptions( Option.SUPPRESS_EXCEPTIONS );
 
+   @SuppressWarnings( "checkstyle:LineLength" )
    @ParameterizedTest
    @Execution( ExecutionMode.CONCURRENT )
    @EnumSource( value = TestAspect.class )
@@ -98,25 +98,23 @@ class AspectModelOpenApiGeneratorTest {
       final JsonNode json = result.getContent();
       assertSpecificationIsValid( json, json.toString(), aspect );
       assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ) ).isNotNull();
-      assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asText() ).isEqualTo( aspect.urn().toString() );
+      assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asString() ).isEqualTo( aspect.urn().toString() );
 
       // Check that the map containing separate schema files contains the same information as the
       // all-in-one JSON document
       final Map<Path, JsonNode> jsonMap = result.getContentWithSeparateSchemasAsJson();
       assertThat( jsonMap ).containsKey( Path.of( aspect.getName() + ".oai.json" ) );
-      for ( final Iterator<Map.Entry<String, JsonNode>> it = json.get( "components" ).get( "schemas" ).fields(); it.hasNext(); ) {
-         final Map.Entry<String, JsonNode> schema = it.next();
+      for ( final Map.Entry<String, JsonNode> schema : json.get( "components" ).get( "schemas" ).properties() ) {
          final Path keyForSchemaName = Path.of( schema.getKey() + ".json" );
          assertThat( jsonMap ).containsKey( keyForSchemaName );
       }
       final JsonNode rootDocument = jsonMap.get( Path.of( aspect.getName() + ".oai.json" ) );
-      assertThat( Streams.stream( rootDocument.get( "components" ).fieldNames() ).toList() ).doesNotContain( "schemas" );
+      assertThat( rootDocument.get( "components" ).propertyNames() ).doesNotContain( "schemas" );
 
       // And the same thing for YAML format
       final Map<Path, String> yamlMap = result.getContentWithSeparateSchemasAsYaml();
       assertThat( yamlMap ).containsKey( Path.of( aspect.getName() + ".oai.yaml" ) );
-      for ( final Iterator<Map.Entry<String, JsonNode>> it = json.get( "components" ).get( "schemas" ).fields(); it.hasNext(); ) {
-         final Map.Entry<String, JsonNode> schema = it.next();
+      for ( final Map.Entry<String, JsonNode> schema : json.get( "components" ).get( "schemas" ).properties() ) {
          final Path keyForSchemaName = Path.of( schema.getKey() + ".yaml" );
          assertThat( yamlMap ).containsKey( keyForSchemaName );
       }
@@ -136,7 +134,7 @@ class AspectModelOpenApiGeneratorTest {
 
       assertThat( openApi.getInfo().getVersion() ).isEqualTo( "v1.0.0" );
       assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ) ).isNotNull();
-      assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asText() ).isEqualTo( aspect.urn().toString() );
+      assertThat( json.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asString() ).isEqualTo( aspect.urn().toString() );
 
       openApi.getServers().forEach( server -> assertThat( server.getUrl() ).contains( "v1.0.0" ) );
    }
@@ -333,8 +331,10 @@ class AspectModelOpenApiGeneratorTest {
    void testYamlGenerator() throws IOException {
       final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITHOUT_SEE_ATTRIBUTE ).aspect();
       final YAMLFactory yamlFactory = YAMLFactory.builder()
-            .stringQuotingChecker( new AbstractSchemaArtifact.OpenApiStringQuotingChecker() ).build();
-      final YAMLMapper yamlMapper = new YAMLMapper( yamlFactory ).enable( YAMLGenerator.Feature.MINIMIZE_QUOTES );
+            .stringQuotingChecker( new AbstractSchemaArtifact.OpenApiStringQuotingChecker() )
+            .enable( YAMLWriteFeature.MINIMIZE_QUOTES )
+            .build();
+      final YAMLMapper yamlMapper = new YAMLMapper( yamlFactory );
       final OpenApiSchemaGenerationConfig yamlConfig = OpenApiSchemaGenerationConfigBuilder.builder()
             .useSemanticVersion( true )
             .baseUrl( TEST_BASE_URL )
@@ -947,7 +947,7 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( openApi.getInfo().getVersion() ).isEqualTo( expectedApiVersion );
 
       assertThat( node.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ) ).isNotNull();
-      assertThat( node.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asText() ).isEqualTo( aspect.urn().toString() );
+      assertThat( node.get( "info" ).get( AspectModelJsonSchemaGenerator.SAMM_EXTENSION ).asString() ).isEqualTo( aspect.urn().toString() );
 
       assertThat( openApi.getServers() ).hasSize( 1 );
       assertThat( openApi.getServers().get( 0 ).getUrl() ).isEqualTo( TEST_BASE_URL + "/api/" + expectedApiVersion );
@@ -976,7 +976,7 @@ class AspectModelOpenApiGeneratorTest {
    private void validateReferences( final JsonNode rootNode ) {
       final List<JsonNode> nodes = rootNode.findValues( "$ref" ).stream().distinct().toList();
       nodes.forEach( node -> {
-         final String[] text = node.asText().split( "/" );
+         final String[] text = node.asString().split( "/" );
          final DocumentContext context = JsonPath.using( config ).parse( rootNode.toString() );
          final LinkedHashMap<String, Object> read = context
                .<LinkedHashMap<String, Object>>read( String.format( "$['%s']['%s']['%s']", text[1], text[2], text[3] ) );
@@ -999,9 +999,9 @@ class AspectModelOpenApiGeneratorTest {
    }
 
    private void validateUnsupportedKeywords( final JsonNode jsonNode ) throws IOException {
-      final JsonParser jsonParser = jsonNode.traverse();
+      final JsonParser jsonParser = jsonNode.traverse( ObjectReadContext.empty() );
       while ( !jsonParser.isClosed() ) {
-         if ( jsonParser.nextToken() == JsonToken.FIELD_NAME ) {
+         if ( jsonParser.nextToken() == JsonToken.PROPERTY_NAME ) {
             assertThat( jsonParser.currentName() ).isNotIn( UNSUPPORTED_KEYWORDS );
          }
       }

--- a/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporter.java
+++ b/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporter.java
@@ -74,6 +74,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.compress.utils.Lists;
+import org.apache.commons.lang3.StringUtils;
+
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.generator.Artifact;
 import org.eclipse.esmf.aspectmodel.generator.Generator;
@@ -102,14 +105,13 @@ import org.eclipse.esmf.metamodel.constraint.RangeConstraint;
 import org.eclipse.esmf.metamodel.constraint.RegularExpressionConstraint;
 import org.eclipse.esmf.metamodel.impl.DefaultCharacteristic;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.CaseFormat;
-import com.google.common.collect.Streams;
-import io.vavr.control.Try;
-import org.apache.commons.compress.utils.Lists;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.CaseFormat;
+
+import io.vavr.control.Try;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Base class for translators from JSON Schema to {@link StructureElement}s. For concrete usage, see
@@ -206,7 +208,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
     * @param <SELF> the builder's self type
     * @return the builder
     */
-   @SuppressWarnings( { "checkstyle:MethodTypeParameterName" } )
+   @SuppressWarnings( { "checkstyle:MethodTypeParameterName", "NewClassNamingConvention" } )
    //@formatter:off
    protected abstract <SELF extends SammBuilder.StructureElementBuilder<SELF, T>> SammBuilder.StructureElementBuilder<SELF, T>
          elementBuilder();
@@ -266,7 +268,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
     * @return the title
     */
    protected Optional<String> determinePreferredName( final JsonNode elementNode ) {
-      return jsonProperty( elementNode, TITLE ).map( JsonNode::asText );
+      return jsonProperty( elementNode, TITLE ).map( JsonNode::asString );
    }
 
    /**
@@ -302,7 +304,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
    protected Optional<String> determineDescription( final JsonNode node ) {
       return jsonProperty( node, DESCRIPTION )
             .or( () -> jsonProperty( node, $COMMENT ) )
-            .map( JsonNode::asText )
+            .map( JsonNode::asString )
             .or( this::todoComment );
    }
 
@@ -313,8 +315,8 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
     * @return which properties are required
     */
    protected Set<String> determineRequiredProperties( final JsonNode node ) {
-      return jsonProperty( node, REQUIRED ).map( required -> Streams.stream( required.elements() )
-            .map( JsonNode::asText )
+      return jsonProperty( node, REQUIRED ).map( required -> required.values().stream()
+            .map( JsonNode::asString )
             .collect( Collectors.toSet() ) ).orElse( Set.of() );
    }
 
@@ -323,7 +325,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       return jsonProperty( node, PROPERTIES )
             .or( () -> jsonProperty( node, $DEFS ) )
             .stream()
-            .flatMap( propertyNode -> Streams.stream( propertyNode.fields() ) )
+            .flatMap( propertyNode -> propertyNode.properties().stream() )
             .map( field -> buildProperty( field, determineRequiredProperties( node ), context ) )
             .toList();
    }
@@ -336,7 +338,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
    }
 
    protected Optional<RegularExpressionConstraint> buildRegularExpressionConstraint( final JsonNode propertyNode ) {
-      final String pattern = jsonProperty( propertyNode, PATTERN ).map( JsonNode::textValue ).orElse( null );
+      final String pattern = jsonProperty( propertyNode, PATTERN ).map( JsonNode::stringValue ).orElse( null );
       return pattern != null
             ? Optional.of( regularExpressionConstraint().value( pattern ).build() )
             : Optional.empty();
@@ -356,9 +358,9 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
 
    protected Optional<RangeConstraint> buildRangeConstraint( final JsonNode propertyNode, final Scalar type ) {
       final Optional<String> minimum = jsonProperty( propertyNode, MINIMUM )
-            .map( JsonNode::asText );
+            .map( JsonNode::asString );
       final Optional<String> maximum = jsonProperty( propertyNode, MAXIMUM )
-            .map( JsonNode::asText );
+            .map( JsonNode::asString );
       if ( minimum.isPresent() || maximum.isPresent() ) {
          final BoundDefinition lowerBound = jsonProperty( propertyNode, EXCLUSIVE_MINIMUM )
                .map( JsonNode::booleanValue )
@@ -380,7 +382,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
 
    protected Optional<JsonSchemaFormat> determineFormat( final JsonNode propertyNode ) {
       return jsonProperty( propertyNode, FORMAT )
-            .map( JsonNode::textValue )
+            .map( JsonNode::stringValue )
             .flatMap( formatString -> Try.of(
                   () -> JsonSchemaFormat.valueOf( formatString.toUpperCase().replace( "-", "_" ) ) )
                   .toJavaOptional() );
@@ -514,25 +516,25 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       }
 
       final Optional<String> jsonTypeName = jsonProperty( propertyNode, TYPE )
-            .map( JsonNode::asText )
+            .map( JsonNode::asString )
             .or( () -> Optional.ofNullable( context.type() ) );
 
       final Optional<Characteristic> either = jsonProperty( propertyNode, ONE_OF )
             .or( () -> jsonProperty( propertyNode, ANY_OF ) )
             .filter( JsonNode::isArray )
             .map( node -> {
-               final List<JsonNode> elements = Lists.newArrayList( node.elements() );
+               final List<JsonNode> elements = Lists.newArrayList( node.values().iterator() );
                // Check if this is a "oneOf [ { required: X }, { required: Y } ]" construct.
                // In this case build an Either of the Properties themselves.
                final boolean propertiesAreEitherElements = elements.stream().allMatch(
                      elementNode -> jsonProperty( elementNode, TYPE ).isEmpty() && jsonProperty( elementNode, REQUIRED ).isPresent() );
                final Optional<JsonNode> properties = jsonProperty( propertyNode, PROPERTIES );
                if ( propertiesAreEitherElements && properties.isPresent() ) {
-                  return buildEither( Streams.stream( properties.get().fields() ).toList(), context );
+                  return buildEither( properties.get().values().iterator(), context );
                }
 
                // It's not the case, therefore create an Either from the oneOf nodes.
-               return buildEither( node.elements(), jsonTypeName.map( context::withType ).orElse( context ) );
+               return buildEither( node.values().iterator(), jsonTypeName.map( context::withType ).orElse( context ) );
             } );
       if ( either.isPresent() && jsonTypeName.isEmpty() ) {
          return either.get();
@@ -540,7 +542,8 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
 
       if ( jsonTypeName.isEmpty() ) {
          if ( propertyNode.isArray() ) {
-            return buildCharacteristicForArraySchema( Lists.newArrayList( propertyNode.elements() ), context.withNoCharacteristicUrn() );
+            return buildCharacteristicForArraySchema( Lists.newArrayList( propertyNode.values().iterator() ),
+                  context.withNoCharacteristicUrn() );
          }
          throw new AspectModelBuildingException(
                "Property node for '" + context.propertyName() + "' is missing the required 'type' property, ignoring" );
@@ -570,7 +573,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       // Prevent infinite recursion: If the Property being referenced is already in the process of being
       // constructed,
       // return a forward reference instead.
-      final String reference = refNode.asText();
+      final String reference = refNode.asString();
       final Characteristic schemaCharacteristic = context.schemaCharacteristicsByPath().get( reference );
       final String characteristicName = StringUtils.capitalize( determineElementNameForSchema( reference ) ) + "Characteristic";
       final AspectModelUrn characteristicUrn = buildCharacteristicUrn( characteristicName );
@@ -597,7 +600,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       // No Characteristic exists yet for the referenced schema. Create one.
       final Collection<DefaultCharacteristicWrapper> forwardReferences = new ArrayList<>();
       context.schemaCharacteristicsInProgress().put( reference, forwardReferences );
-      final Characteristic result = buildCharacteristic( resolveRef( refNode.asText() ),
+      final Characteristic result = buildCharacteristic( resolveRef( refNode.asString() ),
             context.withCharacteristicUrn( characteristicUrn ) );
       // If this is the end of the recursion, update the forward references with the created
       // Characteristic
@@ -613,7 +616,8 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
 
    protected Characteristic buildCollection( final JsonNode propertyNode, final Context context ) {
       if ( propertyNode.isArray() ) {
-         return buildCharacteristicForArraySchema( Lists.newArrayList( propertyNode.elements() ), context.withNoCharacteristicUrn() );
+         return buildCharacteristicForArraySchema( Lists.newArrayList( propertyNode.values().iterator() ),
+               context.withNoCharacteristicUrn() );
       }
 
       final boolean uniqueItems = jsonProperty( propertyNode, UNIQUE_ITEMS )
@@ -623,7 +627,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       final Optional<JsonNode> oneOfOrAnyOf = jsonProperty( propertyNode, ONE_OF ).or( () -> jsonProperty( propertyNode, ANY_OF ) );
       final Characteristic elementCharacteristic;
       if ( items.isEmpty() && oneOfOrAnyOf.isPresent() ) {
-         elementCharacteristic = buildEither( oneOfOrAnyOf.get().elements(), context.withNoCharacteristicUrn() );
+         elementCharacteristic = buildEither( oneOfOrAnyOf.get().values().iterator(), context.withNoCharacteristicUrn() );
       } else if ( items.isPresent() ) {
          elementCharacteristic = buildCharacteristic( items.get(),
                context.withNoCharacteristicUrn().withPropertyName( context.propertyName() + "Element" ) );
@@ -658,13 +662,13 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
          final Context context ) {
       final Map<String, String> valueDescriptions = jsonProperty( propertyNode, META_ENUM )
             .stream()
-            .flatMap( node -> Streams.stream( node.fields() ) )
-            .map( entry -> Map.entry( entry.getKey(), entry.getValue().asText() ) )
+            .flatMap( node -> node.properties().stream() )
+            .map( entry -> Map.entry( entry.getKey(), entry.getValue().asString() ) )
             .collect( asMap() );
 
-      final List<ScalarValue> values = Streams.stream( enumNode.elements() )
+      final List<ScalarValue> values = enumNode.values().stream()
             .map( node -> {
-               final String enumValue = node.asText();
+               final String enumValue = node.asString();
                return value()
                      .description( valueDescriptions.get( enumValue ) )
                      .lexicalValue( enumValue )
@@ -712,10 +716,8 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
 
    protected JsonNode resolveRef( final String ref ) {
       // First check if a custom ref resolver is present. This is required for handling references to
-      // external files,
-      // because only the caller knows how to open/resolve those: They could be local files, or remote
-      // resources
-      // or something else.
+      // external files, because only the caller knows how to open/resolve those: They could be local
+      // files, or remote resources or something else.
       final Function<String, Optional<JsonNode>> customResolver = config.customRefResolver();
       if ( customResolver != null ) {
          final Optional<JsonNode> result = customResolver.apply( ref );
@@ -744,8 +746,8 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       // Anchor-based refs: #ElementName
       final String elementName = ref.substring( 1 );
       try {
-         return Streams.stream( root().get( $DEFS.key() ).elements() )
-               .filter( node -> node.get( $ANCHOR.key() ).asText().equals( elementName ) )
+         return root().get( $DEFS.key() ).values().stream()
+               .filter( node -> node.get( $ANCHOR.key() ).asString().equals( elementName ) )
                .findFirst()
                .orElseThrow();
       } catch ( final Exception exception ) {
@@ -788,7 +790,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       final Characteristic characteristic;
       final Optional<JsonNode> refNode = jsonProperty( propertyNode, $REF );
       if ( refNode.isPresent() ) {
-         final String reference = refNode.get().asText();
+         final String reference = refNode.get().asString();
          final JsonNode referencedNode = resolveRef( reference );
          if ( context.schemaCharacteristicsByNode().containsKey( referencedNode ) ) {
             characteristic = context.schemaCharacteristicsByNode().get( referencedNode );
@@ -809,10 +811,10 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
       final String preferredNameForThisElement = determinePreferredName( propertyNode, preliminaryPropertyName );
       final Optional<ScalarValue> exampleValueForThisElement = jsonProperty( propertyNode, EXAMPLES )
             .filter( JsonNode::isArray )
-            .flatMap( node -> Streams.stream( node.elements() ).findFirst() )
+            .flatMap( node -> node.values().stream().findFirst() )
             .flatMap( example -> characteristic.getDataType().isPresent()
                   && characteristic.getDataType().get() instanceof final Scalar scalar
-                        ? Optional.of( value( example.asText(), scalar ) )
+                        ? Optional.of( value( example.asString(), scalar ) )
                         : Optional.empty() );
 
       if ( previouslyGeneratedElement instanceof final Property previouslyGeneratedProperty ) {
@@ -856,7 +858,7 @@ public abstract class JsonSchemaImporter<T extends StructureElement, A extends A
    private Optional<JsonNode> findRefNodeInAllOf( final JsonNode propertyNode ) {
       return jsonProperty( propertyNode, ALL_OF )
             .filter( JsonNode::isArray )
-            .flatMap( allOf -> Streams.stream( allOf.elements() )
+            .flatMap( allOf -> allOf.values().stream()
                   .map( n -> n.get( "$ref" ) )
                   .filter( Objects::nonNull )
                   .findFirst() );

--- a/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporterConfig.java
+++ b/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporterConfig.java
@@ -19,8 +19,8 @@ import java.util.function.Function;
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import io.soabase.recordbuilder.core.RecordBuilder;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Configuration for the JSON Schema importer

--- a/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaToAspect.java
+++ b/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaToAspect.java
@@ -19,7 +19,7 @@ import org.eclipse.esmf.aspectmodel.generator.AspectArtifact;
 import org.eclipse.esmf.metamodel.Aspect;
 import org.eclipse.esmf.metamodel.builder.SammBuilder;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Generator that translates a JSON Schema into an {@link Aspect}

--- a/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaToEntity.java
+++ b/core/esmf-aspect-model-importers/src/main/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaToEntity.java
@@ -19,7 +19,7 @@ import org.eclipse.esmf.aspectmodel.generator.EntityArtifact;
 import org.eclipse.esmf.metamodel.Entity;
 import org.eclipse.esmf.metamodel.builder.SammBuilder;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Generator that translates a JSON Schema into an {@link Entity}

--- a/core/esmf-aspect-model-importers/src/test/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporterTest.java
+++ b/core/esmf-aspect-model-importers/src/test/java/org/eclipse/esmf/aspectmodel/importer/jsonschema/JsonSchemaImporterTest.java
@@ -36,6 +36,11 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDF;
+
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.RdfUtil;
 import org.eclipse.esmf.aspectmodel.generator.AspectArtifact;
@@ -61,18 +66,6 @@ import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestModel;
 import org.eclipse.esmf.test.TestResources;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
-import com.github.fge.jsonschema.main.JsonSchema;
-import com.github.fge.jsonschema.main.JsonSchemaFactory;
-import com.google.common.collect.Streams;
-import io.vavr.control.Either;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -82,11 +75,32 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import com.google.common.collect.Streams;
+
+import io.vavr.control.Either;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
 public class JsonSchemaImporterTest {
    private final AspectModelValidator validator = new AspectModelValidator();
    private static final String SCHEMAS_LOCATION = "schemas";
    final ObjectMapper objectMapper = new ObjectMapper();
+   final com.fasterxml.jackson.databind.ObjectMapper legacyObjectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
    final AspectModelUrn testUrn = AspectModelUrn.fromUrn( TestModel.TEST_NAMESPACE + "Test" );
+
+   private com.fasterxml.jackson.databind.JsonNode toLegacyJsonNode( final JsonNode node ) {
+      final String jsonString = objectMapper.writeValueAsString( node );
+      try {
+         return legacyObjectMapper.readTree( jsonString );
+      } catch ( final JsonProcessingException exception ) {
+         throw new RuntimeException( exception );
+      }
+   }
 
    private JsonNode generateJsonData( final Aspect aspect ) {
       try {
@@ -178,7 +192,7 @@ public class JsonSchemaImporterTest {
 
       final JsonNode jsonData = generateJsonData( importedAspect );
       try {
-         final ProcessingReport report = parseSchema( jsonSchema ).validate( jsonData );
+         final ProcessingReport report = parseSchema( jsonSchema ).validate( toLegacyJsonNode( jsonData ) );
          if ( !report.isSuccess() ) {
             System.out.println( report );
          }
@@ -433,7 +447,7 @@ public class JsonSchemaImporterTest {
    private JsonSchema parseSchema( final JsonNode jsonSchema ) {
       final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
       try {
-         return factory.getJsonSchema( jsonSchema );
+         return factory.getJsonSchema( toLegacyJsonNode( jsonSchema ) );
       } catch ( final ProcessingException e ) {
          e.printStackTrace();
          fail();
@@ -444,12 +458,7 @@ public class JsonSchemaImporterTest {
    @SuppressWarnings( "CallToPrintStackTrace" )
    private void showJson( final JsonNode node ) {
       final ByteArrayOutputStream out = new ByteArrayOutputStream();
-      try {
-         objectMapper.writerWithDefaultPrettyPrinter().writeValue( out, node );
-      } catch ( final IOException e ) {
-         e.printStackTrace();
-         fail();
-      }
+      objectMapper.writerWithDefaultPrettyPrinter().writeValue( out, node );
       System.out.println( out );
    }
 }

--- a/core/esmf-aspect-model-jackson/pom.xml
+++ b/core/esmf-aspect-model-jackson/pom.xml
@@ -34,20 +34,12 @@
          <artifactId>esmf-aspect-meta-model-java</artifactId>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>com.fasterxml.jackson.datatype</groupId>
-         <artifactId>jackson-datatype-jsr310</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>com.fasterxml.jackson.datatype</groupId>
-         <artifactId>jackson-datatype-jdk8</artifactId>
       </dependency>
       <dependency>
          <groupId>org.eclipse.esmf</groupId>

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModule.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModule.java
@@ -13,18 +13,21 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
+import java.io.Serial;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.esmf.metamodel.datatype.Curie;
 import org.eclipse.esmf.metamodel.datatype.LangString;
 
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
  * A Jackson module to register serializers and deserializers specific to Aspect models
  */
 public class AspectModelJacksonModule extends SimpleModule {
-   private static final long serialVersionUID = -2621996753536054906L;
+   @Serial
+   private static final long serialVersionUID = -2621996753536054907L;
 
    public AspectModelJacksonModule() {
       addSerializer( XMLGregorianCalendar.class, XmlGregorianCalendarSerializer.INSTANCE );

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinaryDeserializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinaryDeserializer.java
@@ -13,30 +13,22 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-import java.io.Serial;
 import java.util.Optional;
 
 import org.eclipse.esmf.metamodel.datatype.SammType;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonTokenId;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class Base64BinaryDeserializer extends StdDeserializer<byte[]> {
-   @Serial
-   private static final long serialVersionUID = 6637893688907290484L;
+public class Base64BinaryDeserializer extends ValueDeserializer<byte[]> {
    public static final Base64BinaryDeserializer INSTANCE = new Base64BinaryDeserializer();
 
-   private Base64BinaryDeserializer() {
-      super( byte[].class );
-   }
-
    @Override
-   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) throws IOException {
+   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) {
       if ( parser.currentTokenId() == JsonTokenId.ID_STRING ) {
-         final Optional<byte[]> value = SammType.BASE64_BINARY.parseTyped( parser.getText() );
+         final Optional<byte[]> value = SammType.BASE64_BINARY.parseTyped( parser.getString() );
          if ( value.isPresent() ) {
             return value.get();
          }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinarySerializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinarySerializer.java
@@ -13,25 +13,18 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-
 import org.eclipse.esmf.metamodel.datatype.SammType;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class Base64BinarySerializer extends StdSerializer<byte[]> {
-   private static final long serialVersionUID = 2028371627433200656L;
+public class Base64BinarySerializer extends ValueSerializer<byte[]> {
    public static final Base64BinarySerializer INSTANCE = new Base64BinarySerializer();
 
-   private Base64BinarySerializer() {
-      super( byte[].class );
-   }
-
    @Override
-   public void serialize( final byte[] value, final JsonGenerator generator, final SerializerProvider provider )
-         throws IOException {
+   public void serialize( final byte[] value, final JsonGenerator generator, final SerializationContext context ) throws JacksonException {
       generator.writeString( SammType.BASE64_BINARY.serialize( value ) );
    }
 }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/CurieDeserializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/CurieDeserializer.java
@@ -13,32 +13,24 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-import java.io.Serial;
 import java.util.Optional;
 
 import org.eclipse.esmf.metamodel.datatype.Curie;
 import org.eclipse.esmf.metamodel.datatype.CurieType;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonTokenId;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class CurieDeserializer extends StdDeserializer<Curie> {
-   @Serial
-   private static final long serialVersionUID = 1285377288430239636L;
+public class CurieDeserializer extends ValueDeserializer<Curie> {
    public static final CurieDeserializer INSTANCE = new CurieDeserializer();
 
-   private CurieDeserializer() {
-      super( Curie.class );
-   }
-
    @Override
-   public Curie deserialize( final JsonParser parser, final DeserializationContext context ) throws IOException, JacksonException {
+   public Curie deserialize( final JsonParser parser, final DeserializationContext context ) throws JacksonException {
       if ( parser.currentTokenId() == JsonTokenId.ID_STRING ) {
-         final Optional<Curie> value = CurieType.INSTANCE.parseTyped( parser.getText() );
+         final Optional<Curie> value = CurieType.INSTANCE.parseTyped( parser.getString() );
          if ( value.isPresent() ) {
             return value.get();
          }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/CurieSerializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/CurieSerializer.java
@@ -13,27 +13,19 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-import java.io.Serial;
-
 import org.eclipse.esmf.metamodel.datatype.Curie;
 import org.eclipse.esmf.metamodel.datatype.CurieType;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class CurieSerializer extends StdSerializer<Curie> {
-   @Serial
-   private static final long serialVersionUID = -6772194217411185019L;
+public class CurieSerializer extends ValueSerializer<Curie> {
    public static final CurieSerializer INSTANCE = new CurieSerializer();
 
-   private CurieSerializer() {
-      super( Curie.class );
-   }
-
    @Override
-   public void serialize( final Curie value, final JsonGenerator generator, final SerializerProvider provider ) throws IOException {
+   public void serialize( final Curie value, final JsonGenerator generator, final SerializationContext context ) throws JacksonException {
       generator.writeString( CurieType.INSTANCE.serialize( value ) );
    }
 }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/HexBinaryDeserializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/HexBinaryDeserializer.java
@@ -13,30 +13,22 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-import java.io.Serial;
 import java.util.Optional;
 
 import org.eclipse.esmf.metamodel.datatype.SammType;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonTokenId;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
-public class HexBinaryDeserializer extends StdDeserializer<byte[]> {
-   @Serial
-   private static final long serialVersionUID = 8408540591452927413L;
+public class HexBinaryDeserializer extends ValueDeserializer<byte[]> {
    public static final HexBinaryDeserializer INSTANCE = new HexBinaryDeserializer();
 
-   private HexBinaryDeserializer() {
-      super( byte[].class );
-   }
-
    @Override
-   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) throws IOException {
+   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) {
       if ( parser.currentTokenId() == JsonTokenId.ID_STRING ) {
-         final Optional<byte[]> value = SammType.HEX_BINARY.parseTyped( parser.getText() );
+         final Optional<byte[]> value = SammType.HEX_BINARY.parseTyped( parser.getString() );
          if ( value.isPresent() ) {
             return value.get();
          }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/HexBinarySerializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/HexBinarySerializer.java
@@ -13,25 +13,18 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-
 import org.eclipse.esmf.metamodel.datatype.SammType;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class HexBinarySerializer extends StdSerializer<byte[]> {
-   private static final long serialVersionUID = 6817718561520140283L;
+public class HexBinarySerializer extends ValueSerializer<byte[]> {
    public static final HexBinarySerializer INSTANCE = new HexBinarySerializer();
 
-   private HexBinarySerializer() {
-      super( byte[].class );
-   }
-
    @Override
-   public void serialize( final byte[] value, final JsonGenerator generator, final SerializerProvider provider )
-         throws IOException {
+   public void serialize( final byte[] value, final JsonGenerator generator, final SerializationContext context ) throws JacksonException {
       generator.writeString( SammType.HEX_BINARY.serialize( value ) );
    }
 }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/LangStringDeserializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/LangStringDeserializer.java
@@ -13,27 +13,25 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
 import java.util.Locale;
 
 import org.eclipse.esmf.metamodel.datatype.LangString;
 
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-public class LangStringDeserializer extends StdNodeBasedDeserializer<LangString> {
-   private static final long serialVersionUID = 8007942189722606011L;
+public class LangStringDeserializer extends ValueDeserializer<LangString> {
    public static final LangStringDeserializer INSTANCE = new LangStringDeserializer();
 
-   private LangStringDeserializer() {
-      super( LangString.class );
-   }
-
    @Override
-   public LangString convert( final JsonNode root, final DeserializationContext ctxt ) throws IOException {
-      final String key = root.fieldNames().next();
-      final Locale languageTag = Locale.forLanguageTag( key );
-      return new LangString( root.get( key ).asText(), languageTag );
+   public LangString deserialize( final JsonParser parser, final DeserializationContext context ) throws JacksonException {
+      final JsonNode node = parser.readValueAsTree();
+      final String languageTag = node.properties().iterator().next().getKey();
+      final Locale locale = Locale.forLanguageTag( languageTag );
+      final String text = node.get( languageTag ).asString();
+      return new LangString( text, locale );
    }
 }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/LangStringSerializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/LangStringSerializer.java
@@ -13,26 +13,21 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-
 import org.eclipse.esmf.metamodel.datatype.LangString;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class LangStringSerializer extends StdSerializer<LangString> {
-   private static final long serialVersionUID = 963449916984100611L;
+public class LangStringSerializer extends ValueSerializer<LangString> {
    public static final LangStringSerializer INSTANCE = new LangStringSerializer();
 
-   private LangStringSerializer() {
-      super( LangString.class );
-   }
-
    @Override
-   public void serialize( final LangString value, final JsonGenerator generator, final SerializerProvider provider ) throws IOException {
+   public void serialize( final LangString value, final JsonGenerator generator, final SerializationContext context )
+         throws JacksonException {
       generator.writeStartObject();
-      generator.writeStringField( value.getLanguageTag().toLanguageTag(), value.getValue() );
+      generator.writeStringProperty( value.getLanguageTag().toLanguageTag(), value.getValue() );
       generator.writeEndObject();
    }
 }

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/XmlGregorianCalendarDeserializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/XmlGregorianCalendarDeserializer.java
@@ -13,26 +13,22 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
-import java.io.Serial;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
-import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonTokenId;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * Jackson deserializer for {@see XMLGregorianCalendar}.
  */
-public class XmlGregorianCalendarDeserializer extends StdScalarDeserializer<XMLGregorianCalendar> {
-   @Serial
-   private static final long serialVersionUID = 8911315963918963886L;
+public class XmlGregorianCalendarDeserializer extends ValueDeserializer<XMLGregorianCalendar> {
    private static final Logger LOG = LoggerFactory.getLogger( XmlGregorianCalendarDeserializer.class );
    public static final XmlGregorianCalendarDeserializer INSTANCE = new XmlGregorianCalendarDeserializer();
 
@@ -40,19 +36,18 @@ public class XmlGregorianCalendarDeserializer extends StdScalarDeserializer<XMLG
 
    @SuppressWarnings( "squid:S2139" ) // Must throw runtime exception to fail fast
    private XmlGregorianCalendarDeserializer() {
-      super( XMLGregorianCalendar.class );
       try {
          datatypeFactory = DatatypeFactory.newInstance();
       } catch ( final DatatypeConfigurationException exception ) {
          LOG.error( "Could not instantiate DatatypeFactory", exception );
-         throw new RuntimeJsonMappingException( exception.getMessage() );
+         throw new RuntimeException( exception.getMessage() );
       }
    }
 
    @Override
-   public XMLGregorianCalendar deserialize( final JsonParser parser, final DeserializationContext context ) throws IOException {
+   public XMLGregorianCalendar deserialize( final JsonParser parser, final DeserializationContext context ) {
       if ( parser.currentTokenId() == JsonTokenId.ID_STRING ) {
-         return datatypeFactory.newXMLGregorianCalendar( parser.getText().trim() );
+         return datatypeFactory.newXMLGregorianCalendar( parser.getString().trim() );
       }
 
       return (XMLGregorianCalendar) context.handleUnexpectedToken( XMLGregorianCalendar.class, parser );

--- a/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/XmlGregorianCalendarSerializer.java
+++ b/core/esmf-aspect-model-jackson/src/main/java/org/eclipse/esmf/aspectmodel/jackson/XmlGregorianCalendarSerializer.java
@@ -13,27 +13,22 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import java.io.IOException;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /**
  * Jackson serializer for {@see XMLGregorianCalendar}
  */
-class XmlGregorianCalendarSerializer extends StdSerializer<XMLGregorianCalendar> {
-   private static final long serialVersionUID = -7121579663349330794L;
+public class XmlGregorianCalendarSerializer extends ValueSerializer<XMLGregorianCalendar> {
    public static final XmlGregorianCalendarSerializer INSTANCE = new XmlGregorianCalendarSerializer();
 
-   private XmlGregorianCalendarSerializer() {
-      super( XMLGregorianCalendar.class );
-   }
-
    @Override
-   public void serialize( final XMLGregorianCalendar value, final JsonGenerator generator,
-         final SerializerProvider serializers ) throws IOException {
+   public void serialize( final XMLGregorianCalendar value, final JsonGenerator generator, final SerializationContext context )
+         throws JacksonException {
       generator.writeString( value.toXMLFormat() );
    }
 }

--- a/core/esmf-aspect-model-jackson/src/test/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModuleTest.java
+++ b/core/esmf-aspect-model-jackson/src/test/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModuleTest.java
@@ -60,6 +60,9 @@ import tools.jackson.databind.json.JsonMapper;
 
 class AspectModelJacksonModuleTest {
    private static final String PACKAGE = "org.eclipse.esmf.test";
+   final ObjectMapper mapper = JsonMapper.builder()
+         .addModule( new AspectModelJacksonModule() )
+         .build();
 
    @Test
    void testAspectWithMultiLanguageText() throws Exception {
@@ -282,9 +285,6 @@ class AspectModelJacksonModuleTest {
    }
 
    private <T> T parseJson( final String json, final Class<T> targetClass ) {
-      final ObjectMapper mapper = JsonMapper.builder()
-            .addModule( new AspectModelJacksonModule() )
-            .build();
       try {
          return mapper.readValue( json, targetClass );
       } catch ( final JacksonException exception ) {

--- a/core/esmf-aspect-model-jackson/src/test/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModuleTest.java
+++ b/core/esmf-aspect-model-jackson/src/test/java/org/eclipse/esmf/aspectmodel/jackson/AspectModelJacksonModuleTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.esmf.aspectmodel.java.JavaCodeGenerationConfig;
@@ -46,16 +47,16 @@ import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
 import org.eclipse.esmf.test.shared.compiler.JavaCompiler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
 import com.google.common.io.Resources;
 import com.google.common.reflect.TypeToken;
+
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
-import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 class AspectModelJacksonModuleTest {
    private static final String PACKAGE = "org.eclipse.esmf.test";
@@ -263,7 +264,7 @@ class AspectModelJacksonModuleTest {
             .build();
       final AspectModelJavaGenerator codeGenerator = new AspectModelJavaGenerator( aspect, config );
       final Map<QualifiedName, ByteArrayOutputStream> outputs = new LinkedHashMap<>();
-      codeGenerator.generate( name -> outputs.computeIfAbsent( name, name2 -> new ByteArrayOutputStream() ) );
+      codeGenerator.generate( name -> outputs.computeIfAbsent( name, _ -> new ByteArrayOutputStream() ) );
 
       final Map<QualifiedName, String> sources = new LinkedHashMap<>();
       final List<QualifiedName> loadOrder = new ArrayList<>();
@@ -281,14 +282,12 @@ class AspectModelJacksonModuleTest {
    }
 
    private <T> T parseJson( final String json, final Class<T> targetClass ) {
-      final ObjectMapper mapper = new ObjectMapper();
-      mapper.registerModule( new JavaTimeModule() );
-      mapper.registerModule( new Jdk8Module() );
-      mapper.registerModule( new AspectModelJacksonModule() );
-      mapper.configure( SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false );
+      final ObjectMapper mapper = JsonMapper.builder()
+            .addModule( new AspectModelJacksonModule() )
+            .build();
       try {
          return mapper.readValue( json, targetClass );
-      } catch ( final JsonProcessingException exception ) {
+      } catch ( final JacksonException exception ) {
          throw new EnumAttributeNotFoundException( exception );
       }
    }

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/pojo/StructureElementJavaArtifactGenerator.java
@@ -20,10 +20,17 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
+
 import javax.annotation.processing.Generated;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.XSD;
+import org.apache.velocity.app.FieldMethodizer;
+import org.apache.velocity.runtime.RuntimeConstants;
 
 import org.eclipse.esmf.aspectmodel.generator.ArtifactGenerator;
 import org.eclipse.esmf.aspectmodel.generator.TemplateEngine;
@@ -44,19 +51,16 @@ import org.eclipse.esmf.metamodel.impl.DefaultScalar;
 import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
 import org.eclipse.esmf.samm.KnownVersion;
 
+import org.jboss.forge.roaster.Roaster;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.XSD;
-import org.apache.velocity.app.FieldMethodizer;
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.jboss.forge.roaster.Roaster;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 /**
  * A {@link ArtifactGenerator} that generates Java Pojo code for {@link StructureElement}s

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinaryDeserializer.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinaryDeserializer.java
@@ -13,18 +13,19 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 /*
  * Dummy Class - this exists only here to be present in the classpath during compilation tests.
  * A dependency to the module containing the real class (esmf-aspect-model-jackson) can not be
  * added due to cyclic dependencies.
  */
-public class Base64BinaryDeserializer extends JsonDeserializer<byte[]> {
+public class Base64BinaryDeserializer extends ValueDeserializer<byte[]> {
    @Override
-   public byte[] deserialize( final JsonParser p, final DeserializationContext ctxt ) {
+   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) throws JacksonException {
       throw new UnsupportedOperationException( "This is a dummy class only intended for tests" );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinarySerializer.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Base64BinarySerializer.java
@@ -13,18 +13,19 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /*
  * Dummy Class - this exists only here to be present in the classpath during compilation tests.
  * A dependency to the module containing the real class (esmf-aspect-model-jackson) can not be
  * added due to cyclic dependencies.
  */
-public class Base64BinarySerializer extends JsonSerializer<byte[]> {
+public class Base64BinarySerializer extends ValueSerializer<byte[]> {
    @Override
-   public void serialize( final byte[] value, final JsonGenerator gen, final SerializerProvider serializers ) {
+   public void serialize( final byte[] value, final JsonGenerator generator, final SerializationContext context ) throws JacksonException {
       throw new UnsupportedOperationException( "This is a dummy class only intended for tests" );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Either.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/Either.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * added due to cyclic dependencies.
  */
 public class Either<L, R> {
-
    private final Optional<L> left;
    private final Optional<R> right;
 

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/HexBinaryDeserializer.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/HexBinaryDeserializer.java
@@ -13,18 +13,18 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 /*
  * Dummy Class - this exists only here to be present in the classpath during compilation tests.
  * A dependency to the module containing the real class (esmf-aspect-model-jackson) can not be
  * added due to cyclic dependencies.
  */
-public class HexBinaryDeserializer extends JsonDeserializer<byte[]> {
+public class HexBinaryDeserializer extends ValueDeserializer<byte[]> {
    @Override
-   public byte[] deserialize( final JsonParser p, final DeserializationContext ctxt ) {
+   public byte[] deserialize( final JsonParser parser, final DeserializationContext context ) {
       throw new UnsupportedOperationException( "This is a dummy class only intended for tests" );
    }
 }

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/HexBinarySerializer.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/jackson/HexBinarySerializer.java
@@ -13,18 +13,19 @@
 
 package org.eclipse.esmf.aspectmodel.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /*
  * Dummy Class - this exists only here to be present in the classpath during compilation tests.
  * A dependency to the module containing the real class (esmf-aspect-model-jackson) can not be
  * added due to cyclic dependencies.
  */
-public class HexBinarySerializer extends JsonSerializer<byte[]> {
+public class HexBinarySerializer extends ValueSerializer<byte[]> {
    @Override
-   public void serialize( final byte[] value, final JsonGenerator gen, final SerializerProvider serializers ) {
+   public void serialize( final byte[] value, final JsonGenerator generator, final SerializationContext context ) throws JacksonException {
       throw new UnsupportedOperationException( "This is a dummy class only intended for tests" );
    }
 }

--- a/core/esmf-aspect-model-urn/pom.xml
+++ b/core/esmf-aspect-model-urn/pom.xml
@@ -62,12 +62,12 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-core</artifactId>
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
          <scope>test</scope>
       </dependency>

--- a/core/esmf-aspect-model-urn/src/test/java/org/eclipse/esmf/aspectmodel/urn/AspectModelUrnJsonTest.java
+++ b/core/esmf-aspect-model-urn/src/test/java/org/eclipse/esmf/aspectmodel/urn/AspectModelUrnJsonTest.java
@@ -18,10 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tools.jackson.databind.ObjectMapper;
 
 public class AspectModelUrnJsonTest {
    private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -33,7 +34,7 @@ public class AspectModelUrnJsonTest {
          + ".samm:aspect-model:Aspect:1.0.0\"}";
 
    @Test
-   public void serializeToJson() throws JsonProcessingException {
+   public void serializeToJson() {
       assertThat( MAPPER.writeValueAsString( TEST_MODEL ) )
             .isEqualTo( TEST_MODEL_JSON );
    }

--- a/core/esmf-test-resources/pom.xml
+++ b/core/esmf-test-resources/pom.xml
@@ -38,7 +38,7 @@
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
       </dependency>
       <dependency>

--- a/core/esmf-test-resources/src/main/java/org/eclipse/esmf/test/TestResources.java
+++ b/core/esmf-test-resources/src/main/java/org/eclipse/esmf/test/TestResources.java
@@ -26,11 +26,11 @@ import org.eclipse.esmf.aspectmodel.validation.Validator;
 import org.eclipse.esmf.metamodel.AspectModel;
 import org.eclipse.esmf.samm.KnownVersion;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class TestResources {
    public record IdentifiedInputStream(

--- a/core/esmf-tree-sitter-turtle/pom.xml
+++ b/core/esmf-tree-sitter-turtle/pom.xml
@@ -72,7 +72,7 @@
          <scope>compile</scope>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
          <scope>compile</scope>
       </dependency>

--- a/core/esmf-tree-sitter-turtle/src-buildtime/main/java/org/eclipse/esmf/buildtime/GenerateParserTokenType.java
+++ b/core/esmf-tree-sitter-turtle/src-buildtime/main/java/org/eclipse/esmf/buildtime/GenerateParserTokenType.java
@@ -23,9 +23,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Streams;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class GenerateParserTokenType extends BuildTimeTool {
    private static final String CLASS_NAME = "ParserTokenType";
@@ -84,8 +83,8 @@ public class GenerateParserTokenType extends BuildTimeTool {
 
    private Stream<String> getNodeTypes( final JsonNode node ) {
       return node.isArray()
-            ? Streams.stream( node.elements() ).flatMap( this::getNodeTypes )
-            : Optional.ofNullable( node.get( "type" ) ).map( JsonNode::asText ).stream();
+            ? node.values().stream().flatMap( this::getNodeTypes )
+            : Optional.ofNullable( node.get( "type" ) ).map( JsonNode::asString ).stream();
    }
 
    static void main( final String[] args ) {

--- a/documentation/developer-guide/modules/tooling-guide/examples/GenerateAsyncApi.java
+++ b/documentation/developer-guide/modules/tooling-guide/examples/GenerateAsyncApi.java
@@ -20,7 +20,7 @@ import org.eclipse.esmf.aspectmodel.generator.asyncapi.AsyncApiSchemaGenerationC
 import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.metamodel.AspectModel;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 // end::imports[]
 
 import java.io.File;

--- a/documentation/developer-guide/modules/tooling-guide/examples/GenerateJsonSchema.java
+++ b/documentation/developer-guide/modules/tooling-guide/examples/GenerateJsonSchema.java
@@ -21,7 +21,7 @@ import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.metamodel.AspectModel;
 
 import java.util.Locale;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 // end::imports[]
 import java.io.File;
 import java.io.IOException;

--- a/documentation/developer-guide/modules/tooling-guide/examples/GenerateOpenApi.java
+++ b/documentation/developer-guide/modules/tooling-guide/examples/GenerateOpenApi.java
@@ -21,11 +21,10 @@ import org.eclipse.esmf.aspectmodel.generator.openapi.PagingOption;
 import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.metamodel.AspectModel;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 // end::imports[]
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 public class GenerateOpenApi {
    @Test
-   public void generateYaml() throws JsonProcessingException {
+   public void generateYaml() {
       // tag::generateYaml[]
       // AspectModel as returned by the AspectModelLoader
       final AspectModel aspectModel = // ...
@@ -125,7 +124,7 @@ public class GenerateOpenApi {
       // end::generateJson[]
    }
 
-   private static ObjectNode readYaml( String content ) throws JsonProcessingException {
+   private static ObjectNode readYaml( String content ) {
       return (ObjectNode) new YAMLMapper().readTree( content );
    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
    <parent>
       <groupId>org.eclipse.esmf</groupId>
       <artifactId>esmf-parent</artifactId>
-      <version>25</version>
+      <version>27</version>
    </parent>
 
    <artifactId>esmf-sdk-parent</artifactId>

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/AspectModelMojo.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/AspectModelMojo.java
@@ -33,28 +33,6 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 
-import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
-import org.eclipse.esmf.aspectmodel.resolver.FileSystemStrategy;
-import org.eclipse.esmf.aspectmodel.resolver.GithubRepository;
-import org.eclipse.esmf.util.download.ProxyConfig;
-import org.eclipse.esmf.aspectmodel.resolver.ResolutionStrategy;
-import org.eclipse.esmf.aspectmodel.resolver.github.GitHubStrategy;
-import org.eclipse.esmf.aspectmodel.resolver.github.GithubModelSourceConfig;
-import org.eclipse.esmf.aspectmodel.resolver.github.GithubModelSourceConfigBuilder;
-import org.eclipse.esmf.aspectmodel.shacl.violation.Violation;
-import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
-import org.eclipse.esmf.aspectmodel.validation.services.AspectModelValidator;
-import org.eclipse.esmf.aspectmodel.validation.services.DetailedViolationFormatter;
-import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
-import org.eclipse.esmf.metamodel.Aspect;
-import org.eclipse.esmf.metamodel.AspectModel;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import io.vavr.control.Either;
-import io.vavr.control.Try;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -67,8 +45,33 @@ import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
+import org.eclipse.esmf.aspectmodel.resolver.FileSystemStrategy;
+import org.eclipse.esmf.aspectmodel.resolver.GithubRepository;
+import org.eclipse.esmf.aspectmodel.resolver.ResolutionStrategy;
+import org.eclipse.esmf.aspectmodel.resolver.github.GitHubStrategy;
+import org.eclipse.esmf.aspectmodel.resolver.github.GithubModelSourceConfig;
+import org.eclipse.esmf.aspectmodel.resolver.github.GithubModelSourceConfigBuilder;
+import org.eclipse.esmf.aspectmodel.shacl.violation.Violation;
+import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
+import org.eclipse.esmf.aspectmodel.validation.services.AspectModelValidator;
+import org.eclipse.esmf.aspectmodel.validation.services.DetailedViolationFormatter;
+import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
+import org.eclipse.esmf.metamodel.Aspect;
+import org.eclipse.esmf.metamodel.AspectModel;
+import org.eclipse.esmf.util.download.ProxyConfig;
+
+import io.vavr.control.Either;
+import io.vavr.control.Try;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
+
 public abstract class AspectModelMojo extends AbstractMojo {
-   protected static final ObjectMapper YAML_MAPPER = new YAMLMapper().enable( YAMLGenerator.Feature.MINIMIZE_QUOTES );
+   protected static final ObjectMapper YAML_MAPPER =
+         new YAMLMapper( YAMLFactory.builder().enable( YAMLWriteFeature.MINIMIZE_QUOTES ).build() );
    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
    @Parameter

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateAsyncApiSpec.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateAsyncApiSpec.java
@@ -22,32 +22,35 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
 import org.eclipse.esmf.aspectmodel.generator.asyncapi.AspectModelAsyncApiGenerator;
 import org.eclipse.esmf.aspectmodel.generator.asyncapi.AsyncApiSchemaArtifact;
 import org.eclipse.esmf.aspectmodel.generator.asyncapi.AsyncApiSchemaGenerationConfig;
 import org.eclipse.esmf.aspectmodel.generator.asyncapi.AsyncApiSchemaGenerationConfigBuilder;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import io.vavr.control.Try;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.vavr.control.Try;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 @Mojo( name = GenerateAsyncApiSpec.MAVEN_GOAL,
    defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class GenerateAsyncApiSpec extends AspectModelMojo {
    public static final String MAVEN_GOAL = "generateAsyncApiSpec";
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-   private static final ObjectMapper YAML_MAPPER = new YAMLMapper().enable( YAMLGenerator.Feature.MINIMIZE_QUOTES );
+   private static final ObjectMapper YAML_MAPPER =
+         new YAMLMapper( YAMLFactory.builder().enable( YAMLWriteFeature.MINIMIZE_QUOTES ).build() );
    private static final Logger LOG = LoggerFactory.getLogger( GenerateAsyncApiSpec.class );
 
    @Parameter( required = true )
@@ -130,7 +133,7 @@ public class GenerateAsyncApiSpec extends AspectModelMojo {
    private String jsonToYaml( final JsonNode json ) {
       try {
          return YAML_MAPPER.writeValueAsString( json );
-      } catch ( final JsonProcessingException exception ) {
+      } catch ( final Exception exception ) {
          LOG.error( "JSON could not be converted to YAML", exception );
          return json.toString();
       }

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonSchema.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonSchema.java
@@ -24,8 +24,8 @@ import org.eclipse.esmf.aspectmodel.generator.jsonschema.JsonSchemaGenerationCon
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.JsonSchemaGenerationConfigBuilder;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpec.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateOpenApiSpec.java
@@ -30,7 +30,7 @@ import org.eclipse.esmf.aspectmodel.generator.openapi.OpenApiSchemaGenerationCon
 import org.eclipse.esmf.aspectmodel.generator.openapi.PagingOption;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import io.vavr.control.Try;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/tools/samm-cli/pom.xml
+++ b/tools/samm-cli/pom.xml
@@ -50,7 +50,7 @@
          <artifactId>esmf-turtle-language-server</artifactId>
       </dependency>
       <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
+         <groupId>tools.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
       </dependency>
       <dependency>

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAasCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAasCommand.java
@@ -14,7 +14,6 @@
 package org.eclipse.esmf.aspect.to;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.eclipse.esmf.AbstractCommand;
 import org.eclipse.esmf.LoggingMixin;
@@ -26,11 +25,12 @@ import org.eclipse.esmf.aspectmodel.aas.AasGenerationConfigBuilder;
 import org.eclipse.esmf.aspectmodel.aas.AspectModelAasGenerator;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @CommandLine.Command(
    name = AspectToAasCommand.COMMAND_NAME,
@@ -81,7 +81,7 @@ public class AspectToAasCommand extends AbstractCommand {
       final ObjectMapper objectMapper = new ObjectMapper();
       try {
          return objectMapper.readTree( aspectData );
-      } catch ( final IOException exception ) {
+      } catch ( final Exception exception ) {
          LOG.error( "Could not read Aspect JSON data from file: {}", aspectData );
          return null;
       }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToAsyncapiCommand.java
@@ -35,13 +35,9 @@ import org.eclipse.esmf.aspectmodel.generator.asyncapi.AsyncApiSchemaGenerationC
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @CommandLine.Command(
    name = AspectToAsyncapiCommand.COMMAND_NAME,
@@ -50,11 +46,7 @@ import picocli.CommandLine;
    parameterListHeading = "%n@|bold Parameters|@:%n",
    optionListHeading = "%n@|bold Options|@:%n" )
 public class AspectToAsyncapiCommand extends AbstractCommand {
-
    public static final String COMMAND_NAME = "asyncapi";
-
-   private static final Logger LOG = LoggerFactory.getLogger( AspectToAsyncapiCommand.class );
-   private static final ObjectMapper YAML_MAPPER = new YAMLMapper().enable( YAMLGenerator.Feature.MINIMIZE_QUOTES );
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
    @CommandLine.Option(

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonSchemaCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonSchemaCommand.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.esmf.aspect.to;
 
-import java.io.IOException;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -27,9 +26,9 @@ import org.eclipse.esmf.aspectmodel.generator.jsonschema.JsonSchemaGenerationCon
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @CommandLine.Command(
    name = AspectToJsonSchemaCommand.COMMAND_NAME,
@@ -83,7 +82,7 @@ public class AspectToJsonSchemaCommand extends AbstractCommand {
          final ObjectMapper objectMapper = new ObjectMapper();
          try {
             objectMapper.writerWithDefaultPrettyPrinter().writeValue( outputStream, schema );
-         } catch ( final IOException exception ) {
+         } catch ( final Exception exception ) {
             throw new CommandException( "Could not format JSON Schema", exception );
          }
       } );

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToOpenapiCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToOpenapiCommand.java
@@ -29,6 +29,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import org.eclipse.esmf.AbstractCommand;
 import org.eclipse.esmf.LoggingMixin;
 import org.eclipse.esmf.ResolverConfigurationMixin;
@@ -41,16 +45,14 @@ import org.eclipse.esmf.aspectmodel.generator.openapi.PagingOption;
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.metamodel.Aspect;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import io.vavr.control.Try;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import picocli.CommandLine;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+import tools.jackson.dataformat.yaml.YAMLWriteFeature;
 
 @CommandLine.Command(
    name = AspectToOpenapiCommand.COMMAND_NAME,
@@ -61,7 +63,8 @@ import picocli.CommandLine;
 public class AspectToOpenapiCommand extends AbstractCommand {
    public static final String COMMAND_NAME = "openapi";
    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-   private static final ObjectMapper YAML_MAPPER = new YAMLMapper().enable( YAMLGenerator.Feature.MINIMIZE_QUOTES );
+   private static final ObjectMapper YAML_MAPPER =
+         new YAMLMapper( YAMLFactory.builder().enable( YAMLWriteFeature.MINIMIZE_QUOTES ).build() );
 
    @SuppressWarnings( "FieldCanBeLocal" )
    @CommandLine.Option(

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/importer/ImportCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/importer/ImportCommand.java
@@ -34,8 +34,8 @@ import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.exception.CommandException;
 import org.eclipse.esmf.metamodel.StructureElement;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import picocli.CommandLine;
 
 @CommandLine.Command(

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -28,9 +28,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.tika.mime.MediaType;
+
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
-import org.eclipse.esmf.util.process.ProcessLauncher;
-import org.eclipse.esmf.util.process.ProcessLauncher.ExecutionResult;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
 import org.eclipse.esmf.aspectmodel.validation.InvalidSyntaxViolation;
 import org.eclipse.esmf.aspectmodel.validation.ProcessingViolation;
@@ -41,11 +42,9 @@ import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestModel;
 import org.eclipse.esmf.test.TestResources;
 import org.eclipse.esmf.test.TestSharedModel;
+import org.eclipse.esmf.util.process.ProcessLauncher;
+import org.eclipse.esmf.util.process.ProcessLauncher.ExecutionResult;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.FileUtils;
-import org.apache.tika.mime.MediaType;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -56,6 +55,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * The tests for the CLI that are executed by Maven Surefire. They work using the
@@ -1234,7 +1236,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final File targetFile = modelLocation.resolve( "target.ttl" ).toFile();
@@ -1259,7 +1261,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final File targetFile = modelLocation.resolve( "target.ttl" ).toFile();
@@ -1284,7 +1286,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final File targetFile = modelLocation.resolve( "target.ttl" ).toFile();
@@ -1307,7 +1309,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final File targetFile = modelLocation.resolve( "target.ttl" ).toFile();
@@ -1330,14 +1332,14 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocationNs1 = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocationNs1.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs1 );
       final File inputFile = modelLocationNs1.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final String targetNamespace = "urn:samm:org.eclipse.example.newnamespace:1.0.0";
       final AspectModelUrn newNamespace = AspectModelUrn.fromUrn( targetNamespace );
       final Path modelLocationNs2 = outputDirectory.resolve( newNamespace.getNamespaceMainPart() )
             .resolve( newNamespace.getVersion() );
-      modelLocationNs2.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs2 );
       final File targetFile = modelLocationNs2.resolve( "target.ttl" ).toFile();
       Files.createFile( targetFile.toPath() );
       try ( final PrintWriter out = new PrintWriter( targetFile ) ) {
@@ -1360,14 +1362,14 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocationNs1 = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocationNs1.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs1 );
       final File inputFile = modelLocationNs1.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final String targetNamespace = "urn:samm:org.eclipse.example.newnamespace:1.0.0";
       final AspectModelUrn newNamespace = AspectModelUrn.fromUrn( targetNamespace );
       final Path modelLocationNs2 = outputDirectory.resolve( newNamespace.getNamespaceMainPart() )
             .resolve( newNamespace.getVersion() );
-      modelLocationNs2.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs2 );
       final File targetFile = modelLocationNs2.resolve( "target.ttl" ).toFile();
       Files.createFile( targetFile.toPath() );
       try ( final PrintWriter out = new PrintWriter( targetFile ) ) {
@@ -1392,7 +1394,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocationNs1 = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocationNs1.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs1 );
       final File inputFile = modelLocationNs1.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final String targetNamespace = "urn:samm:org.eclipse.example.newnamespace:1.0.0";
@@ -1419,7 +1421,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocationNs1 = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocationNs1.toFile().mkdirs();
+      Files.createDirectories( modelLocationNs1 );
       final File inputFile = modelLocationNs1.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
       final String targetNamespace = "urn:samm:org.eclipse.example.newnamespace:1.0.0";
@@ -1446,7 +1448,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
 
@@ -1466,7 +1468,7 @@ class SammCliTest extends SammCliAbstractTest {
       // Set up file system structure of writable files
       final Path modelLocation = outputDirectory.resolve( testModel.getUrn().getNamespaceMainPart() )
             .resolve( testModel.getUrn().getVersion() );
-      modelLocation.toFile().mkdirs();
+      Files.createDirectories( modelLocation );
       final File inputFile = modelLocation.resolve( "AspectWithEntity.ttl" ).toFile();
       FileUtils.copyFile( inputFile( testModel ).getAbsoluteFile(), inputFile );
 
@@ -1519,10 +1521,10 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
-   void testPackageImport( @TempDir final Path outputDirectory ) {
+   void testPackageImport( @TempDir final Path outputDirectory ) throws IOException {
       // Set up new empty models root directory
       final File modelsRoot = outputDirectory.toFile();
-      modelsRoot.mkdirs();
+      Files.createDirectories( outputDirectory );
 
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "package",
             inputFile( "namespaces.zip" ).getAbsolutePath(), "import", "--models-root", modelsRoot.getAbsolutePath() );


### PR DESCRIPTION
## Description

* Update from Jackson 2 to 3. Since the update from 2 to 3 is breaking and Jackson classes are also used as part of APIs, this implies this is also a breaking change for esmf-sdk.
* Fixes construction of idShort in SAMM2AAS for one-character element names (since idShort must be at least two characters).

Fixes #981.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

Jackson 2 remains part of the class path for tests, since the use of [json-schema-core](https://github.com/java-json-tools/json-schema-core/) for validating JSON schema - which is used in tests - still depends on Jackson 2.
