### PR TITLE
[Task] add lsp basic completion support

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/RdfNamespace.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/RdfNamespace.java
@@ -14,6 +14,7 @@
 package org.eclipse.esmf.metamodel.vocabulary;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.esmf.samm.KnownVersion;
@@ -45,6 +46,14 @@ public interface RdfNamespace {
 
    default Resource resource( final String name ) {
       return ResourceFactory.createResource( urn( name ) );
+   }
+
+   default List<Resource> allResources() {
+      return List.of();
+   }
+
+   default List<Property> allProperties() {
+      return List.of();
    }
 
    static Map<String, String> createPrefixMap( final KnownVersion metaModelVersion ) {

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMM.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMM.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.esmf.metamodel.vocabulary;
 
+import java.util.List;
+
 import org.eclipse.esmf.samm.KnownVersion;
 
 import org.apache.jena.rdf.model.Property;
@@ -225,5 +227,19 @@ public class SAMM implements RdfNamespace {
 
    public Property symbol() {
       return property( "symbol" );
+   }
+
+   @Override
+   public List<Resource> allResources() {
+      return List.of( Namespace(), Property(), AbstractProperty(), Characteristic(), Constraint(), Aspect(), Operation(), Event(),
+            Entity(), AbstractEntity(), Value(), Unit(), QuantityKind() );
+   }
+
+   @Override
+   public List<Property> allProperties() {
+      return List.of( listType(), input(), output(), curie(), description(), preferredName(), characteristic(), dataType(),
+            exampleValue(), optional(), notInPayload(), payloadName(), see(), property(), properties(), parameters(),
+            operations(), events(), _extends(), value(), quantityKind(), referenceUnit(), commonCode(), conversionFactor(),
+            numericConversionFactor(), symbol() );
    }
 }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMMC.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMMC.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.esmf.metamodel.vocabulary;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -301,5 +302,20 @@ public class SAMMC implements RdfNamespace {
             .of( Code(), Duration(), Either(), Enumeration(), Measurement(), Quantifiable(), SingleEntity(), State(),
                   StructuredValue() );
       return Stream.of( allCollections(), allConstraints(), miscCharacteristics ).flatMap( Function.identity() );
+   }
+
+   @Override
+   public List<Resource> allResources() {
+      return List.of( RangeConstraint(), EncodingConstraint(), RegularExpressionConstraint(), LengthConstraint(), LanguageConstraint(),
+            LocaleConstraint(), StructuredValue(), Quantifiable(), Measurement(), Duration(), State(), Enumeration(), Collection(),
+            Set(), SortedSet(), List(), TimeSeries(), SingleEntity(), Code(), FixedPointConstraint(), Trait(), Either(), Timestamp(),
+            Text(), MultiLanguageText(), Language(), Locale(), Boolean(), ResourcePath(), MimeType(), UnitReference() );
+   }
+
+   @Override
+   public List<Property> allProperties() {
+      return List.of( minValue(), maxValue(), unit(), baseCharacteristic(), values(), defaultValue(), left(), right(),
+            lowerBoundDefinition(), upperBoundDefinition(), elements(), deconstructionRule(), scale(), integer(),
+            elementCharacteristic(), constraint(), languageCode(), localeCode() );
    }
 }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMME.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMME.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.metamodel.vocabulary;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.eclipse.esmf.samm.KnownVersion;
@@ -101,5 +102,15 @@ public class SAMME implements RdfNamespace {
 
    public Stream<Resource> allEntities() {
       return Stream.of( TimeSeriesEntity(), Point3d(), FileResource(), Quantity() );
+   }
+
+   @Override
+   public List<Resource> allResources() {
+      return List.of( TimeSeriesEntity(), Point3d(), FileResource(), Quantity() );
+   }
+
+   @Override
+   public List<Property> allProperties() {
+      return List.of( resource(), mimeType(), timestamp(), value(), x(), y(), z(), unit() );
    }
 }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMME.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/vocabulary/SAMME.java
@@ -101,7 +101,7 @@ public class SAMME implements RdfNamespace {
    }
 
    public Stream<Resource> allEntities() {
-      return Stream.of( TimeSeriesEntity(), Point3d(), FileResource(), Quantity() );
+      return allResources().stream();
    }
 
    @Override

--- a/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/template/Units.java
+++ b/core/esmf-aspect-meta-model-java/src-buildtime/main/java/org/eclipse/esmf/buildtime/template/Units.java
@@ -14,6 +14,7 @@
 package org.eclipse.esmf.buildtime.template;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -50,6 +51,13 @@ public class Units {
     */
    public AspectModelFile getSourceFile() {
       return MetaModelFile.UNITS;
+   }
+
+   public static Collection<Unit> getUnits() {
+      if ( UNITS_BY_NAME.isEmpty() ) {
+         fromName( "" );
+      }
+      return Collections.unmodifiableCollection( UNITS_BY_NAME.values() );
    }
 
    /**

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/SHACL.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/SHACL.java
@@ -13,6 +13,12 @@
 
 package org.eclipse.esmf.aspectmodel.shacl;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
 import org.eclipse.esmf.metamodel.vocabulary.RdfNamespace;
 
 import org.apache.jena.rdf.model.Property;
@@ -1439,5 +1445,33 @@ public class SHACL implements RdfNamespace {
    @SuppressWarnings( "checkstyle:MethodName" )
    public Resource XoneConstraintComponent_xone() {
       return resource( "XoneConstraintComponent-xone" );
+   }
+
+   @Override
+   public List<Resource> allResources() {
+      return allByReturnType( Resource.class );
+   }
+
+   @Override
+   public List<Property> allProperties() {
+      return allByReturnType( Property.class );
+   }
+
+   private <T> List<T> allByReturnType( final Class<T> returnType ) {
+      return Arrays.stream( SHACL.class.getDeclaredMethods() )
+            .filter( method -> method.getParameterCount() == 0 )
+            .filter( method -> !method.isSynthetic() )
+            .filter( method -> method.getReturnType() == returnType )
+            .sorted( Comparator.comparing( Method::getName ) )
+            .map( method -> invoke( method, returnType ) )
+            .toList();
+   }
+
+   private <T> T invoke( final Method method, final Class<T> returnType ) {
+      try {
+         return returnType.cast( method.invoke( this ) );
+      } catch ( final IllegalAccessException | InvocationTargetException exception ) {
+         throw new IllegalStateException( "Could not invoke SHACL vocabulary method: " + method.getName(), exception );
+      }
    }
 }

--- a/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
+++ b/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
@@ -91,11 +91,17 @@ public class TurtleSyntaxTree {
    public record Error(
          String type,
          Diagnostic.Code errorType,
-         Location location
+         Location location,
+         List<Node> children
    ) implements Node {
       @Override
       public boolean isError() {
          return true;
+      }
+
+      @Override
+      public List<Node> children() {
+         return children;
       }
 
       @Override
@@ -195,17 +201,17 @@ public class TurtleSyntaxTree {
             inputNode.getStartPoint().getColumn(),
             inputNode.getEndPoint().getRow(),
             inputNode.getEndPoint().getColumn() );
-      if ( inputNode.isError() ) {
-         return new Error( inputNode.getType(), TurtleDiagnostic.TurtleCode.E0003, location );
-      } else if ( inputNode.isMissing() ) {
-         return new Error( inputNode.getType(), TurtleDiagnostic.TurtleCode.E0004, location );
-      }
-      final String token = tokenProvider.apply( location );
       final List<Node> children = IntStream.range( 0, inputNode.getChildCount() )
             .mapToObj( inputNode::getChild )
             .filter( Objects::nonNull )
             .map( child -> nodeForTsNode( child, tokenProvider ) )
             .toList();
+      if ( inputNode.isError() ) {
+         return new Error( inputNode.getType(), TurtleDiagnostic.TurtleCode.E0003, location, children );
+      } else if ( inputNode.isMissing() ) {
+         return new Error( inputNode.getType(), TurtleDiagnostic.TurtleCode.E0004, location, children );
+      }
+      final String token = tokenProvider.apply( location );
       return new Token( inputNode.getType(), token, location, children );
    }
 

--- a/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
+++ b/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
@@ -51,6 +51,10 @@ public class TurtleSyntaxTree {
          return !isError();
       }
 
+      default String content() {
+         throw new TurtleSyntaxTreeTraversalError();
+      }
+
       default List<Node> children() {
          return List.of();
       }
@@ -86,6 +90,11 @@ public class TurtleSyntaxTree {
       public Token asToken() {
          return this;
       }
+
+      @Override
+      public String content() {
+         return content;
+      }
    }
 
    public record Error(
@@ -107,6 +116,11 @@ public class TurtleSyntaxTree {
       @Override
       public Error asError() {
          return this;
+      }
+
+      @Override
+      public String content() {
+         return "ERROR";
       }
    }
 

--- a/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
+++ b/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
@@ -51,9 +51,7 @@ public class TurtleSyntaxTree {
          return !isError();
       }
 
-      default String content() {
-         throw new TurtleSyntaxTreeTraversalError();
-      }
+      String content();
 
       default List<Node> children() {
          return List.of();
@@ -89,11 +87,6 @@ public class TurtleSyntaxTree {
       @Override
       public Token asToken() {
          return this;
-      }
-
-      @Override
-      public String content() {
-         return content;
       }
    }
 

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/TurtleLanguageServer.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/TurtleLanguageServer.java
@@ -18,6 +18,7 @@ import java.net.InetSocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.Channels;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -29,6 +30,7 @@ import org.eclipse.esmf.turtle.languageserver.lsp.text.TurtleTextDocumentService
 import org.eclipse.esmf.turtle.languageserver.lsp.workspace.TurtleWorkspaceService;
 import org.eclipse.esmf.turtle.languageserver.structure.TurtleTokenService;
 
+import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -51,6 +53,7 @@ public class TurtleLanguageServer implements LanguageServer, LanguageClientAware
    // R=18, D=4, F=6
    public static final int DEFAULT_PORT = 1846;
 
+   private static final List<String> COMPLETION_TRIGGER_SYMBOLS = List.of( ":" );
    private static final Logger LOG = LoggerFactory.getLogger( TurtleLanguageServer.class );
    private static volatile boolean serverRunning = true;
    private final TurtleTextDocumentService textDocumentService;
@@ -70,6 +73,7 @@ public class TurtleLanguageServer implements LanguageServer, LanguageClientAware
       syncOptions.setSave( new SaveOptions( true ) );
       capabilities.setTextDocumentSync( syncOptions );
       capabilities.setDefinitionProvider( true );
+      capabilities.setCompletionProvider( new CompletionOptions( false, COMPLETION_TRIGGER_SYMBOLS ) );
       capabilities.setSemanticTokensProvider(
             new SemanticTokensWithRegistrationOptions( TurtleTokenService.SUPPORTED_TOKEN_TYPES, true, false ) );
       capabilities.setDocumentSymbolProvider( new DocumentSymbolOptions( "Turtle Document Symbols" ) );

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/ParsedDocument.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/ParsedDocument.java
@@ -46,13 +46,7 @@ public record ParsedDocument(
 
    public boolean isAspectModel() {
       return this.turtleSyntaxTree().nodes().anyMatch(
-            node -> {
-               if ( node.isToken() ) {
-                  return ParserTokenType.PN_PREFIX.equals( node.type() )
-                        && SAMM_PREFIXES.contains( node.content() );
-               }
-               return false;
-            }
+            node -> node.isToken() && ParserTokenType.PN_PREFIX.equals( node.type() ) && SAMM_PREFIXES.contains( node.content() )
       );
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/ParsedDocument.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/ParsedDocument.java
@@ -47,9 +47,9 @@ public record ParsedDocument(
    public boolean isAspectModel() {
       return this.turtleSyntaxTree().nodes().anyMatch(
             node -> {
-               if ( node instanceof TurtleSyntaxTree.Token token ) {
-                  return ParserTokenType.PN_PREFIX.equals( token.type() )
-                        && SAMM_PREFIXES.contains( token.content() );
+               if ( node.isToken() ) {
+                  return ParserTokenType.PN_PREFIX.equals( node.type() )
+                        && SAMM_PREFIXES.contains( node.content() );
                }
                return false;
             }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
@@ -26,9 +26,13 @@ import org.eclipse.esmf.turtle.languageserver.aspect.service.AspectValidationCoo
 import org.eclipse.esmf.turtle.languageserver.diagnostic.DiagnosticReport;
 import org.eclipse.esmf.turtle.languageserver.structure.DocumentSymbolService;
 import org.eclipse.esmf.turtle.languageserver.structure.TurtleTokenService;
+import org.eclipse.esmf.turtle.languageserver.turtle.TurtleCompletionService;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleSyntaxDiagnosticsService;
 import org.eclipse.esmf.turtle.languageserver.turtle.navigation.TurtleDefinitionService;
 
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -53,6 +57,7 @@ public class TurtleTextDocumentService implements TextDocumentService {
 
    private final TextDocumentClientNotifier clientNotifier;
    private final TurtleDefinitionService turtleDefinitionService;
+   private final TurtleCompletionService turtleCompletionService;
    private final AspectValidationCoordinator aspectValidationCoordinator;
    private final TreeSitterTurtleParserService turtleParserService;
    private final TurtleTokenService tokenService;
@@ -64,6 +69,7 @@ public class TurtleTextDocumentService implements TextDocumentService {
    public TurtleTextDocumentService() {
       clientNotifier = new TextDocumentClientNotifier( new AspectDiagnosticMapper() );
       turtleDefinitionService = new TurtleDefinitionService();
+      turtleCompletionService = new TurtleCompletionService();
       turtleParserService = new TreeSitterTurtleParserService();
       tokenService = new TurtleTokenService( turtleParserService );
       syntaxDiagnostics = new TurtleSyntaxDiagnosticsService();
@@ -208,4 +214,12 @@ public class TurtleTextDocumentService implements TextDocumentService {
       return CompletableFuture.completedFuture( symbols );
    }
 
+   @Override
+   public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion( final CompletionParams position ) {
+      final String uri = position.getTextDocument().getUri();
+      final Document document = documents.get( uri );
+      final ParsedDocument parsedDocument = turtleParserService.apply( document );
+      return CompletableFuture.completedFuture(
+            Either.forLeft( turtleCompletionService.complete( parsedDocument, position ) ) );
+   }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
@@ -4,9 +4,13 @@
 
 package org.eclipse.esmf.turtle.languageserver.turtle;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
@@ -16,6 +20,13 @@ import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Position;
 
 public class TurtleCompletionService extends TurtleService {
+   static final Map<String, List<CompletionItem>> SAMM_PREFIXES_COMPLETION_MAP = SammNs.sammNamespaces().map( n -> {
+      final String prefix = n.getShortForm() + ":";
+      final List<CompletionItem> elements = Stream.of( n.allResources(), n.allProperties() )
+            .flatMap( Collection::stream )
+            .map( r -> new CompletionItem( r.getLocalName() ) ).toList();
+      return Map.entry( prefix, elements );
+   } ).collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
 
    public List<CompletionItem> complete( final ParsedDocument parsedDocument, final CompletionParams completionParams ) {
       final Position position = completionParams.getPosition();
@@ -46,17 +57,21 @@ public class TurtleCompletionService extends TurtleService {
             return List.of();
          }
       }
-
       final String prefix = namespaceAtCursor.content();
-      return parsedDocument.turtleSyntaxTree().nodes()
-            .filter( t -> ParserTokenType.PREFIXED_NAME.equals( t.type() ) )
-            .filter( n -> isPrefixedBy( n, prefix ) )
-            .flatMap( n -> n.children().stream() )
-            .filter( t -> ParserTokenType.PN_LOCAL.equals( t.type() ) )
-            .filter( TurtleSyntaxTree.Token.class::isInstance )
-            .map( TurtleSyntaxTree.Token.class::cast )
-            .map( TurtleSyntaxTree.Token::content )
-            .map( CompletionItem::new )
-            .collect( Collectors.toSet() ).stream().toList();
+
+      if ( ":".equals( prefix ) ) {
+         return parsedDocument.turtleSyntaxTree().nodes()
+               .filter( t -> ParserTokenType.PREFIXED_NAME.equals( t.type() ) )
+               .filter( n -> isPrefixedBy( n, prefix ) )
+               .flatMap( n -> n.children().stream() )
+               .filter( t -> ParserTokenType.PN_LOCAL.equals( t.type() ) )
+               .filter( TurtleSyntaxTree.Token.class::isInstance )
+               .map( TurtleSyntaxTree.Token.class::cast )
+               .map( TurtleSyntaxTree.Token::content )
+               .map( CompletionItem::new )
+               .collect( Collectors.toSet() ).stream().toList();
+      }
+
+      return SAMM_PREFIXES_COMPLETION_MAP.getOrDefault( prefix, List.of() );
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
@@ -4,12 +4,17 @@
 
 package org.eclipse.esmf.turtle.languageserver.turtle;
 
+import static org.eclipse.esmf.metamodel.vocabulary.SammNs.UNIT;
+
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.esmf.aspectmodel.shacl.SHACL;
+import org.eclipse.esmf.metamodel.Units;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
@@ -20,13 +25,7 @@ import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.Position;
 
 public class TurtleCompletionService extends TurtleService {
-   static final Map<String, List<CompletionItem>> SAMM_PREFIXES_COMPLETION_MAP = SammNs.sammNamespaces().map( n -> {
-      final String prefix = n.getShortForm() + ":";
-      final List<CompletionItem> elements = Stream.of( n.allResources(), n.allProperties() )
-            .flatMap( Collection::stream )
-            .map( r -> new CompletionItem( r.getLocalName() ) ).toList();
-      return Map.entry( prefix, elements );
-   } ).collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+   static final Map<String, List<CompletionItem>> SAMM_PREFIXES_COMPLETION_MAP = initSammPrefixesCompletionMap();
 
    public List<CompletionItem> complete( final ParsedDocument parsedDocument, final CompletionParams completionParams ) {
       final Position position = completionParams.getPosition();
@@ -73,5 +72,25 @@ public class TurtleCompletionService extends TurtleService {
       }
 
       return SAMM_PREFIXES_COMPLETION_MAP.getOrDefault( prefix, List.of() );
+   }
+
+   private static HashMap<String, List<CompletionItem>> initSammPrefixesCompletionMap() {
+      final SHACL shacl = new SHACL();
+      final HashMap<String, List<CompletionItem>> result = new HashMap<>( SammNs.sammNamespaces().map( n -> {
+         final String prefix = n.getShortForm() + ":";
+         final List<CompletionItem> elements = Stream.of( n.allResources(), n.allProperties() )
+               .flatMap( Collection::stream )
+               .map( r -> new CompletionItem( r.getLocalName() ) ).toList();
+         return Map.entry( prefix, elements );
+      } ).collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) ) );
+
+      result.put( UNIT.getShortForm() + ":", Units.getUnits().stream()
+            .map( u -> new CompletionItem( u.getName() ) ).toList() );
+
+      result.put( shacl.getShortForm() + ":", Stream.of( shacl.allProperties(), shacl.allResources() )
+            .flatMap( Collection::stream )
+            .map( r -> new CompletionItem( r.getLocalName() ) ).toList() );
+
+      return result;
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
@@ -4,6 +4,7 @@
 
 package org.eclipse.esmf.turtle.languageserver.turtle;
 
+import static org.eclipse.esmf.aspectmodel.StreamUtil.asMap;
 import static org.eclipse.esmf.metamodel.vocabulary.SammNs.UNIT;
 
 import java.util.Collection;
@@ -34,22 +35,21 @@ public class TurtleCompletionService extends TurtleService {
 
       // First try: cursor is right after the colon of a namespace prefix (e.g. user typed "ex:")
       // This is important for incomplete trees with error nodes, when PREFIXED_NAME is not parsed
-      TurtleSyntaxTree.Token namespaceAtCursor = parsedDocument.turtleSyntaxTree()
+      TurtleSyntaxTree.Node namespaceAtCursor = parsedDocument.turtleSyntaxTree()
             .findMatchingTreeSitterToken( List.of( ParserTokenType.NAMESPACE ), targetLine, targetColumn );
 
       if ( namespaceAtCursor == null ) {
          // Second try: cursor is inside the local-name part of a prefixed name (e.g. "ex:sub|ject").
          // Find the enclosing prefixed_name node and retrieve its namespace child.
          // Relevant when user re-triggers completion manually
-         final TurtleSyntaxTree.Token prefixedNameAtCursor = parsedDocument.turtleSyntaxTree()
+         final TurtleSyntaxTree.Node prefixedNameAtCursor = parsedDocument.turtleSyntaxTree()
                .findMatchingTreeSitterToken( List.of( ParserTokenType.PREFIXED_NAME ), targetLine, targetColumn );
          if ( prefixedNameAtCursor == null ) {
             return List.of();
          }
          namespaceAtCursor = prefixedNameAtCursor.children().stream()
                .filter( n -> ParserTokenType.NAMESPACE.equals( n.type() ) )
-               .filter( TurtleSyntaxTree.Token.class::isInstance )
-               .map( TurtleSyntaxTree.Token.class::cast )
+               .filter( TurtleSyntaxTree.Node::isToken )
                .findFirst()
                .orElse( null );
          if ( namespaceAtCursor == null ) {
@@ -64,9 +64,8 @@ public class TurtleCompletionService extends TurtleService {
                .filter( n -> isPrefixedBy( n, prefix ) )
                .flatMap( n -> n.children().stream() )
                .filter( t -> ParserTokenType.PN_LOCAL.equals( t.type() ) )
-               .filter( TurtleSyntaxTree.Token.class::isInstance )
-               .map( TurtleSyntaxTree.Token.class::cast )
-               .map( TurtleSyntaxTree.Token::content )
+               .filter( TurtleSyntaxTree.Node::isToken )
+               .map( TurtleSyntaxTree.Node::content )
                .map( CompletionItem::new )
                .collect( Collectors.toSet() ).stream().toList();
       }
@@ -82,7 +81,7 @@ public class TurtleCompletionService extends TurtleService {
                .flatMap( Collection::stream )
                .map( r -> new CompletionItem( r.getLocalName() ) ).toList();
          return Map.entry( prefix, elements );
-      } ).collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) ) );
+      } ).collect( asMap() ) );
 
       result.put( UNIT.getShortForm() + ":", Units.getUnits().stream()
             .map( u -> new CompletionItem( u.getName() ) ).toList() );

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
@@ -19,12 +19,34 @@ public class TurtleCompletionService extends TurtleService {
 
    public List<CompletionItem> complete( final ParsedDocument parsedDocument, final CompletionParams completionParams ) {
       final Position position = completionParams.getPosition();
-      final TurtleSyntaxTree.Token namespaceAtCursor = parsedDocument.turtleSyntaxTree()
-            .findMatchingTreeSitterToken( List.of( ParserTokenType.NAMESPACE ), position.getLine(),
-                  position.getCharacter() - 1L ); // character one entry before cursor position is relevant to fetch previous token
+      final long targetLine = position.getLine();
+      final long targetColumn = position.getCharacter() - 1L; // character one entry before cursor position is relevant
+
+      // First try: cursor is right after the colon of a namespace prefix (e.g. user typed "ex:")
+      // This is important for incomplete trees with error nodes, when PREFIXED_NAME is not parsed
+      TurtleSyntaxTree.Token namespaceAtCursor = parsedDocument.turtleSyntaxTree()
+            .findMatchingTreeSitterToken( List.of( ParserTokenType.NAMESPACE ), targetLine, targetColumn );
+
       if ( namespaceAtCursor == null ) {
-         return List.of();
+         // Second try: cursor is inside the local-name part of a prefixed name (e.g. "ex:sub|ject").
+         // Find the enclosing prefixed_name node and retrieve its namespace child.
+         // Relevant when user re-triggers completion manually
+         final TurtleSyntaxTree.Token prefixedNameAtCursor = parsedDocument.turtleSyntaxTree()
+               .findMatchingTreeSitterToken( List.of( ParserTokenType.PREFIXED_NAME ), targetLine, targetColumn );
+         if ( prefixedNameAtCursor == null ) {
+            return List.of();
+         }
+         namespaceAtCursor = prefixedNameAtCursor.children().stream()
+               .filter( n -> ParserTokenType.NAMESPACE.equals( n.type() ) )
+               .filter( TurtleSyntaxTree.Token.class::isInstance )
+               .map( TurtleSyntaxTree.Token.class::cast )
+               .findFirst()
+               .orElse( null );
+         if ( namespaceAtCursor == null ) {
+            return List.of();
+         }
       }
+
       final String prefix = namespaceAtCursor.content();
       return parsedDocument.turtleSyntaxTree().nodes()
             .filter( t -> ParserTokenType.PREFIXED_NAME.equals( t.type() ) )

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH, Germany. All rights reserved.
+ */
+
+package org.eclipse.esmf.turtle.languageserver.turtle;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.esmf.treesitterturtle.ParserTokenType;
+import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+
+public class TurtleCompletionService extends TurtleService {
+
+   public List<CompletionItem> complete( final ParsedDocument parsedDocument, final CompletionParams completionParams ) {
+      final Position position = completionParams.getPosition();
+      final TurtleSyntaxTree.Token namespaceAtCursor = parsedDocument.turtleSyntaxTree()
+            .findMatchingTreeSitterToken( List.of( ParserTokenType.NAMESPACE ), position.getLine(),
+                  position.getCharacter() - 1L ); // character one entry before cursor position is relevant to fetch previous token
+      if ( namespaceAtCursor == null ) {
+         return List.of();
+      }
+      final String prefix = namespaceAtCursor.content();
+      return parsedDocument.turtleSyntaxTree().nodes()
+            .filter( t -> ParserTokenType.PREFIXED_NAME.equals( t.type() ) )
+            .filter( n -> isPrefixedBy( n, prefix ) )
+            .flatMap( n -> n.children().stream() )
+            .filter( t -> ParserTokenType.PN_LOCAL.equals( t.type() ) )
+            .filter( TurtleSyntaxTree.Token.class::isInstance )
+            .map( TurtleSyntaxTree.Token.class::cast )
+            .map( TurtleSyntaxTree.Token::content )
+            .map( CompletionItem::new )
+            .collect( Collectors.toSet() ).stream().toList();
+   }
+}

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
@@ -35,34 +35,32 @@ public abstract class TurtleService {
     * @return true if 'rdf:type' or 'a' is used as predictate
     */
    protected boolean hasTypeDefinitionPredicate( final TurtleSyntaxTree.Token triple ) {
-      final Map<TurtleSyntaxTree.Token, TurtleSyntaxTree.Token> predicateObjectMap = predicateObjectMapForTriple( triple );
-      return predicateObjectMap.keySet().stream().map( TurtleSyntaxTree.Token::content )
+      final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap = predicateObjectMapForTriple( triple );
+      return predicateObjectMap.keySet().stream().map( TurtleSyntaxTree.Node::content )
             .anyMatch( TYPE_DEFINITION_PREDICATES::contains );
    }
 
    protected boolean isPrefixedBy( final TurtleSyntaxTree.Node prefixedName, final String prefix ) {
       return prefixedName.children().stream()
-            .filter( TurtleSyntaxTree.Token.class::isInstance )
-            .map( TurtleSyntaxTree.Token.class::cast )
+            .filter( TurtleSyntaxTree.Node::isToken )
             .filter( n -> ParserTokenType.NAMESPACE.equals( n.type() ) )
             .anyMatch( n -> n.content().equals( prefix ) );
    }
 
-   protected Map<TurtleSyntaxTree.Token, TurtleSyntaxTree.Token> predicateObjectMapForTriple( final TurtleSyntaxTree.Token triple ) {
+   protected Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMapForTriple( final TurtleSyntaxTree.Token triple ) {
       return triple.childWithType( ParserTokenType.PROPERTY_LIST ).stream()
             .flatMap( propertyList -> propertyList.children().stream()
                   .filter( node -> ParserTokenType.PROPERTY.equals( node.type() ) ) )
             .flatMap( property -> property.childWithType( ParserTokenType.PREDICATE )
                   .filter( TurtleSyntaxTree.Node::isToken )
-                  .map( TurtleSyntaxTree.Node::asToken ).stream()
+                  .stream()
                   .flatMap( predicate -> property.childWithType( ParserTokenType.OBJECT_LIST )
-                        .filter( TurtleSyntaxTree.Node::isToken )
-                        .map( TurtleSyntaxTree.Node::asToken ).stream()
+                        .filter( TurtleSyntaxTree.Node::isToken ).stream()
                         .map( objectToken -> Map.entry( predicate, objectToken ) ) ) )
             .collect( asSortedMap() );
    }
 
-   protected Stream<TurtleSyntaxTree.Token> getPrefixDefinitionTokens( final TurtleSyntaxTree turtleSyntaxTree ) {
+   protected Stream<TurtleSyntaxTree.Node> getPrefixDefinitionTokens( final TurtleSyntaxTree turtleSyntaxTree ) {
       return turtleSyntaxTree.nodes()
             .filter( node -> ParserTokenType.DIRECTIVE.equals( node.type() ) )
             .flatMap( node -> node.children().stream() )
@@ -70,7 +68,6 @@ public abstract class TurtleService {
             .flatMap( node -> node.children().stream() )
             .filter( node -> ParserTokenType.NAMESPACE.equals( node.type() ) )
             .flatMap( node -> node.children().stream() )
-            .filter( TurtleSyntaxTree.Token.class::isInstance )
-            .map( TurtleSyntaxTree.Token.class::cast );
+            .filter( TurtleSyntaxTree.Node::isToken );
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
@@ -17,6 +17,7 @@ import static org.eclipse.esmf.aspectmodel.StreamUtil.asSortedMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
@@ -39,6 +40,14 @@ public abstract class TurtleService {
             .anyMatch( TYPE_DEFINITION_PREDICATES::contains );
    }
 
+   protected boolean isPrefixedBy( final TurtleSyntaxTree.Node prefixedName, final String prefix ) {
+      return prefixedName.children().stream()
+            .filter( TurtleSyntaxTree.Token.class::isInstance )
+            .map( TurtleSyntaxTree.Token.class::cast )
+            .filter( n -> ParserTokenType.NAMESPACE.equals( n.type() ) )
+            .anyMatch( n -> n.content().equals( prefix ) );
+   }
+
    protected Map<TurtleSyntaxTree.Token, TurtleSyntaxTree.Token> predicateObjectMapForTriple( final TurtleSyntaxTree.Token triple ) {
       return triple.childWithType( ParserTokenType.PROPERTY_LIST ).stream()
             .flatMap( propertyList -> propertyList.children().stream()
@@ -51,5 +60,17 @@ public abstract class TurtleService {
                         .map( TurtleSyntaxTree.Node::asToken ).stream()
                         .map( objectToken -> Map.entry( predicate, objectToken ) ) ) )
             .collect( asSortedMap() );
+   }
+
+   protected Stream<TurtleSyntaxTree.Token> getPrefixDefinitionTokens( final TurtleSyntaxTree turtleSyntaxTree ) {
+      return turtleSyntaxTree.nodes()
+            .filter( node -> ParserTokenType.DIRECTIVE.equals( node.type() ) )
+            .flatMap( node -> node.children().stream() )
+            .filter( node -> ParserTokenType.PREFIX_ID.equals( node.type() ) )
+            .flatMap( node -> node.children().stream() )
+            .filter( node -> ParserTokenType.NAMESPACE.equals( node.type() ) )
+            .flatMap( node -> node.children().stream() )
+            .filter( TurtleSyntaxTree.Token.class::isInstance )
+            .map( TurtleSyntaxTree.Token.class::cast );
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
@@ -48,12 +48,7 @@ public class TurtleDefinitionService extends TurtleService {
 
    private Optional<Location> findPrefixDefinition( final String prefixName, final ParsedDocument parsedDocument,
          final TurtleSyntaxTree turtleSyntaxTree ) {
-      final Optional<TurtleSyntaxTree.Node> prefixDefinitionNode = turtleSyntaxTree.nodes()
-            .filter( node -> ParserTokenType.DIRECTIVE.equals( node.type() ) )
-            .flatMap( node -> node.children().stream() )
-            .filter( node -> ParserTokenType.PREFIX_ID.equals( node.type() ) )
-            .flatMap( node -> node.children().stream() )
-            .filter( node -> ParserTokenType.NAMESPACE.equals( node.type() ) )
+      final Optional<TurtleSyntaxTree.Node> prefixDefinitionNode = this.getPrefixDefinitionTokens( turtleSyntaxTree )
             .flatMap( node -> node.children().stream() )
             .filter( node -> {
                if ( node instanceof final TurtleSyntaxTree.Token token ) {

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
@@ -28,7 +28,7 @@ import org.eclipse.lsp4j.Range;
 public class TurtleDefinitionService extends TurtleService {
    public Optional<Location> findDefinition( final ParsedDocument parsedDocument, final Position position ) {
       final TurtleSyntaxTree turtleSyntaxTree = parsedDocument.turtleSyntaxTree();
-      final TurtleSyntaxTree.Token highlightedToken = turtleSyntaxTree.findMatchingTreeSitterToken( position.getLine(),
+      final TurtleSyntaxTree.Node highlightedToken = turtleSyntaxTree.findMatchingTreeSitterToken( position.getLine(),
             position.getCharacter() );
       if ( highlightedToken == null ) {
          return Optional.empty();
@@ -58,7 +58,7 @@ public class TurtleDefinitionService extends TurtleService {
 
    private Optional<Location> findElementDefinition( final Position position, final ParsedDocument parsedDocument,
          final TurtleSyntaxTree turtleSyntaxTree ) {
-      final TurtleSyntaxTree.Token prefixedName = turtleSyntaxTree
+      final TurtleSyntaxTree.Node prefixedName = turtleSyntaxTree
             .findMatchingTreeSitterToken( List.of( ParserTokenType.PREFIXED_NAME ), position.getLine(), position.getCharacter() );
 
       if ( prefixedName == null ) {
@@ -72,8 +72,8 @@ public class TurtleDefinitionService extends TurtleService {
             .filter( n -> ParserTokenType.SUBJECT.equals( n.type() ) )
             .flatMap( n -> n.children().stream() )
             .filter( n -> {
-               if ( n instanceof final TurtleSyntaxTree.Token t ) {
-                  return ParserTokenType.PREFIXED_NAME.equals( t.type() ) && prefixedName.content().equals( t.content() );
+               if ( n.isToken() ) {
+                  return ParserTokenType.PREFIXED_NAME.equals( n.type() ) && prefixedName.content().equals( n.content() );
                }
                return false;
             } )

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
@@ -71,12 +71,7 @@ public class TurtleDefinitionService extends TurtleService {
             .flatMap( t -> t.children().stream() )
             .filter( n -> ParserTokenType.SUBJECT.equals( n.type() ) )
             .flatMap( n -> n.children().stream() )
-            .filter( n -> {
-               if ( n.isToken() ) {
-                  return ParserTokenType.PREFIXED_NAME.equals( n.type() ) && prefixedName.content().equals( n.content() );
-               }
-               return false;
-            } )
+            .filter( n -> n.isToken() && ParserTokenType.PREFIXED_NAME.equals( n.type() ) && prefixedName.content().equals( n.content() ) )
             .flatMap( node -> node.children().stream() )
             .filter( node -> ParserTokenType.PN_LOCAL.equals( node.type() ) )
             .findFirst();

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/navigation/TurtleDefinitionService.java
@@ -49,15 +49,10 @@ public class TurtleDefinitionService extends TurtleService {
    private Optional<Location> findPrefixDefinition( final String prefixName, final ParsedDocument parsedDocument,
          final TurtleSyntaxTree turtleSyntaxTree ) {
       final Optional<TurtleSyntaxTree.Node> prefixDefinitionNode = this.getPrefixDefinitionTokens( turtleSyntaxTree )
-            .flatMap( node -> node.children().stream() )
-            .filter( node -> {
-               if ( node instanceof final TurtleSyntaxTree.Token token ) {
-                  return ParserTokenType.PN_PREFIX.equals( token.type() )
-                        && token.content().equals( prefixName );
-               }
-               return false;
-            } )
-            .findFirst();
+            .filter( token -> ParserTokenType.PN_PREFIX.equals( token.type() )
+                  && token.content().equals( prefixName ) )
+            .findFirst()
+            .map( TurtleSyntaxTree.Node.class::cast );
       return prefixDefinitionNode.map( definition -> getLocationForLsp( parsedDocument, definition ) );
    }
 

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.turtle.languageserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.TreeSitterTurtleParserService;
+import org.eclipse.esmf.turtle.languageserver.turtle.TurtleCompletionService;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@SuppressWarnings( { "HttpUrlsUsage" } )
+class TurtleCompletionServiceTest {
+   private TurtleCompletionService completionService;
+   private TreeSitterTurtleParserService parserService;
+
+   @BeforeEach
+   void setUp() {
+      completionService = new TurtleCompletionService();
+      parserService = new TreeSitterTurtleParserService();
+   }
+
+   static Stream<Arguments> completionScenarios() {
+      return Stream.of(
+            Arguments.of(
+                  "typing partial object in new incomplete triple – names collected from whole document",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object .
+                     ex:newSubject ex:predicate ex:obj""",
+                  // ex:newSubject(0-12) ' '(13) ex:predicate(14-25) ' '(26) ex:obj(27-32)
+                  new Position( 3, 33 ), // cursor after 'j'; char-1=32 is within ex:obj [27,33)
+                  List.of( "subject", "predicate", "object", "newSubject", "obj" )
+            ),
+            Arguments.of(
+                  "multiple prefixes active – only names for the typed prefix are returned",
+                  """
+                     @prefix ex: <http://example.org/> .
+                     @prefix ns: <http://namespace.org/> .
+
+                     ex:subject ns:predicate ex:object .
+                     ex:subject ns:predicate ns:val""",
+                  // ex:subject(0-9) ' '(10) ns:predicate(11-22) ' '(23) ns:val(24-29)
+                  new Position( 4, 30 ), // cursor after 'l'; char-1=29 is within ns:val [24,30)
+                  List.of( "predicate", "val" )
+            ),
+            Arguments.of(
+                  "deduplication – repeated local names across triples appear only once",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object .
+                     ex:subject ex:otherPredicate ex:object .
+                     ex:subject ex:predicate ex:obj""",
+                  // ex:subject(0-9) ' '(10) ex:predicate(11-22) ' '(23) ex:obj(24-29)
+                  new Position( 4, 30 ), // cursor after 'j'; char-1=29 is within ex:obj [24,30)
+                  List.of( "subject", "predicate", "object", "otherPredicate", "obj" )
+            ),
+            Arguments.of(
+                  "typing partial object in semicolon-continued property list",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object ;
+                        ex:otherPredicate ex:obj""",
+                  // '   '(0-2) ex:otherPredicate(3-19) ' '(20) ex:obj(21-26)
+                  new Position( 3, 27 ), // cursor after 'j'; char-1=26 is within ex:obj [21,27)
+                  List.of( "subject", "predicate", "object", "otherPredicate", "obj" )
+            ),
+            Arguments.of(
+                  "typing a fresh prefixed name on a new line at the end of the document (incomplete subject)",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object .
+                     ex:obj""",
+                  // ex:obj is the start of a new, still incomplete statement -> tree-sitter wraps it in an
+                  // ERROR node; the nested prefixed_name must still be discoverable for completion.
+                  new Position( 3, 6 ), // cursor after 'j'; char-1=5 is within ex:obj [0,6)
+                  List.of( "subject", "predicate", "object", "obj" )
+            )
+      );
+   }
+
+   @ParameterizedTest( name = "{0}" )
+   @MethodSource( "completionScenarios" )
+   void testCompletionReturnsExpectedLocalNames( final String scenarioName,
+         final String content,
+         final Position position,
+         final List<String> expectedLabels ) {
+      final Document document = new Document( "test.ttl", content );
+      final ParsedDocument parsedDocument = parserService.apply( document );
+      final CompletionParams params = new CompletionParams( new TextDocumentIdentifier( "test.ttl" ), position );
+
+      final List<CompletionItem> completions = completionService.complete( parsedDocument, params );
+
+      final List<String> labels = completions.stream().map( CompletionItem::getLabel ).toList();
+      assertThat( labels ).containsExactlyInAnyOrder( expectedLabels.toArray( String[]::new ) );
+   }
+
+   static Stream<Arguments> noCompletionScenarios() {
+      return Stream.of(
+            Arguments.of(
+                  "cursor inside a string literal being typed",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object .
+                     ex:subject ex:predicate "typing""",
+                  new Position( 3, 28 ) // char-1=27 inside "typing"
+            ),
+            Arguments.of(
+                  "cursor on blank line after pressing Enter",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:object .
+                     """,
+                  new Position( 3, 0 )
+            ),
+            Arguments.of(
+                  "cursor inside the IRI of a prefix declaration",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:subject ex:predicate ex:obj""",
+                  new Position( 0, 20 ) // char-1=19 inside <http://example.org/>
+            ),
+            Arguments.of(
+                  "empty document",
+                  "",
+                  new Position( 0, 0 )
+            )
+      );
+   }
+
+   @ParameterizedTest( name = "{0}" )
+   @MethodSource( "noCompletionScenarios" )
+   void testNoCompletionWhenCursorIsNotOnPrefixedName( final String scenarioName,
+         final String content,
+         final Position position ) {
+      assertNoCompletions( content, position );
+   }
+
+   private void assertNoCompletions( final String content, final Position position ) {
+      final Document document = new Document( "test.ttl", content );
+      final ParsedDocument parsedDocument = parserService.apply( document );
+      final CompletionParams params = new CompletionParams( new TextDocumentIdentifier( "test.ttl" ), position );
+      assertThat( completionService.complete( parsedDocument, params ) ).isEmpty();
+   }
+}

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
@@ -87,7 +87,7 @@ class TurtleCompletionServiceTest {
 
                      ex:subject ex:predicate ex:object ;
                         ex:otherPredicate ex:""",
-                  // '   '(0-2) ex:otherPredicate(3-19) ' '(20) ex:obj(21-26)
+                  // ' '(0-2) ex:otherPredicate(3-19) ' '(20) ex:obj(21-26)
                   new Position( 3, 24 ),
                   List.of( "subject", "predicate", "object", "otherPredicate" )
             ),

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/TurtleCompletionServiceTest.java
@@ -63,10 +63,10 @@ class TurtleCompletionServiceTest {
                      @prefix ns: <http://namespace.org/> .
 
                      ex:subject ns:predicate ex:object .
-                     ex:subject ns:predicate ns:val""",
-                  // ex:subject(0-9) ' '(10) ns:predicate(11-22) ' '(23) ns:val(24-29)
-                  new Position( 4, 30 ), // cursor after 'l'; char-1=29 is within ns:val [24,30)
-                  List.of( "predicate", "val" )
+                     ex:subject ns:predicate ns:""",
+                  // ex:subject(0-9) ' '(10) ns:predicate(11-22) ' '(23) ns:(24-27)
+                  new Position( 4, 27 ), // cursor after 'ns:'
+                  List.of( "predicate" )
             ),
             Arguments.of(
                   "deduplication – repeated local names across triples appear only once",
@@ -86,10 +86,10 @@ class TurtleCompletionServiceTest {
                      @prefix ex: <http://example.org/> .
 
                      ex:subject ex:predicate ex:object ;
-                        ex:otherPredicate ex:obj""",
+                        ex:otherPredicate ex:""",
                   // '   '(0-2) ex:otherPredicate(3-19) ' '(20) ex:obj(21-26)
-                  new Position( 3, 27 ), // cursor after 'j'; char-1=26 is within ex:obj [21,27)
-                  List.of( "subject", "predicate", "object", "otherPredicate", "obj" )
+                  new Position( 3, 24 ),
+                  List.of( "subject", "predicate", "object", "otherPredicate" )
             ),
             Arguments.of(
                   "typing a fresh prefixed name on a new line at the end of the document (incomplete subject)",
@@ -100,7 +100,7 @@ class TurtleCompletionServiceTest {
                      ex:obj""",
                   // ex:obj is the start of a new, still incomplete statement -> tree-sitter wraps it in an
                   // ERROR node; the nested prefixed_name must still be discoverable for completion.
-                  new Position( 3, 6 ), // cursor after 'j'; char-1=5 is within ex:obj [0,6)
+                  new Position( 3, 3 ), // cursor after 'j'; char-1=5 is within ex:obj [0,6)
                   List.of( "subject", "predicate", "object", "obj" )
             )
       );

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionServiceTest.java
@@ -89,6 +89,57 @@ class TurtleCompletionServiceTest {
       assertThat( labels ).containsExactlyInAnyOrder( expectedLabels.toArray( String[]::new ) );
    }
 
+   static Stream<Arguments> nonEmptyKnownPrefixScenarios() {
+      return Stream.of(
+            Arguments.of(
+                  "samm prefix returns at least one completion",
+                  """
+                     @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+
+                     samm:""",
+                  new Position( 2, 5 )
+            ),
+            Arguments.of(
+                  "samm-c prefix returns at least one completion",
+                  """
+                     @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+
+                     samm-c:""",
+                  new Position( 2, 7 )
+            ),
+            Arguments.of(
+                  "unit prefix returns at least one completion",
+                  """
+                     @prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+
+                     unit:""",
+                  new Position( 2, 5 )
+            ),
+            Arguments.of(
+                  "sh prefix returns at least one completion",
+                  """
+                     @prefix sh: <http://www.w3.org/ns/shacl#> .
+
+                     sh:""",
+                  new Position( 2, 3 )
+            )
+      );
+   }
+
+   @ParameterizedTest( name = "{0}" )
+   @MethodSource( "nonEmptyKnownPrefixScenarios" )
+   void testCompletionIsNotEmptyForKnownPrefixes( final String scenarioName,
+         final String content,
+         final Position position ) {
+      final Document document = new Document( "test.ttl", content );
+      final ParsedDocument parsedDocument = parserService.apply( document );
+      final CompletionParams params = new CompletionParams( new TextDocumentIdentifier( "test.ttl" ), position );
+
+      final List<CompletionItem> completions = completionService.complete( parsedDocument, params );
+
+      assertThat( completions ).isNotEmpty();
+   }
+
    static Stream<Arguments> noCompletionScenarios() {
       return Stream.of(
             Arguments.of(

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleCompletionServiceTest.java
@@ -1,27 +1,20 @@
 /*
- * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
- *
- * See the AUTHORS file(s) distributed with this work for additional
- * information regarding authorship.
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- *
- * SPDX-License-Identifier: MPL-2.0
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH, Germany. All rights reserved.
  */
 
-package org.eclipse.esmf.turtle.languageserver;
+package org.eclipse.esmf.turtle.languageserver.turtle;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.esmf.metamodel.vocabulary.RdfNamespace;
+import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.TreeSitterTurtleParserService;
-import org.eclipse.esmf.turtle.languageserver.turtle.TurtleCompletionService;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionParams;
@@ -46,62 +39,36 @@ class TurtleCompletionServiceTest {
    static Stream<Arguments> completionScenarios() {
       return Stream.of(
             Arguments.of(
-                  "typing partial object in new incomplete triple – names collected from whole document",
+                  "typing a known SAMM prefix returns vocabulary completions",
                   """
-                     @prefix ex: <http://example.org/> .
+                     @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
 
-                     ex:subject ex:predicate ex:object .
-                     ex:newSubject ex:predicate ex:obj""",
-                  // ex:newSubject(0-12) ' '(13) ex:predicate(14-25) ' '(26) ex:obj(27-32)
-                  new Position( 3, 33 ), // cursor after 'j'; char-1=32 is within ex:obj [27,33)
-                  List.of( "subject", "predicate", "object", "newSubject", "obj" )
+                     samm-e:""",
+                  new Position( 2, 6 ),
+                  List.of( "TimeSeriesEntity", "Point3d", "FileResource", "Quantity", "resource", "mimeType", "timestamp", "value",
+                        "x", "y", "z", "unit" )
             ),
             Arguments.of(
-                  "multiple prefixes active – only names for the typed prefix are returned",
+                  "typing inside the local-name part for a SAMM prefix still resolves by namespace",
                   """
-                     @prefix ex: <http://example.org/> .
-                     @prefix ns: <http://namespace.org/> .
+                     @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+                     @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
 
-                     ex:subject ns:predicate ex:object .
-                     ex:subject ns:predicate ns:""",
-                  // ex:subject(0-9) ' '(10) ns:predicate(11-22) ' '(23) ns:(24-27)
-                  new Position( 4, 27 ), // cursor after 'ns:'
-                  List.of( "predicate" )
+                     samm-e:Tim""",
+                  new Position( 3, 8 ),
+                  List.of( "TimeSeriesEntity", "Point3d", "FileResource", "Quantity", "resource", "mimeType", "timestamp", "value",
+                        "x", "y", "z", "unit" )
             ),
             Arguments.of(
-                  "deduplication – repeated local names across triples appear only once",
+                  "typing partial object with default prefix returns local names from the document",
                   """
-                     @prefix ex: <http://example.org/> .
+                     @prefix : <http://example.org/> .
 
-                     ex:subject ex:predicate ex:object .
-                     ex:subject ex:otherPredicate ex:object .
-                     ex:subject ex:predicate ex:obj""",
-                  // ex:subject(0-9) ' '(10) ex:predicate(11-22) ' '(23) ex:obj(24-29)
-                  new Position( 4, 30 ), // cursor after 'j'; char-1=29 is within ex:obj [24,30)
+                     :subject :predicate :object .
+                     :subject :otherPredicate :object .
+                     :subject :predicate :obj""",
+                  new Position( 4, 21 ),
                   List.of( "subject", "predicate", "object", "otherPredicate", "obj" )
-            ),
-            Arguments.of(
-                  "typing partial object in semicolon-continued property list",
-                  """
-                     @prefix ex: <http://example.org/> .
-
-                     ex:subject ex:predicate ex:object ;
-                        ex:otherPredicate ex:""",
-                  // ' '(0-2) ex:otherPredicate(3-19) ' '(20) ex:obj(21-26)
-                  new Position( 3, 24 ),
-                  List.of( "subject", "predicate", "object", "otherPredicate" )
-            ),
-            Arguments.of(
-                  "typing a fresh prefixed name on a new line at the end of the document (incomplete subject)",
-                  """
-                     @prefix ex: <http://example.org/> .
-
-                     ex:subject ex:predicate ex:object .
-                     ex:obj""",
-                  // ex:obj is the start of a new, still incomplete statement -> tree-sitter wraps it in an
-                  // ERROR node; the nested prefixed_name must still be discoverable for completion.
-                  new Position( 3, 3 ), // cursor after 'j'; char-1=5 is within ex:obj [0,6)
-                  List.of( "subject", "predicate", "object", "obj" )
             )
       );
    }
@@ -124,6 +91,14 @@ class TurtleCompletionServiceTest {
 
    static Stream<Arguments> noCompletionScenarios() {
       return Stream.of(
+            Arguments.of(
+                  "typing an unknown non-SAMM prefix",
+                  """
+                     @prefix ex: <http://example.org/> .
+
+                     ex:""",
+                  new Position( 2, 3 )
+            ),
             Arguments.of(
                   "cursor inside a string literal being typed",
                   """
@@ -171,5 +146,34 @@ class TurtleCompletionServiceTest {
       final ParsedDocument parsedDocument = parserService.apply( document );
       final CompletionParams params = new CompletionParams( new TextDocumentIdentifier( "test.ttl" ), position );
       assertThat( completionService.complete( parsedDocument, params ) ).isEmpty();
+   }
+
+   private static List<String> expectedLabelsForPrefix( final String prefix ) {
+      return SammNs.sammNamespaces()
+            .filter( namespace -> ( namespace.getShortForm() + ":" ).equals( prefix ) )
+            .findFirst()
+            .stream()
+            .flatMap( TurtleCompletionServiceTest::namespaceLabels )
+            .distinct()
+            .toList();
+   }
+
+   private static Stream<String> namespaceLabels( final RdfNamespace namespace ) {
+      return Stream.of( "allResources", "allProperties" )
+            .flatMap( methodName -> invokeCollectionMethod( namespace, methodName ).stream() )
+            .map( Object::toString )
+            .map( iri -> iri.substring( iri.lastIndexOf( '#' ) + 1 ) );
+   }
+
+   private static Collection<?> invokeCollectionMethod( final RdfNamespace namespace, final String methodName ) {
+      try {
+         final Object result = namespace.getClass().getMethod( methodName ).invoke( namespace );
+         if ( result instanceof Collection<?> collection ) {
+            return collection;
+         }
+      } catch ( final ReflectiveOperationException ignored ) {
+         // Older vocabulary variants may not expose these methods for tests.
+      }
+      return List.of();
    }
 }


### PR DESCRIPTION
## Description

- Implement basic support for lsp completion directive. Trigger symbol is ':', which then suggests element definitions that were already used in the same file
- Keep children of error nodes, since they could include partial definitions / references used for parsing for completion

Fixes #985

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

