### PR TITLE
Generate valid annotation

### DIFF
--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -58,6 +58,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Converter;
+import jakarta.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.text.translate.UnicodeUnescaper;
@@ -305,9 +306,18 @@ public class AspectModelJavaUtil {
 
    private static Optional<String> buildConstraintForCollectionElements( final Collection collection,
          final JavaCodeGenerationConfig codeGenerationConfig ) {
-      return collection.getElementCharacteristic()
+      final Set<String> constraints = new LinkedHashSet<>();
+      collection.getElementCharacteristic()
             .filter( elementCharacteristic -> elementCharacteristic.is( Trait.class ) )
-            .map( elementCharacteristic -> buildConstraintsForCharacteristic( (Trait) elementCharacteristic, codeGenerationConfig ) );
+            .map( elementCharacteristic -> buildConstraintsForCharacteristic( (Trait) elementCharacteristic, codeGenerationConfig ) )
+            .ifPresent( constraints::add );
+
+      if ( collection.getDataType().filter( type -> type.is( Entity.class ) ).isPresent() ) {
+         codeGenerationConfig.importTracker().importExplicit( Valid.class );
+         constraints.add( "@Valid " );
+      }
+
+      return constraints.isEmpty() ? Optional.empty() : Optional.of( String.join( "", constraints ) );
    }
 
    public static String containerType( final Class<?> containerClass, final String elementType, final Optional<String> elementConstraint ) {

--- a/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/esmf-aspect-model-java-generator/src/test/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -1009,7 +1009,7 @@ class AspectModelJavaGeneratorTest {
    @Test
    void testGenerateAspectModelWithCollectionWithAbstractEntity() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForAspectClass = ImmutableMap.<String, Object>builder()
-            .put( "testProperty", "Collection<ExtendingTestEntity>" )
+            .put( "testProperty", "Collection<@Valid ExtendingTestEntity>" )
             .build();
 
       final ImmutableMap<String, Object> expectedFieldsForEntityClass = ImmutableMap.<String, Object>builder()
@@ -1253,7 +1253,8 @@ class AspectModelJavaGeneratorTest {
    void testValidAnnotationRules() throws IOException {
       final ImmutableMap<String, Object> expectedFieldsForEvaluationResults = ImmutableMap.<String, Object>builder()
             .put( "entity", "TestEntity" )
-            .put( "collectionEntity", "Collection<TestEntity>" )
+            .put( "collectionEntity", "Collection<@Valid TestEntity>" )
+            .put( "optionalCollectionEntity", "Optional<Collection<@Valid TestEntity>>" )
             .put( "optionalEntity", "Optional<TestEntity>" )
             .put( "testProperty", String.class )
             .put( "collectionTestProperty", "Collection<String>" )
@@ -1268,10 +1269,15 @@ class AspectModelJavaGeneratorTest {
             ImmutableMap.<String, String>builder()
                   .put( "entity", "@Valid@NotNull" )
                   .put( "collectionEntity", "@Valid@NotNull" )
+                  .put( "optionalCollectionEntity", "@Valid" )
                   .put( "optionalEntity", "@Valid" )
                   .put( "testProperty", "@NotNull" )
                   .put( "collectionTestProperty", "@NotNull" )
                   .put( "optionalTestProperty", "" )
                   .build() );
+      result.assertCollectionElementValidationAnnotations( "AspectWithValidAnnotationTest", "collectionEntity",
+            "@Valid @NotNull private Collection<@Valid TestEntity> collectionEntity;" );
+      result.assertCollectionElementValidationAnnotations( "AspectWithValidAnnotationTest", "optionalCollectionEntity",
+            "@Valid private Optional<Collection<@Valid TestEntity>> optionalCollectionEntity;" );
    }
 }

--- a/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithValidAnnotationTest.ttl
+++ b/core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithValidAnnotationTest.ttl
@@ -21,6 +21,7 @@
    samm:properties (
          :entity
          :collectionEntity
+       [ samm:property :optionalCollectionEntity ; samm:optional "true"^^xsd:boolean ]
        [ samm:property :optionalEntity ; samm:optional "true"^^xsd:boolean ]
          :testProperty
          :collectionTestProperty
@@ -48,6 +49,9 @@
    samm:characteristic :EntityCharacteristic .
 
 :collectionEntity a samm:Property ;
+   samm:characteristic :TestCollection .
+
+:optionalCollectionEntity a samm:Property ;
    samm:characteristic :TestCollection .
 
 :EntityCharacteristic a samm-c:SingleEntity ;


### PR DESCRIPTION
  ## Description

Fixes Java DTO generation for collection properties whose element type is a SAMM Entity. The generator now adds Bean Validation `@Valid` as a type-use annotation on collection element types, so optional wrappers preserve element validation, e.g. `Optional<Collection<@Valid TestEntity>>`.

Existing collection element constraints from `elementCharacteristic` / `Trait` remain supported.

No new dependencies are required.

Fixes #978

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works