### PR TITLE
Add LSP aspect validation for samm best practices

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/Diagnostic.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/Diagnostic.java
@@ -4,6 +4,8 @@
 
 package org.eclipse.esmf;
 
+import java.util.Optional;
+
 /**
  * Generic diagnostic interface representing a problem found during document processing.
  *
@@ -47,6 +49,10 @@ public interface Diagnostic<C extends Diagnostic.Code> {
       String code();
 
       String description();
+
+      default Optional<String> href() {
+         return Optional.empty();
+      }
    }
 
    enum Severity {

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectDiagnosticCode.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectDiagnosticCode.java
@@ -13,13 +13,21 @@
 
 package org.eclipse.esmf.turtle.languageserver.aspect.diagnostic;
 
+import java.util.Optional;
+
 import org.eclipse.esmf.Diagnostic;
 
 public record AspectDiagnosticCode(
-      String code
+      String code,
+      Optional<String> href
 ) implements Diagnostic.Code {
    @Override
    public String description() {
       return code;
+   }
+
+   @Override
+   public Optional<String> href() {
+      return href;
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectViolationDiagnosticMapper.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectViolationDiagnosticMapper.java
@@ -36,6 +36,7 @@ import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticReport;
 
 public class AspectViolationDiagnosticMapper implements Function<List<Violation>, DiagnosticReport> {
    public static final String PROCESSING_ERROR_MESSAGE = "Model validation failed. See language server logs for details.";
+   private static final String ERROR_CODES_DOC_LINK = "https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/error-codes.html#";
 
    @Override
    public DiagnosticReport apply( final List<Violation> violations ) {
@@ -59,7 +60,9 @@ public class AspectViolationDiagnosticMapper implements Function<List<Violation>
 
    public DiagnosticReport processingFailureReport() {
       return new DiagnosticReport(
-            new AspectDiagnostic( PROCESSING_ERROR_MESSAGE, new AspectDiagnosticCode( ProcessingViolation.ERROR_CODE ) ) );
+            new AspectDiagnostic( PROCESSING_ERROR_MESSAGE,
+                  new AspectDiagnosticCode( ProcessingViolation.ERROR_CODE,
+                        Optional.of( ERROR_CODES_DOC_LINK + ProcessingViolation.ERROR_CODE.toUpperCase().replace( "_", "-" ) ) ) ) );
    }
 
    private Optional<Diagnostic<AspectDiagnosticCode>> mapViolation( final Violation violation ) {
@@ -76,7 +79,7 @@ public class AspectViolationDiagnosticMapper implements Function<List<Violation>
    }
 
    private Diagnostic<AspectDiagnosticCode> mapLexicalViolation( final InvalidLexicalValueViolation violation ) {
-      final AspectDiagnosticCode code = new AspectDiagnosticCode( InvalidLexicalValueViolation.ERROR_CODE );
+      final AspectDiagnosticCode code = new AspectDiagnosticCode( InvalidLexicalValueViolation.ERROR_CODE, Optional.empty() );
       final Location diagnosticsLocation = new Location( Math.max( 0, violation.line() - 1 ),
             Math.max( 0, violation.column() - 1 ),
             Math.max( 0, violation.line() - 1 ),
@@ -92,11 +95,13 @@ public class AspectViolationDiagnosticMapper implements Function<List<Violation>
    }
 
    private Diagnostic<AspectDiagnosticCode> mapProcessingViolation( final ProcessingViolation violation ) {
-      return mapViolationWithOptionalLocation( violation, new AspectDiagnosticCode( ProcessingViolation.ERROR_CODE ) );
+      return mapViolationWithOptionalLocation( violation,
+            new AspectDiagnosticCode( ProcessingViolation.ERROR_CODE,
+                  Optional.of( ERROR_CODES_DOC_LINK + violation.errorCode().toUpperCase().replace( "_", "-" ) ) ) );
    }
 
    private Diagnostic<AspectDiagnosticCode> mapSemanticViolation( final Violation violation ) {
-      return mapViolationWithOptionalLocation( violation, new AspectDiagnosticCode( violation.errorCode() ) );
+      return mapViolationWithOptionalLocation( violation, new AspectDiagnosticCode( violation.errorCode(), Optional.empty() ) );
    }
 
    private Diagnostic<AspectDiagnosticCode> mapViolationWithOptionalLocation( final Violation violation, final AspectDiagnosticCode code ) {

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.esmf.Diagnostic;
-import org.eclipse.esmf.metamodel.vocabulary.RdfNamespace;
+import org.eclipse.esmf.aspectmodel.RdfUtil;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
@@ -37,12 +37,10 @@ import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticsProvider
 import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleService;
 
-import org.apache.jena.rdf.model.Resource;
-
 public class AspectModelNamingConventionValidationService extends TurtleService implements DiagnosticsProvider {
    private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "ERR_NAMING_CONVENTION" );
    private static final Pattern UPPERCASE_ACRONYM = Pattern.compile( "\\p{Upper}{2,}" );
-   private static final String SAMM_DESCRIPTION_PREDICATE = qualifiedName( SammNs.SAMM, SammNs.SAMM.description() );
+   private static final String SAMM_DESCRIPTION_PREDICATE = RdfUtil.curie( SammNs.SAMM.description().getURI() );
    private static final Set<String> CHARACTERISTIC_TYPES = characteristicTypes();
    private static final Set<String> PROPERTY_TYPES = propertyTypes();
 
@@ -181,27 +179,15 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
       return rawContent;
    }
 
-   private static String qualifiedName( final RdfNamespace namespace, final Resource resource ) {
-      return namespace.getShortForm() + ":" + resource.getLocalName();
-   }
-
    private static Set<String> characteristicTypes() {
-      return Stream.concat(
-            Stream.of( SammNs.SAMM.Characteristic() )
-                  .map( resource -> qualifiedName( SammNs.SAMM, resource ) ),
-            Stream.of(
-                  SammNs.SAMMC.StructuredValue(), SammNs.SAMMC.Quantifiable(), SammNs.SAMMC.Measurement(),
-                  SammNs.SAMMC.Duration(), SammNs.SAMMC.State(), SammNs.SAMMC.Enumeration(),
-                  SammNs.SAMMC.Collection(), SammNs.SAMMC.Set(), SammNs.SAMMC.SortedSet(),
-                  SammNs.SAMMC.List(), SammNs.SAMMC.TimeSeries(), SammNs.SAMMC.SingleEntity(),
-                  SammNs.SAMMC.Code(), SammNs.SAMMC.Trait(), SammNs.SAMMC.Either() )
-                  .map( resource -> qualifiedName( SammNs.SAMMC, resource ) ) )
+      return Stream.concat( Stream.of( SammNs.SAMM.Characteristic() ), SammNs.SAMMC.allCharacteristics() )
+            .map( resource -> RdfUtil.curie( resource.getURI() ) )
             .collect( Collectors.toUnmodifiableSet() );
    }
 
    private static Set<String> propertyTypes() {
       return Stream.of( SammNs.SAMM.Property(), SammNs.SAMM.AbstractProperty() )
-            .map( resource -> qualifiedName( SammNs.SAMM, resource ) )
+            .map( resource -> RdfUtil.curie( resource.getURI() ) )
             .collect( Collectors.toUnmodifiableSet() );
    }
 

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.turtle.languageserver.aspect.service;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.esmf.Diagnostic;
+import org.eclipse.esmf.metamodel.vocabulary.RdfNamespace;
+import org.eclipse.esmf.metamodel.vocabulary.SammNs;
+import org.eclipse.esmf.treesitterturtle.ParserTokenType;
+import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
+import org.eclipse.esmf.turtle.languageserver.aspect.diagnostic.AspectDiagnosticCode;
+import org.eclipse.esmf.turtle.languageserver.aspect.diagnostic.AspectDocumentDiagnostic;
+import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticReport;
+import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticsProvider;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
+import org.eclipse.esmf.turtle.languageserver.turtle.TurtleService;
+
+import org.apache.jena.rdf.model.Resource;
+
+public class AspectModelNamingConventionValidationService extends TurtleService implements DiagnosticsProvider {
+   private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "ERR_NAMING_CONVENTION" );
+   private static final Pattern UPPERCASE_ACRONYM = Pattern.compile( "\\p{Upper}{2,}" );
+   private static final String SAMM_DESCRIPTION_PREDICATE = qualifiedName( SammNs.SAMM, SammNs.SAMM.description() );
+   private static final Set<String> CHARACTERISTIC_TYPES = characteristicTypes();
+   private static final Set<String> PROPERTY_TYPES = propertyTypes();
+
+   @Override
+   public DiagnosticReport validate( final ParsedDocument parsedDocument ) {
+      if ( !documentIsAspectModel( parsedDocument ) ) {
+         return DiagnosticReport.EMPTY;
+      }
+      return new DiagnosticReport(
+            parsedDocument.turtleSyntaxTree().tokens()
+                  .filter( token -> ParserTokenType.TRIPLE.equals( token.type() ) )
+                  .flatMap( triple -> checkNamingConvention( triple, parsedDocument ) )
+                  .toList() );
+   }
+
+   private Stream<Diagnostic<?>> checkNamingConvention( final TurtleSyntaxTree.Token triple, final ParsedDocument parsedDocument ) {
+      final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap = predicateObjectMapForTriple( triple );
+      final Stream.Builder<Diagnostic<?>> diagnostics = Stream.builder();
+
+      subjectLocalName( triple ).ifPresent( localName -> {
+         final boolean isCharacteristic = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
+               .map( TurtleSyntaxTree.Node::content )
+               .anyMatch( CHARACTERISTIC_TYPES::contains );
+         if ( isCharacteristic ) {
+            uppercaseFirstLetterDiagnostic( "Characteristic name", localName.content(), localName, parsedDocument )
+                  .ifPresent( diagnostics::add );
+         }
+         final boolean isProperty = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
+               .map( TurtleSyntaxTree.Node::content )
+               .anyMatch( PROPERTY_TYPES::contains );
+         if ( isProperty ) {
+            lowercaseFirstLetterDiagnostic( "Property name", localName.content(), localName, parsedDocument )
+                  .ifPresent( diagnostics::add );
+         }
+         acronymCasingDiagnostic( localName, parsedDocument ).ifPresent( diagnostics::add );
+         redundantTypeNameDiagnostic( localName, predicateObjectMap, parsedDocument ).ifPresent( diagnostics::add );
+      } );
+
+      descriptionValues( predicateObjectMap ).forEach( description -> {
+         uppercaseFirstLetterDiagnostic( "Description", stripQuotes( description.content() ), description, parsedDocument )
+               .ifPresent( diagnostics::add );
+
+         lastLetterPunctuationDiagnostic( "Description", stripQuotes( description.content() ), description, parsedDocument )
+               .ifPresent( diagnostics::add );
+      } );
+
+      return diagnostics.build();
+   }
+
+   private static Optional<Diagnostic<?>> uppercaseFirstLetterDiagnostic( final String label, final String text,
+         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
+      if ( text.isEmpty() || Character.isUpperCase( text.charAt( 0 ) ) ) {
+         return Optional.empty();
+      }
+      final String suggestion = Character.toUpperCase( text.charAt( 0 ) ) + text.substring( 1 );
+      final String message = "%s '%s' should start with an uppercase letter, e.g. '%s'".formatted( label, text, suggestion );
+      return Optional.of(
+            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
+                  Diagnostic.Severity.WARNING ) );
+   }
+
+   private static Optional<Diagnostic<?>> lowercaseFirstLetterDiagnostic( final String label, final String text,
+         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
+      if ( text.isEmpty() || Character.isLowerCase( text.charAt( 0 ) ) ) {
+         return Optional.empty();
+      }
+      final String suggestion = Character.toLowerCase( text.charAt( 0 ) ) + text.substring( 1 );
+      final String message = "%s '%s' should start with a lowercase letter, e.g. '%s'".formatted( label, text, suggestion );
+      return Optional.of(
+            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
+                  Diagnostic.Severity.WARNING ) );
+   }
+
+   private static Optional<Diagnostic<?>> lastLetterPunctuationDiagnostic( final String label, final String text,
+         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
+      if ( text.isEmpty() || text.charAt( text.length() - 1 ) == '.' ) {
+         return Optional.empty();
+      }
+      final String suggestion = text + ".";
+      final String message = "%s '%s' should end with a period, e.g. '%s'".formatted( label, text, suggestion );
+      return Optional.of(
+            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
+                  Diagnostic.Severity.WARNING ) );
+   }
+
+   private static Optional<Diagnostic<?>> acronymCasingDiagnostic( final TurtleSyntaxTree.Node localName,
+         final ParsedDocument parsedDocument ) {
+      return acronymCasingSuggestion( localName.content() ).map( suggestion -> {
+         final String message = "Name '%s' should use camel case for acronyms instead of all-uppercase, e.g. '%s'"
+               .formatted( localName.content(), suggestion );
+         return new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), localName.location(),
+               Diagnostic.Severity.WARNING );
+      } );
+   }
+
+   private static Optional<Diagnostic<?>> redundantTypeNameDiagnostic( final TurtleSyntaxTree.Node localName,
+         final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap, final ParsedDocument parsedDocument ) {
+      final String name = localName.content();
+      return objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
+            .map( TurtleSyntaxTree.Node::content )
+            .flatMap( typeReference -> sammTypeLocalName( typeReference ).stream() )
+            .filter( name::contains )
+            .max( Comparator.comparingInt( String::length ) )
+            .map( typeName -> {
+               final int matchIndex = name.indexOf( typeName );
+               final String remainder = name.substring( 0, matchIndex ) + name.substring( matchIndex + typeName.length() );
+               final String message = remainder.isEmpty()
+                     ? "Name '%s' should not simply repeat the meta model element type '%s', choose a more descriptive name"
+                           .formatted( name, typeName )
+                     : "Name '%s' should not contain the meta model element type '%s', e.g. '%s'"
+                           .formatted( name, typeName, remainder );
+               return new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), localName.location(),
+                     Diagnostic.Severity.WARNING );
+            } );
+   }
+
+   private static Optional<String> sammTypeLocalName( final String typeReference ) {
+      final int separatorIndex = typeReference.indexOf( ':' );
+      if ( separatorIndex < 0 ) {
+         return Optional.empty();
+      }
+      final String prefix = typeReference.substring( 0, separatorIndex );
+      if ( !SAMM_PREFIXES.contains( prefix ) ) {
+         return Optional.empty();
+      }
+      return Optional.of( typeReference.substring( separatorIndex + 1 ) );
+   }
+
+   private static String stripQuotes( final String rawContent ) {
+      for ( final String delimiter : List.of( "\"\"\"", "'''", "\"", "'" ) ) {
+         if ( rawContent.startsWith( delimiter ) && rawContent.endsWith( delimiter )
+               && rawContent.length() >= delimiter.length() * 2 ) {
+            return rawContent.substring( delimiter.length(), rawContent.length() - delimiter.length() );
+         }
+      }
+      return rawContent;
+   }
+
+   private static String qualifiedName( final RdfNamespace namespace, final Resource resource ) {
+      return namespace.getShortForm() + ":" + resource.getLocalName();
+   }
+
+   private static Set<String> characteristicTypes() {
+      return Stream.concat(
+            Stream.of( SammNs.SAMM.Characteristic() )
+                  .map( resource -> qualifiedName( SammNs.SAMM, resource ) ),
+            Stream.of(
+                  SammNs.SAMMC.StructuredValue(), SammNs.SAMMC.Quantifiable(), SammNs.SAMMC.Measurement(),
+                  SammNs.SAMMC.Duration(), SammNs.SAMMC.State(), SammNs.SAMMC.Enumeration(),
+                  SammNs.SAMMC.Collection(), SammNs.SAMMC.Set(), SammNs.SAMMC.SortedSet(),
+                  SammNs.SAMMC.List(), SammNs.SAMMC.TimeSeries(), SammNs.SAMMC.SingleEntity(),
+                  SammNs.SAMMC.Code(), SammNs.SAMMC.Trait(), SammNs.SAMMC.Either() )
+                  .map( resource -> qualifiedName( SammNs.SAMMC, resource ) ) )
+            .collect( Collectors.toUnmodifiableSet() );
+   }
+
+   private static Set<String> propertyTypes() {
+      return Stream.of( SammNs.SAMM.Property(), SammNs.SAMM.AbstractProperty() )
+            .map( resource -> qualifiedName( SammNs.SAMM, resource ) )
+            .collect( Collectors.toUnmodifiableSet() );
+   }
+
+   private static Stream<TurtleSyntaxTree.Node> descriptionValues(
+         final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap ) {
+      return objectsForPredicates( predicateObjectMap, List.of( SAMM_DESCRIPTION_PREDICATE ) )
+            .flatMap( objectList -> descriptionValueNode( objectList ).stream() );
+   }
+
+   private static Optional<String> acronymCasingSuggestion( final String name ) {
+      final Matcher matcher = UPPERCASE_ACRONYM.matcher( name );
+      final StringBuilder result = new StringBuilder();
+      int lastEnd = 0;
+      boolean changed = false;
+      while ( matcher.find() ) {
+         final String acronym = matcher.group();
+         final int acronymEnd = matcher.end();
+         final boolean keepLastLetterUppercase = acronymEnd < name.length() && Character.isLowerCase( name.charAt( acronymEnd ) );
+         final String replacement = camelCase( acronym, keepLastLetterUppercase );
+         changed = changed || !replacement.equals( acronym );
+         result.append( name, lastEnd, matcher.start() ).append( replacement );
+         lastEnd = acronymEnd;
+      }
+      if ( !changed ) {
+         return Optional.empty();
+      }
+      return Optional.of( result.append( name.substring( lastEnd ) ).toString() );
+   }
+
+   private static String camelCase( final String acronym, final boolean keepLastLetterUppercase ) {
+      if ( keepLastLetterUppercase ) {
+         return acronym.charAt( 0 )
+               + acronym.substring( 1, acronym.length() - 1 ).toLowerCase( Locale.ROOT )
+               + acronym.charAt( acronym.length() - 1 );
+      }
+      return acronym.charAt( 0 ) + acronym.substring( 1 ).toLowerCase( Locale.ROOT );
+   }
+
+   private static Stream<TurtleSyntaxTree.Node> objectsForPredicates(
+         final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap,
+         final Collection<String> predicates ) {
+      return predicateObjectMap.entrySet().stream()
+            .filter( entry -> predicates.contains( entry.getKey().content() ) )
+            .map( Map.Entry::getValue );
+   }
+
+   private static Optional<TurtleSyntaxTree.Node> subjectLocalName( final TurtleSyntaxTree.Token triple ) {
+      return triple.childWithType( ParserTokenType.SUBJECT )
+            .flatMap( subject -> subject.childWithType( ParserTokenType.PREFIXED_NAME ) )
+            .flatMap( prefixedName -> prefixedName.childWithType( ParserTokenType.PN_LOCAL ) );
+   }
+
+   private static Optional<TurtleSyntaxTree.Node> descriptionValueNode( final TurtleSyntaxTree.Node objectList ) {
+      return objectList.childWithType( ParserTokenType.RDF_LITERAL )
+            .flatMap( rdfLiteral -> rdfLiteral.childWithType( ParserTokenType.STRING ) );
+   }
+}

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.esmf.turtle.languageserver.aspect.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -38,11 +39,28 @@ import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleService;
 
 public class AspectModelNamingConventionValidationService extends TurtleService implements DiagnosticsProvider {
-   private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "ERR_NAMING_CONVENTION" );
+   private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "WARN_NAMING_CONVENTION" );
+   private static final AspectDiagnosticCode NAMING_BEST_PRACTICE_CODE = new AspectDiagnosticCode( "WARN_NAMING_BEST_PRACTICE" );
    private static final Pattern UPPERCASE_ACRONYM = Pattern.compile( "\\p{Upper}{2,}" );
    private static final String SAMM_DESCRIPTION_PREDICATE = RdfUtil.curie( SammNs.SAMM.description().getURI() );
-   private static final Set<String> CHARACTERISTIC_TYPES = characteristicTypes();
-   private static final Set<String> PROPERTY_TYPES = propertyTypes();
+   private static final Set<String> UPPERCASE_TYPES;
+   private static final Set<String> LOWERCASE_TYPES;
+   private static final String NAMING_CONVENTION_DOCS =
+         "https://eclipse-esmf.github.io/samm-specification/snapshot/modeling-guidelines.html#naming-rules";
+   private static final String BEST_PRACTICES_DOCS =
+         "https://eclipse-esmf.github.io/samm-specification/snapshot/appendix/best-practices.html";
+
+   static {
+      UPPERCASE_TYPES = Stream.concat(
+            Stream.of( SammNs.SAMM.Aspect(), SammNs.SAMM.AbstractEntity(), SammNs.SAMM.Entity(), SammNs.SAMM.Event(),
+                  SammNs.SAMM.Constraint(), SammNs.SAMM.Characteristic() ),
+            SammNs.SAMMC.allResources().stream() )
+            .map( resource -> RdfUtil.curie( resource.getURI() ) )
+            .collect( Collectors.toUnmodifiableSet() );
+      LOWERCASE_TYPES = Stream.of( SammNs.SAMM.Property(), SammNs.SAMM.AbstractProperty(), SammNs.SAMM.Operation() )
+            .map( resource -> RdfUtil.curie( resource.getURI() ) )
+            .collect( Collectors.toUnmodifiableSet() );
+   }
 
    @Override
    public DiagnosticReport validate( final ParsedDocument parsedDocument ) {
@@ -60,78 +78,82 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
       final Map<TurtleSyntaxTree.Node, TurtleSyntaxTree.Node> predicateObjectMap = predicateObjectMapForTriple( triple );
       final Stream.Builder<Diagnostic<?>> diagnostics = Stream.builder();
 
-      subjectLocalName( triple ).ifPresent( localName -> {
-         final boolean isCharacteristic = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
+      subjectLocalName( triple ).ifPresent( node -> {
+         final boolean isUppercaseType = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
                .map( TurtleSyntaxTree.Node::content )
-               .anyMatch( CHARACTERISTIC_TYPES::contains );
-         if ( isCharacteristic ) {
-            uppercaseFirstLetterDiagnostic( "Characteristic name", localName.content(), localName, parsedDocument )
+               .anyMatch( UPPERCASE_TYPES::contains );
+         if ( isUppercaseType ) {
+            uppercaseFirstLetterDiagnostic( node, parsedDocument )
                   .ifPresent( diagnostics::add );
          }
-         final boolean isProperty = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
+         final boolean isLowercaseType = objectsForPredicates( predicateObjectMap, TYPE_DEFINITION_PREDICATES )
                .map( TurtleSyntaxTree.Node::content )
-               .anyMatch( PROPERTY_TYPES::contains );
-         if ( isProperty ) {
-            lowercaseFirstLetterDiagnostic( "Property name", localName.content(), localName, parsedDocument )
+               .anyMatch( LOWERCASE_TYPES::contains );
+         if ( isLowercaseType ) {
+            lowercaseFirstLetterDiagnostic( node, parsedDocument )
                   .ifPresent( diagnostics::add );
          }
-         acronymCasingDiagnostic( localName, parsedDocument ).ifPresent( diagnostics::add );
-         redundantTypeNameDiagnostic( localName, predicateObjectMap, parsedDocument ).ifPresent( diagnostics::add );
+         acronymCasingDiagnostic( node, parsedDocument ).ifPresent( diagnostics::add );
+         redundantTypeNameDiagnostic( node, predicateObjectMap, parsedDocument ).ifPresent( diagnostics::add );
       } );
 
-      descriptionValues( predicateObjectMap ).forEach( description -> {
-         uppercaseFirstLetterDiagnostic( "Description", stripQuotes( description.content() ), description, parsedDocument )
-               .ifPresent( diagnostics::add );
-
-         lastLetterPunctuationDiagnostic( "Description", stripQuotes( description.content() ), description, parsedDocument )
-               .ifPresent( diagnostics::add );
-      } );
+      descriptionValues( predicateObjectMap ).forEach( description ->
+            descriptionDiagnostic( description, parsedDocument ).forEach( diagnostics::add )
+      );
 
       return diagnostics.build();
    }
 
-   private static Optional<Diagnostic<?>> uppercaseFirstLetterDiagnostic( final String label, final String text,
-         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
-      if ( text.isEmpty() || Character.isUpperCase( text.charAt( 0 ) ) ) {
-         return Optional.empty();
-      }
-      final String suggestion = Character.toUpperCase( text.charAt( 0 ) ) + text.substring( 1 );
-      final String message = "%s '%s' should start with an uppercase letter, e.g. '%s'".formatted( label, text, suggestion );
-      return Optional.of(
-            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
-                  Diagnostic.Severity.WARNING ) );
-   }
-
-   private static Optional<Diagnostic<?>> lowercaseFirstLetterDiagnostic( final String label, final String text,
-         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
-      if ( text.isEmpty() || Character.isLowerCase( text.charAt( 0 ) ) ) {
-         return Optional.empty();
-      }
-      final String suggestion = Character.toLowerCase( text.charAt( 0 ) ) + text.substring( 1 );
-      final String message = "%s '%s' should start with a lowercase letter, e.g. '%s'".formatted( label, text, suggestion );
-      return Optional.of(
-            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
-                  Diagnostic.Severity.WARNING ) );
-   }
-
-   private static Optional<Diagnostic<?>> lastLetterPunctuationDiagnostic( final String label, final String text,
-         final TurtleSyntaxTree.Node location, final ParsedDocument parsedDocument ) {
-      if ( text.isEmpty() || text.charAt( text.length() - 1 ) == '.' ) {
-         return Optional.empty();
-      }
-      final String suggestion = text + ".";
-      final String message = "%s '%s' should end with a period, e.g. '%s'".formatted( label, text, suggestion );
-      return Optional.of(
-            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), location.location(),
-                  Diagnostic.Severity.WARNING ) );
-   }
-
-   private static Optional<Diagnostic<?>> acronymCasingDiagnostic( final TurtleSyntaxTree.Node localName,
+   private static Optional<Diagnostic<?>> uppercaseFirstLetterDiagnostic( final TurtleSyntaxTree.Node node,
          final ParsedDocument parsedDocument ) {
-      return acronymCasingSuggestion( localName.content() ).map( suggestion -> {
-         final String message = "Name '%s' should use camel case for acronyms instead of all-uppercase, e.g. '%s'"
-               .formatted( localName.content(), suggestion );
-         return new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), localName.location(),
+      final String content = stripQuotes( node.content() );
+      if ( content.isEmpty() || Character.isUpperCase( content.charAt( 0 ) ) ) {
+         return Optional.empty();
+      }
+      final String suggestion = Character.toUpperCase( content.charAt( 0 ) ) + content.substring( 1 );
+      final String message = ( "'%s' should start with an uppercase letter, e.g. '%s'%n%s" ).formatted( content, suggestion,
+            NAMING_CONVENTION_DOCS );
+      return Optional.of(
+            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), node.location(),
+                  Diagnostic.Severity.WARNING ) );
+   }
+
+   private static Optional<Diagnostic<?>> lowercaseFirstLetterDiagnostic( final TurtleSyntaxTree.Node node,
+         final ParsedDocument parsedDocument ) {
+      final String content = stripQuotes( node.content() );
+      if ( content.isEmpty() || Character.isLowerCase( content.charAt( 0 ) ) ) {
+         return Optional.empty();
+      }
+      final String suggestion = Character.toLowerCase( content.charAt( 0 ) ) + content.substring( 1 );
+      final String message = "'%s' should start with a lowercase letter, e.g. '%s'%n%s".formatted( content, suggestion,
+            NAMING_CONVENTION_DOCS );
+      return Optional.of(
+            new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), node.location(),
+                  Diagnostic.Severity.WARNING ) );
+   }
+
+   private static List<Diagnostic<?>> descriptionDiagnostic( final TurtleSyntaxTree.Node node,
+         final ParsedDocument parsedDocument ) {
+      final List<Diagnostic<?>> diagnostics = new ArrayList<>();
+      final String content = stripQuotes( node.content() );
+      if ( !content.isEmpty() && content.charAt( content.length() - 1 ) != '.' ) {
+         final String message = "Description should end with a period%n%s".formatted( BEST_PRACTICES_DOCS );
+         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
+               Diagnostic.Severity.WARNING ) );
+      }
+      if ( !content.isEmpty() && Character.isLowerCase( content.charAt( 0 ) ) ) {
+         final String message = "Description should start with an uppercase letter%n%s".formatted( BEST_PRACTICES_DOCS );
+         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
+               Diagnostic.Severity.WARNING ) );
+      }
+      return diagnostics;
+   }
+
+   private static Optional<Diagnostic<?>> acronymCasingDiagnostic( final TurtleSyntaxTree.Node node, final ParsedDocument parsedDocument ) {
+      return acronymCasingSuggestion( node.content() ).map( suggestion -> {
+         final String message = "Name '%s' should use camel case for acronyms instead of all-uppercase, e.g. '%s'%n%s"
+               .formatted( node.content(), suggestion, BEST_PRACTICES_DOCS );
+         return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
                Diagnostic.Severity.WARNING );
       } );
    }
@@ -148,11 +170,11 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
                final int matchIndex = name.indexOf( typeName );
                final String remainder = name.substring( 0, matchIndex ) + name.substring( matchIndex + typeName.length() );
                final String message = remainder.isEmpty()
-                     ? "Name '%s' should not simply repeat the meta model element type '%s', choose a more descriptive name"
-                           .formatted( name, typeName )
-                     : "Name '%s' should not contain the meta model element type '%s', e.g. '%s'"
-                           .formatted( name, typeName, remainder );
-               return new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), localName.location(),
+                     ? "Name '%s' should not simply repeat the meta model element type '%s', choose a more descriptive name%n%s"
+                     .formatted( name, typeName, BEST_PRACTICES_DOCS )
+                     : "Name '%s' should not contain the meta model element type '%s', e.g. '%s'%n%s"
+                     .formatted( name, typeName, remainder, BEST_PRACTICES_DOCS );
+               return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), localName.location(),
                      Diagnostic.Severity.WARNING );
             } );
    }
@@ -177,18 +199,6 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
          }
       }
       return rawContent;
-   }
-
-   private static Set<String> characteristicTypes() {
-      return Stream.concat( Stream.of( SammNs.SAMM.Characteristic() ), SammNs.SAMMC.allCharacteristics() )
-            .map( resource -> RdfUtil.curie( resource.getURI() ) )
-            .collect( Collectors.toUnmodifiableSet() );
-   }
-
-   private static Set<String> propertyTypes() {
-      return Stream.of( SammNs.SAMM.Property(), SammNs.SAMM.AbstractProperty() )
-            .map( resource -> RdfUtil.curie( resource.getURI() ) )
-            .collect( Collectors.toUnmodifiableSet() );
    }
 
    private static Stream<TurtleSyntaxTree.Node> descriptionValues(

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationService.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.esmf.Diagnostic;
 import org.eclipse.esmf.aspectmodel.RdfUtil;
+import org.eclipse.esmf.aspectmodel.VersionInfo;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
@@ -39,16 +40,20 @@ import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleService;
 
 public class AspectModelNamingConventionValidationService extends TurtleService implements DiagnosticsProvider {
-   private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "WARN_NAMING_CONVENTION" );
-   private static final AspectDiagnosticCode NAMING_BEST_PRACTICE_CODE = new AspectDiagnosticCode( "WARN_NAMING_BEST_PRACTICE" );
+   private static final String NAMING_CONVENTION_DOCS_HREF =
+         "https://eclipse-esmf.github.io/samm-specification/%s/modeling-guidelines.html#naming-rules"
+               .formatted( VersionInfo.ASPECT_META_MODEL_VERSION );
+   private static final String BEST_PRACTICES_DOCS =
+         "https://eclipse-esmf.github.io/samm-specification/%s/appendix/best-practices.html"
+               .formatted( VersionInfo.ASPECT_META_MODEL_VERSION );
+   private static final AspectDiagnosticCode NAMING_CONVENTION_CODE = new AspectDiagnosticCode( "WARN_NAMING_CONVENTION",
+         Optional.of( NAMING_CONVENTION_DOCS_HREF ) );
+   private static final AspectDiagnosticCode NAMING_BEST_PRACTICES_CODE = new AspectDiagnosticCode( "WARN_NAMING_BEST_PRACTICES",
+         Optional.of( BEST_PRACTICES_DOCS ) );
    private static final Pattern UPPERCASE_ACRONYM = Pattern.compile( "\\p{Upper}{2,}" );
    private static final String SAMM_DESCRIPTION_PREDICATE = RdfUtil.curie( SammNs.SAMM.description().getURI() );
    private static final Set<String> UPPERCASE_TYPES;
    private static final Set<String> LOWERCASE_TYPES;
-   private static final String NAMING_CONVENTION_DOCS =
-         "https://eclipse-esmf.github.io/samm-specification/snapshot/modeling-guidelines.html#naming-rules";
-   private static final String BEST_PRACTICES_DOCS =
-         "https://eclipse-esmf.github.io/samm-specification/snapshot/appendix/best-practices.html";
 
    static {
       UPPERCASE_TYPES = Stream.concat(
@@ -97,9 +102,9 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
          redundantTypeNameDiagnostic( node, predicateObjectMap, parsedDocument ).ifPresent( diagnostics::add );
       } );
 
-      descriptionValues( predicateObjectMap ).forEach( description ->
-            descriptionDiagnostic( description, parsedDocument ).forEach( diagnostics::add )
-      );
+      descriptionValues( predicateObjectMap )
+            .forEach( description -> descriptionDiagnostic( description, parsedDocument ).forEach( diagnostics::add )
+            );
 
       return diagnostics.build();
    }
@@ -111,8 +116,7 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
          return Optional.empty();
       }
       final String suggestion = Character.toUpperCase( content.charAt( 0 ) ) + content.substring( 1 );
-      final String message = ( "'%s' should start with an uppercase letter, e.g. '%s'%n%s" ).formatted( content, suggestion,
-            NAMING_CONVENTION_DOCS );
+      final String message = ( "'%s' should start with an uppercase letter, e.g. '%s'" ).formatted( content, suggestion );
       return Optional.of(
             new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), node.location(),
                   Diagnostic.Severity.WARNING ) );
@@ -125,8 +129,7 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
          return Optional.empty();
       }
       final String suggestion = Character.toLowerCase( content.charAt( 0 ) ) + content.substring( 1 );
-      final String message = "'%s' should start with a lowercase letter, e.g. '%s'%n%s".formatted( content, suggestion,
-            NAMING_CONVENTION_DOCS );
+      final String message = "'%s' should start with a lowercase letter, e.g. '%s'".formatted( content, suggestion );
       return Optional.of(
             new AspectDocumentDiagnostic( message, NAMING_CONVENTION_CODE, parsedDocument.getUri(), node.location(),
                   Diagnostic.Severity.WARNING ) );
@@ -137,13 +140,13 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
       final List<Diagnostic<?>> diagnostics = new ArrayList<>();
       final String content = stripQuotes( node.content() );
       if ( !content.isEmpty() && content.charAt( content.length() - 1 ) != '.' ) {
-         final String message = "Description should end with a period%n%s".formatted( BEST_PRACTICES_DOCS );
-         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
+         final String message = "Description should end with a period";
+         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICES_CODE, parsedDocument.getUri(), node.location(),
                Diagnostic.Severity.WARNING ) );
       }
       if ( !content.isEmpty() && Character.isLowerCase( content.charAt( 0 ) ) ) {
-         final String message = "Description should start with an uppercase letter%n%s".formatted( BEST_PRACTICES_DOCS );
-         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
+         final String message = "Description should start with an uppercase letter";
+         diagnostics.add( new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICES_CODE, parsedDocument.getUri(), node.location(),
                Diagnostic.Severity.WARNING ) );
       }
       return diagnostics;
@@ -151,9 +154,9 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
 
    private static Optional<Diagnostic<?>> acronymCasingDiagnostic( final TurtleSyntaxTree.Node node, final ParsedDocument parsedDocument ) {
       return acronymCasingSuggestion( node.content() ).map( suggestion -> {
-         final String message = "Name '%s' should use camel case for acronyms instead of all-uppercase, e.g. '%s'%n%s"
-               .formatted( node.content(), suggestion, BEST_PRACTICES_DOCS );
-         return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), node.location(),
+         final String message = "Name '%s' should use camel case for acronyms instead of all-uppercase, e.g. '%s'"
+               .formatted( node.content(), suggestion );
+         return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICES_CODE, parsedDocument.getUri(), node.location(),
                Diagnostic.Severity.WARNING );
       } );
    }
@@ -170,11 +173,11 @@ public class AspectModelNamingConventionValidationService extends TurtleService 
                final int matchIndex = name.indexOf( typeName );
                final String remainder = name.substring( 0, matchIndex ) + name.substring( matchIndex + typeName.length() );
                final String message = remainder.isEmpty()
-                     ? "Name '%s' should not simply repeat the meta model element type '%s', choose a more descriptive name%n%s"
-                     .formatted( name, typeName, BEST_PRACTICES_DOCS )
-                     : "Name '%s' should not contain the meta model element type '%s', e.g. '%s'%n%s"
-                     .formatted( name, typeName, remainder, BEST_PRACTICES_DOCS );
-               return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICE_CODE, parsedDocument.getUri(), localName.location(),
+                     ? "Name '%s' should not simply repeat the meta model element type '%s', choose a more descriptive name"
+                           .formatted( name, typeName )
+                     : "Name '%s' should not contain the meta model element type '%s', e.g. '%s'"
+                           .formatted( name, typeName, remainder );
+               return new AspectDocumentDiagnostic( message, NAMING_BEST_PRACTICES_CODE, parsedDocument.getUri(), localName.location(),
                      Diagnostic.Severity.WARNING );
             } );
    }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/diagnostic/DiagnosticMapper.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/diagnostic/DiagnosticMapper.java
@@ -24,6 +24,7 @@ import org.eclipse.esmf.DocumentDiagnostic;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
 
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticCodeDescription;
 import org.eclipse.lsp4j.DiagnosticRelatedInformation;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Location;
@@ -46,6 +47,7 @@ public final class DiagnosticMapper {
          diagnostic.setSeverity( toDiagnosticSeverity( lspDiagnostic.severity() ) );
          diagnostic.setMessage( lspDiagnostic.message() );
          diagnostic.setCode( lspDiagnostic.code().code() );
+         lspDiagnostic.code().href().ifPresent( href -> diagnostic.setCodeDescription( new DiagnosticCodeDescription( href ) ) );
          if ( lspDiagnostic instanceof final DocumentDiagnostic<?> documentDiagnostic ) {
             if ( documentDiagnostic.sourceLocation().equals( sourceDocument.uri() ) ) {
                diagnostic.setRange( toRange( documentDiagnostic ) );

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/TurtleService.java
@@ -33,7 +33,7 @@ import org.eclipse.lsp4j.Range;
  * Base class for services that operate on a {@link TurtleSyntaxTree}
  */
 public abstract class TurtleService {
-   private static final List<String> SAMM_PREFIXES = SammNs.sammNamespaces().map( RdfNamespace::getShortForm ).toList();
+   protected static final List<String> SAMM_PREFIXES = SammNs.sammNamespaces().map( RdfNamespace::getShortForm ).toList();
    protected static final List<String> TYPE_DEFINITION_PREDICATES = List.of( "a", "rdf:type" );
 
    /**

--- a/core/esmf-turtle-language-server/src/main/resources/META-INF/services/org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticsProvider
+++ b/core/esmf-turtle-language-server/src/main/resources/META-INF/services/org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticsProvider
@@ -1,2 +1,3 @@
 org.eclipse.esmf.turtle.languageserver.turtle.TurtleSyntaxDiagnosticsService
 org.eclipse.esmf.turtle.languageserver.aspect.service.AspectModelValidationService
+org.eclipse.esmf.turtle.languageserver.aspect.service.AspectModelNamingConventionValidationService

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectViolationDiagnosticMapperTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/diagnostic/AspectViolationDiagnosticMapperTest.java
@@ -59,6 +59,7 @@ class AspectViolationDiagnosticMapperTest {
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( InvalidLexicalValueViolation.ERROR_CODE );
                assertThat( diagnostic.message() ).isEqualTo( "Invalid value" );
+               assertThat( diagnostic.code().href() ).isEmpty();
                assertThat( diagnostic ).isInstanceOf( AspectDocumentDiagnostic.class );
             } );
    }
@@ -75,6 +76,7 @@ class AspectViolationDiagnosticMapperTest {
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( InvalidLexicalValueViolation.ERROR_CODE );
                assertThat( diagnostic.message() ).isEqualTo( "Invalid value" );
+               assertThat( diagnostic.code().href() ).isEmpty();
                assertThat( diagnostic ).isExactlyInstanceOf( AspectDiagnostic.class );
             } );
    }
@@ -91,6 +93,8 @@ class AspectViolationDiagnosticMapperTest {
       assertThat( report.diagnostics() ).singleElement()
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( ProcessingViolation.ERROR_CODE );
+               assertThat( diagnostic.code().href() ).contains(
+                     "https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/error-codes.html#ERR-PROCESSING" );
                assertThat( diagnostic.message() )
                      .isEqualTo( "Resource urn:samm:org.eclipse.esmf.test:1.0.0#notExistingProperty has no type" );
             } );
@@ -107,6 +111,8 @@ class AspectViolationDiagnosticMapperTest {
       assertThat( report.diagnostics() ).singleElement()
             .satisfies( diagnostic -> {
                assertThat( diagnostic.message() ).isEqualTo( "user facing validation message" );
+               assertThat( diagnostic.code().href() ).contains(
+                     "https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/error-codes.html#ERR-PROCESSING" );
                assertThat( diagnostic.message() )
                      .doesNotContain( "RuntimeException" )
                      .doesNotContain( "secret internal details" )
@@ -141,6 +147,8 @@ class AspectViolationDiagnosticMapperTest {
       assertThat( report.diagnostics() ).singleElement()
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( ProcessingViolation.ERROR_CODE );
+               assertThat( diagnostic.code().href() )
+                     .contains( "https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/error-codes.html#ERR-PROCESSING" );
                assertThat( diagnostic.message() ).isEqualTo( AspectViolationDiagnosticMapper.PROCESSING_ERROR_MESSAGE );
             } );
    }
@@ -156,6 +164,7 @@ class AspectViolationDiagnosticMapperTest {
       assertThat( report.diagnostics() ).singleElement()
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( TurtleDiagnosticCode.E0003.code() );
+               assertThat( diagnostic.code().href() ).isEmpty();
                assertThat( diagnostic.message() ).isEqualTo( "Triples not terminated by DOT" );
             } );
    }
@@ -170,6 +179,7 @@ class AspectViolationDiagnosticMapperTest {
       assertThat( report.diagnostics() ).singleElement()
             .satisfies( diagnostic -> {
                assertThat( diagnostic.code().code() ).isEqualTo( "ERR_TEST_SHACL" );
+               assertThat( diagnostic.code().href() ).isEmpty();
                assertThat( diagnostic.message() ).isEqualTo( "semantic problem" );
             } );
    }

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
@@ -34,6 +34,10 @@ class AspectModelNamingConventionValidationServiceTest {
       @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
       """;
+   private static final String NAMING_CONVENTION_DOCS = "https://eclipse-esmf.github.io/samm-specification/snapshot/modeling-guidelines"
+         + ".html#naming-rules";
+   private static final String BEST_PRACTICES_DOCS = "https://eclipse-esmf.github.io/samm-specification/snapshot/appendix/best-practices"
+         + ".html";
 
    private final AspectModelNamingConventionValidationService service = new AspectModelNamingConventionValidationService();
 
@@ -51,7 +55,8 @@ class AspectModelNamingConventionValidationServiceTest {
                      :myValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Characteristic name 'myValue' should start with an uppercase letter, e.g. 'MyValue'"
+                  "WARN_NAMING_CONVENTION",
+                  "'myValue' should start with an uppercase letter, e.g. 'MyValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
             ),
             Arguments.of(
                   "characteristic subtype starting lowercase produces warning",
@@ -66,7 +71,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:dataType xsd:string ;
                         samm-c:values ( "a" "b" ) .
                      """,
-                  "Characteristic name 'myState' should start with an uppercase letter, e.g. 'MyState'"
+                  "WARN_NAMING_CONVENTION",
+                  "'myState' should start with an uppercase letter, e.g. 'MyState'%n%s".formatted( NAMING_CONVENTION_DOCS )
             ),
             Arguments.of(
                   "property name starting uppercase produces warning",
@@ -80,7 +86,8 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyState a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Property name 'MyValue' should start with a lowercase letter, e.g. 'myValue'"
+                  "WARN_NAMING_CONVENTION",
+                  "'MyValue' should start with a lowercase letter, e.g. 'myValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
             ),
             Arguments.of(
                   "abstract property name starting uppercase produces warning",
@@ -97,7 +104,8 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyState a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Property name 'MyAbstractValue' should start with a lowercase letter, e.g. 'myAbstractValue'"
+                  "WARN_NAMING_CONVENTION",
+                  "'MyAbstractValue' should start with a lowercase letter, e.g. 'myAbstractValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
             ),
             Arguments.of(
                   "property name with uppercase acronym produces warning",
@@ -111,7 +119,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Name 'documentURL' should use camel case for acronyms instead of all-uppercase, e.g. 'documentUrl'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  ( "Name 'documentURL' should use camel case for acronyms instead of all-uppercase, e.g. 'documentUrl'%n%s" )
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "name with acronym followed by word keeps last acronym letter uppercase",
@@ -125,7 +135,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :XMLParserValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Name 'XMLParserValue' should use camel case for acronyms instead of all-uppercase, e.g. 'XmlParserValue'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  ( "Name 'XMLParserValue' should use camel case for acronyms instead of all-uppercase, e.g. 'XmlParserValue'%n%s" )
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "description starting lowercase produces warning",
@@ -134,7 +146,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:description "this is a test description."@en ;
                         samm:properties ( ) .
                      """,
-                  "Description 'this is a test description.' should start with an uppercase letter, e.g. 'This is a test description.'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Description should start with an uppercase letter%n%s".formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "description ending without punctuation produces warning",
@@ -143,7 +156,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:description "This is a test description"@en ;
                         samm:properties ( ) .
                      """,
-                  "Description 'This is a test description' should end with a period, e.g. 'This is a test description.'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Description should end with a period%n%s".formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "aspect name containing meta model type name produces warning",
@@ -151,7 +165,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :VehicleAspect a samm:Aspect ;
                         samm:properties ( ) .
                      """,
-                  "Name 'VehicleAspect' should not contain the meta model element type 'Aspect', e.g. 'Vehicle'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Name 'VehicleAspect' should not contain the meta model element type 'Aspect', e.g. 'Vehicle'%n%s"
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "property name containing meta model type name produces warning",
@@ -165,15 +181,19 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Name 'priceProperty' should not contain the meta model element type 'Property', e.g. 'price'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Name 'priceProperty' should not contain the meta model element type 'Property', e.g. 'price'%n%s"
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "aspect name containing meta model type name in the middle produces warning",
                   """
-                     :exampleAspectTest a samm:Aspect ;
+                     :ExampleAspectTest a samm:Aspect ;
                         samm:properties ( ) .
                      """,
-                  "Name 'exampleAspectTest' should not contain the meta model element type 'Aspect', e.g. 'exampleTest'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Name 'ExampleAspectTest' should not contain the meta model element type 'Aspect', e.g. 'ExampleTest'%n%s"
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "characteristic name containing meta model type name produces warning",
@@ -187,7 +207,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :TemperatureCharacteristic a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "Name 'TemperatureCharacteristic' should not contain the meta model element type 'Characteristic', e.g. 'Temperature'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Name 'TemperatureCharacteristic' should not contain the meta model element type 'Characteristic', e.g. 'Temperature'%n%s"
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "entity name containing meta model type name produces warning",
@@ -204,7 +226,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :EngineEntity a samm:Entity ;
                         samm:properties ( ) .
                      """,
-                  "Name 'EngineEntity' should not contain the meta model element type 'Entity', e.g. 'Engine'"
+                  "WARN_NAMING_BEST_PRACTICE",
+                  "Name 'EngineEntity' should not contain the meta model element type 'Entity', e.g. 'Engine'%n%s"
+                        .formatted( BEST_PRACTICES_DOCS )
             ),
             Arguments.of(
                   "name equal to meta model type name produces warning without suggestion",
@@ -218,22 +242,23 @@ class AspectModelNamingConventionValidationServiceTest {
                      :Characteristic a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
+                  "WARN_NAMING_BEST_PRACTICE",
                   "Name 'Characteristic' should not simply repeat the meta model element type 'Characteristic', "
-                        + "choose a more descriptive name"
+                        + "choose a more descriptive name%n%s".formatted( BEST_PRACTICES_DOCS )
             )
       );
    }
 
    @ParameterizedTest( name = "{0}" )
    @MethodSource( "namingConventionWarningScenarios" )
-   void namingConventionViolationProducesWarning( final String scenarioName, final String content,
+   void namingConventionViolationProducesWarning( final String scenarioName, final String content, final String expectedErrorCode,
          final String expectedMessage ) {
       final ParsedDocument document = parsedDocument( "Aspect.ttl", PREFIXES + content );
 
       final DiagnosticReport report = service.validate( document );
 
       assertThat( report.diagnostics() ).singleElement().isInstanceOfSatisfying( AspectDocumentDiagnostic.class, diagnostic -> {
-         assertThat( diagnostic.code().code() ).isEqualTo( "ERR_NAMING_CONVENTION" );
+         assertThat( diagnostic.code().code() ).isEqualTo( expectedErrorCode );
          assertThat( diagnostic.severity() ).isEqualTo( Diagnostic.Severity.WARNING );
          assertThat( diagnostic.message() ).isEqualTo( expectedMessage );
       } );

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.turtle.languageserver.aspect.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.esmf.turtle.languageserver.aspect.TestUtil.parsedDocument;
+
+import java.util.stream.Stream;
+
+import org.eclipse.esmf.Diagnostic;
+import org.eclipse.esmf.turtle.languageserver.aspect.diagnostic.AspectDocumentDiagnostic;
+import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticReport;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AspectModelNamingConventionValidationServiceTest {
+   private static final String PREFIXES = """
+      @prefix : <urn:samm:org.eclipse.esmf.test:1.0.0#> .
+      @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+      @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+      @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+      """;
+
+   private final AspectModelNamingConventionValidationService service = new AspectModelNamingConventionValidationService();
+
+   static Stream<Arguments> namingConventionWarningScenarios() {
+      return Stream.of(
+            Arguments.of(
+                  "characteristic name starting lowercase produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :myValue .
+
+                     :myValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Characteristic name 'myValue' should start with an uppercase letter, e.g. 'MyValue'"
+            ),
+            Arguments.of(
+                  "characteristic subtype starting lowercase produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :myState .
+
+                     :myState a samm-c:Enumeration ;
+                        samm:dataType xsd:string ;
+                        samm-c:values ( "a" "b" ) .
+                     """,
+                  "Characteristic name 'myState' should start with an uppercase letter, e.g. 'MyState'"
+            ),
+            Arguments.of(
+                  "property name starting uppercase produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :MyValue ) .
+
+                     :MyValue a samm:Property ;
+                        samm:characteristic :MyState .
+
+                     :MyState a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Property name 'MyValue' should start with a lowercase letter, e.g. 'myValue'"
+            ),
+            Arguments.of(
+                  "abstract property name starting uppercase produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :myValue ) .
+
+                     :myValue a samm:Property ;
+                        samm:extends :MyAbstractValue ;
+                        samm:characteristic :MyState .
+
+                     :MyAbstractValue a samm:AbstractProperty .
+
+                     :MyState a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Property name 'MyAbstractValue' should start with a lowercase letter, e.g. 'myAbstractValue'"
+            ),
+            Arguments.of(
+                  "property name with uppercase acronym produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :documentURL ) .
+
+                     :documentURL a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Name 'documentURL' should use camel case for acronyms instead of all-uppercase, e.g. 'documentUrl'"
+            ),
+            Arguments.of(
+                  "name with acronym followed by word keeps last acronym letter uppercase",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :XMLParserValue .
+
+                     :XMLParserValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Name 'XMLParserValue' should use camel case for acronyms instead of all-uppercase, e.g. 'XmlParserValue'"
+            ),
+            Arguments.of(
+                  "description starting lowercase produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:description "this is a test description."@en ;
+                        samm:properties ( ) .
+                     """,
+                  "Description 'this is a test description.' should start with an uppercase letter, e.g. 'This is a test description.'"
+            ),
+            Arguments.of(
+                  "description ending without punctuation produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:description "This is a test description"@en ;
+                        samm:properties ( ) .
+                     """,
+                  "Description 'This is a test description' should end with a period, e.g. 'This is a test description.'"
+            ),
+            Arguments.of(
+                  "aspect name containing meta model type name produces warning",
+                  """
+                     :VehicleAspect a samm:Aspect ;
+                        samm:properties ( ) .
+                     """,
+                  "Name 'VehicleAspect' should not contain the meta model element type 'Aspect', e.g. 'Vehicle'"
+            ),
+            Arguments.of(
+                  "property name containing meta model type name produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :priceProperty ) .
+
+                     :priceProperty a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Name 'priceProperty' should not contain the meta model element type 'Property', e.g. 'price'"
+            ),
+            Arguments.of(
+                  "aspect name containing meta model type name in the middle produces warning",
+                  """
+                     :exampleAspectTest a samm:Aspect ;
+                        samm:properties ( ) .
+                     """,
+                  "Name 'exampleAspectTest' should not contain the meta model element type 'Aspect', e.g. 'exampleTest'"
+            ),
+            Arguments.of(
+                  "characteristic name containing meta model type name produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :TemperatureCharacteristic .
+
+                     :TemperatureCharacteristic a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Name 'TemperatureCharacteristic' should not contain the meta model element type 'Characteristic', e.g. 'Temperature'"
+            ),
+            Arguments.of(
+                  "entity name containing meta model type name produces warning",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm-c:SingleEntity ;
+                        samm:dataType :EngineEntity .
+
+                     :EngineEntity a samm:Entity ;
+                        samm:properties ( ) .
+                     """,
+                  "Name 'EngineEntity' should not contain the meta model element type 'Entity', e.g. 'Engine'"
+            ),
+            Arguments.of(
+                  "name equal to meta model type name produces warning without suggestion",
+                  """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :Characteristic .
+
+                     :Characteristic a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """,
+                  "Name 'Characteristic' should not simply repeat the meta model element type 'Characteristic', "
+                        + "choose a more descriptive name"
+            )
+      );
+   }
+
+   @ParameterizedTest( name = "{0}" )
+   @MethodSource( "namingConventionWarningScenarios" )
+   void namingConventionViolationProducesWarning( final String scenarioName, final String content,
+         final String expectedMessage ) {
+      final ParsedDocument document = parsedDocument( "Aspect.ttl", PREFIXES + content );
+
+      final DiagnosticReport report = service.validate( document );
+
+      assertThat( report.diagnostics() ).singleElement().isInstanceOfSatisfying( AspectDocumentDiagnostic.class, diagnostic -> {
+         assertThat( diagnostic.code().code() ).isEqualTo( "ERR_NAMING_CONVENTION" );
+         assertThat( diagnostic.severity() ).isEqualTo( Diagnostic.Severity.WARNING );
+         assertThat( diagnostic.message() ).isEqualTo( expectedMessage );
+      } );
+   }
+
+   static Stream<Arguments> noDiagnosticScenarios() {
+      return Stream.of(
+            Arguments.of(
+                  "characteristic name starting uppercase produces no diagnostic",
+                  "Aspect.ttl",
+                  PREFIXES + """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :property ) .
+
+                     :property a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """
+            ),
+            Arguments.of(
+                  "property names are not flagged by characteristic naming convention",
+                  "Aspect.ttl",
+                  PREFIXES + """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :myValue ) .
+
+                     :myValue a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """
+            ),
+            Arguments.of(
+                  "non aspect model document is ignored",
+                  "plain.ttl",
+                  """
+                     @prefix ex: <http://example.com#> .
+
+                     ex:something ex:hasValue "42" .
+                     """
+            ),
+            Arguments.of(
+                  "camel cased name without acronym produces no acronym diagnostic",
+                  "Aspect.ttl",
+                  PREFIXES + """
+                     :Vehicle a samm:Aspect ;
+                        samm:properties ( :documentUrl ) .
+
+                     :documentUrl a samm:Property ;
+                        samm:characteristic :MyValue .
+
+                     :MyValue a samm:Characteristic ;
+                        samm:dataType xsd:string .
+                     """
+            ),
+            Arguments.of(
+                  "description starting uppercase with punctuation produces no diagnostic",
+                  "Aspect.ttl",
+                  PREFIXES + """
+                     :Vehicle a samm:Aspect ;
+                        samm:description "This is a test description."@en ;
+                        samm:properties ( ) .
+                     """
+            )
+      );
+   }
+
+   @ParameterizedTest( name = "{0}" )
+   @MethodSource( "noDiagnosticScenarios" )
+   void producesNoDiagnostic( final String scenarioName, final String fileName, final String content ) {
+      final ParsedDocument document = parsedDocument( fileName, content );
+
+      final DiagnosticReport report = service.validate( document );
+
+      assertThat( report.diagnostics() ).isEmpty();
+   }
+}

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/aspect/service/AspectModelNamingConventionValidationServiceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.esmf.turtle.languageserver.aspect.TestUtil.parsedDocum
 import java.util.stream.Stream;
 
 import org.eclipse.esmf.Diagnostic;
+import org.eclipse.esmf.aspectmodel.VersionInfo;
 import org.eclipse.esmf.turtle.languageserver.aspect.diagnostic.AspectDocumentDiagnostic;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticReport;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
@@ -34,10 +35,11 @@ class AspectModelNamingConventionValidationServiceTest {
       @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
       @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
       """;
-   private static final String NAMING_CONVENTION_DOCS = "https://eclipse-esmf.github.io/samm-specification/snapshot/modeling-guidelines"
-         + ".html#naming-rules";
-   private static final String BEST_PRACTICES_DOCS = "https://eclipse-esmf.github.io/samm-specification/snapshot/appendix/best-practices"
-         + ".html";
+   private static final String NAMING_CONVENTION_DOCS =
+         "https://eclipse-esmf.github.io/samm-specification/%s/modeling-guidelines.html#naming-rules"
+               .formatted( VersionInfo.ASPECT_META_MODEL_VERSION );
+   private static final String BEST_PRACTICES_DOCS = "https://eclipse-esmf.github.io/samm-specification/%s/appendix/best-practices.html"
+         .formatted( VersionInfo.ASPECT_META_MODEL_VERSION );
 
    private final AspectModelNamingConventionValidationService service = new AspectModelNamingConventionValidationService();
 
@@ -56,7 +58,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:dataType xsd:string .
                      """,
                   "WARN_NAMING_CONVENTION",
-                  "'myValue' should start with an uppercase letter, e.g. 'MyValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
+                  NAMING_CONVENTION_DOCS,
+                  "'myValue' should start with an uppercase letter, e.g. 'MyValue'"
             ),
             Arguments.of(
                   "characteristic subtype starting lowercase produces warning",
@@ -72,7 +75,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm-c:values ( "a" "b" ) .
                      """,
                   "WARN_NAMING_CONVENTION",
-                  "'myState' should start with an uppercase letter, e.g. 'MyState'%n%s".formatted( NAMING_CONVENTION_DOCS )
+                  NAMING_CONVENTION_DOCS,
+                  "'myState' should start with an uppercase letter, e.g. 'MyState'"
             ),
             Arguments.of(
                   "property name starting uppercase produces warning",
@@ -87,7 +91,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:dataType xsd:string .
                      """,
                   "WARN_NAMING_CONVENTION",
-                  "'MyValue' should start with a lowercase letter, e.g. 'myValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
+                  NAMING_CONVENTION_DOCS,
+                  "'MyValue' should start with a lowercase letter, e.g. 'myValue'"
             ),
             Arguments.of(
                   "abstract property name starting uppercase produces warning",
@@ -105,7 +110,8 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:dataType xsd:string .
                      """,
                   "WARN_NAMING_CONVENTION",
-                  "'MyAbstractValue' should start with a lowercase letter, e.g. 'myAbstractValue'%n%s".formatted( NAMING_CONVENTION_DOCS )
+                  NAMING_CONVENTION_DOCS,
+                  "'MyAbstractValue' should start with a lowercase letter, e.g. 'myAbstractValue'"
             ),
             Arguments.of(
                   "property name with uppercase acronym produces warning",
@@ -119,9 +125,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  ( "Name 'documentURL' should use camel case for acronyms instead of all-uppercase, e.g. 'documentUrl'%n%s" )
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'documentURL' should use camel case for acronyms instead of all-uppercase, e.g. 'documentUrl'"
             ),
             Arguments.of(
                   "name with acronym followed by word keeps last acronym letter uppercase",
@@ -135,9 +141,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :XMLParserValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  ( "Name 'XMLParserValue' should use camel case for acronyms instead of all-uppercase, e.g. 'XmlParserValue'%n%s" )
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'XMLParserValue' should use camel case for acronyms instead of all-uppercase, e.g. 'XmlParserValue'"
             ),
             Arguments.of(
                   "description starting lowercase produces warning",
@@ -146,8 +152,9 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:description "this is a test description."@en ;
                         samm:properties ( ) .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Description should start with an uppercase letter%n%s".formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Description should start with an uppercase letter"
             ),
             Arguments.of(
                   "description ending without punctuation produces warning",
@@ -156,8 +163,9 @@ class AspectModelNamingConventionValidationServiceTest {
                         samm:description "This is a test description"@en ;
                         samm:properties ( ) .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Description should end with a period%n%s".formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Description should end with a period"
             ),
             Arguments.of(
                   "aspect name containing meta model type name produces warning",
@@ -165,9 +173,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :VehicleAspect a samm:Aspect ;
                         samm:properties ( ) .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Name 'VehicleAspect' should not contain the meta model element type 'Aspect', e.g. 'Vehicle'%n%s"
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'VehicleAspect' should not contain the meta model element type 'Aspect', e.g. 'Vehicle'"
             ),
             Arguments.of(
                   "property name containing meta model type name produces warning",
@@ -181,9 +189,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :MyValue a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Name 'priceProperty' should not contain the meta model element type 'Property', e.g. 'price'%n%s"
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'priceProperty' should not contain the meta model element type 'Property', e.g. 'price'"
             ),
             Arguments.of(
                   "aspect name containing meta model type name in the middle produces warning",
@@ -191,9 +199,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :ExampleAspectTest a samm:Aspect ;
                         samm:properties ( ) .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Name 'ExampleAspectTest' should not contain the meta model element type 'Aspect', e.g. 'ExampleTest'%n%s"
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'ExampleAspectTest' should not contain the meta model element type 'Aspect', e.g. 'ExampleTest'"
             ),
             Arguments.of(
                   "characteristic name containing meta model type name produces warning",
@@ -207,9 +215,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :TemperatureCharacteristic a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Name 'TemperatureCharacteristic' should not contain the meta model element type 'Characteristic', e.g. 'Temperature'%n%s"
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'TemperatureCharacteristic' should not contain the meta model element type 'Characteristic', e.g. 'Temperature'"
             ),
             Arguments.of(
                   "entity name containing meta model type name produces warning",
@@ -226,9 +234,9 @@ class AspectModelNamingConventionValidationServiceTest {
                      :EngineEntity a samm:Entity ;
                         samm:properties ( ) .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
-                  "Name 'EngineEntity' should not contain the meta model element type 'Entity', e.g. 'Engine'%n%s"
-                        .formatted( BEST_PRACTICES_DOCS )
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
+                  "Name 'EngineEntity' should not contain the meta model element type 'Entity', e.g. 'Engine'"
             ),
             Arguments.of(
                   "name equal to meta model type name produces warning without suggestion",
@@ -242,9 +250,10 @@ class AspectModelNamingConventionValidationServiceTest {
                      :Characteristic a samm:Characteristic ;
                         samm:dataType xsd:string .
                      """,
-                  "WARN_NAMING_BEST_PRACTICE",
+                  "WARN_NAMING_BEST_PRACTICES",
+                  BEST_PRACTICES_DOCS,
                   "Name 'Characteristic' should not simply repeat the meta model element type 'Characteristic', "
-                        + "choose a more descriptive name%n%s".formatted( BEST_PRACTICES_DOCS )
+                        + "choose a more descriptive name"
             )
       );
    }
@@ -252,13 +261,14 @@ class AspectModelNamingConventionValidationServiceTest {
    @ParameterizedTest( name = "{0}" )
    @MethodSource( "namingConventionWarningScenarios" )
    void namingConventionViolationProducesWarning( final String scenarioName, final String content, final String expectedErrorCode,
-         final String expectedMessage ) {
+         final String expectedHref, final String expectedMessage ) {
       final ParsedDocument document = parsedDocument( "Aspect.ttl", PREFIXES + content );
 
       final DiagnosticReport report = service.validate( document );
 
       assertThat( report.diagnostics() ).singleElement().isInstanceOfSatisfying( AspectDocumentDiagnostic.class, diagnostic -> {
          assertThat( diagnostic.code().code() ).isEqualTo( expectedErrorCode );
+         assertThat( diagnostic.code().href() ).contains( expectedHref );
          assertThat( diagnostic.severity() ).isEqualTo( Diagnostic.Severity.WARNING );
          assertThat( diagnostic.message() ).isEqualTo( expectedMessage );
       } );


### PR DESCRIPTION
## Description
Add LSP validation for aspects:
- Characteristics and descriptions have to start with an uppercase letter
- Properties have to start with a lowercase letter
- Descriptions have to end with a dot
- Element names shall not be included in element definitions (e.g. TestAspect is an invalid name)
- Acronyms have to be in camel case

Fixes #1009

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works