### PR TITLE
Fix DiagnosticMapper to properly report back once a file is free of errors

### DIFF
--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/diagnostic/DiagnosticMapper.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/diagnostic/DiagnosticMapper.java
@@ -38,6 +38,9 @@ public final class DiagnosticMapper {
 
    public Map<URI, List<Diagnostic>> apply( final Document sourceDocument, final DiagnosticReport report ) {
       final Map<URI, List<Diagnostic>> result = new HashMap<>();
+      // Always include empty diagnostics for sourceDocument, otherwise LSP client does not clear old but
+      // fixed findings
+      result.put( URI.create( sourceDocument.uri() ), new ArrayList<>() );
       for ( final org.eclipse.esmf.Diagnostic<?> lspDiagnostic : report.diagnostics() ) {
          final Diagnostic diagnostic = new Diagnostic();
          diagnostic.setSeverity( toDiagnosticSeverity( lspDiagnostic.severity() ) );
@@ -59,7 +62,7 @@ public final class DiagnosticMapper {
          } else {
             diagnostic.setRange( FALLBACK );
          }
-         result.computeIfAbsent( URI.create( sourceDocument.uri() ), _ -> new ArrayList<>() ).add( diagnostic );
+         result.get( URI.create( sourceDocument.uri() ) ).add( diagnostic );
       }
       return result;
    }


### PR DESCRIPTION
## Description
Report back an empty List when validating models, so that old findings get cleared

Fixes #1007

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
