### PR TITLE
Fix the OAS and JSON schema generation to map integral types to integer

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/XsdToJsonTypeMapping.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/XsdToJsonTypeMapping.java
@@ -25,11 +25,12 @@ import tools.jackson.databind.node.JsonNodeFactory;
 
 public class XsdToJsonTypeMapping {
    public enum JsonType {
-      NUMBER, BOOLEAN, STRING, OBJECT;
+      NUMBER, INTEGER, BOOLEAN, STRING, OBJECT;
 
       public JsonNode toJsonNode() {
          return switch ( this ) {
             case NUMBER -> JsonNodeFactory.instance.stringNode( "number" );
+            case INTEGER -> JsonNodeFactory.instance.stringNode( "integer" );
             case BOOLEAN -> JsonNodeFactory.instance.stringNode( "boolean" );
             case OBJECT -> JsonNodeFactory.instance.stringNode( "object" );
             default -> JsonNodeFactory.instance.stringNode( "string" );
@@ -43,21 +44,21 @@ public class XsdToJsonTypeMapping {
    public static final Map<Resource, JsonType> TYPE_MAP = ImmutableMap.<Resource, JsonType>builder()
          .put( XSD.xboolean, JsonType.BOOLEAN )
          .put( XSD.decimal, JsonType.NUMBER )
-         .put( XSD.integer, JsonType.NUMBER )
+         .put( XSD.integer, JsonType.INTEGER )
          .put( XSD.xfloat, JsonType.NUMBER )
          .put( XSD.xdouble, JsonType.NUMBER )
-         .put( XSD.xbyte, JsonType.NUMBER )
-         .put( XSD.xshort, JsonType.NUMBER )
-         .put( XSD.xint, JsonType.NUMBER )
-         .put( XSD.xlong, JsonType.NUMBER )
-         .put( XSD.unsignedByte, JsonType.NUMBER )
-         .put( XSD.unsignedShort, JsonType.NUMBER )
-         .put( XSD.unsignedInt, JsonType.NUMBER )
-         .put( XSD.unsignedLong, JsonType.NUMBER )
-         .put( XSD.positiveInteger, JsonType.NUMBER )
-         .put( XSD.nonPositiveInteger, JsonType.NUMBER )
-         .put( XSD.negativeInteger, JsonType.NUMBER )
-         .put( XSD.nonNegativeInteger, JsonType.NUMBER )
+         .put( XSD.xbyte, JsonType.INTEGER )
+         .put( XSD.xshort, JsonType.INTEGER )
+         .put( XSD.xint, JsonType.INTEGER )
+         .put( XSD.xlong, JsonType.INTEGER )
+         .put( XSD.unsignedByte, JsonType.INTEGER )
+         .put( XSD.unsignedShort, JsonType.INTEGER )
+         .put( XSD.unsignedInt, JsonType.INTEGER )
+         .put( XSD.unsignedLong, JsonType.INTEGER )
+         .put( XSD.positiveInteger, JsonType.INTEGER )
+         .put( XSD.nonPositiveInteger, JsonType.INTEGER )
+         .put( XSD.negativeInteger, JsonType.INTEGER )
+         .put( XSD.nonNegativeInteger, JsonType.INTEGER )
          .put( RDF.langString, JsonType.OBJECT )
          .build();
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
@@ -503,7 +503,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
       }
 
       return switch ( getSchemaTypeForAspectType( typeResource ) ) {
-         case NUMBER -> getNumberNode( value.getValue() ).getOrElse( FACTORY.numberNode( 0 ) );
+         case NUMBER, INTEGER -> getNumberNode( value.getValue() ).getOrElse( FACTORY.numberNode( 0 ) );
          case STRING -> FACTORY.stringNode( value.getValue().toString() );
          case BOOLEAN -> FACTORY.booleanNode( (boolean) value.getValue() );
          default -> throw new DocumentGenerationException( "Could not convert value " + value + " to JSON" );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaGeneratorTest.java
@@ -208,7 +208,7 @@ class AspectModelJsonSchemaGeneratorTest {
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
       assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['description']" ) )
             .isEqualTo( "This is a byteProperty characteristic." );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       final String unitReference = SammNs.SAMMC.UnitReference().getLocalName();
       assertThat( context.<String>read( "$['properties']['curieProperty']['allOf'][0]['$ref']" ) )
@@ -296,12 +296,12 @@ class AspectModelJsonSchemaGeneratorTest {
       characteristicReference = context.<String>read( "$['properties']['intProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/IntPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['integerProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/IntegerPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       final String multiLanguageText = SammNs.SAMMC.MultiLanguageText().getLocalName();
       assertThat( context.<String>read( "$['properties']['langStringProperty']['allOf'][0]['$ref']" ) )
@@ -315,32 +315,32 @@ class AspectModelJsonSchemaGeneratorTest {
       characteristicReference = context.<String>read( "$['properties']['longProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/LongPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['negativeIntegerProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/NegativeIntegerPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['nonNegativeIntegerProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/NonNegativeIntegerPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['nonPositiveInteger']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/NonPositiveIntegerCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['positiveIntegerProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/PositiveIntegerPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['shortProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/ShortPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       final String text = SammNs.SAMMC.Text().getLocalName();
       assertThat( context.<String>read( "$['properties']['stringProperty']['allOf'][0]['$ref']" ) )
@@ -359,22 +359,22 @@ class AspectModelJsonSchemaGeneratorTest {
       characteristicReference = context.<String>read( "$['properties']['unsignedByteProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/UnsignedBytePropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['unsignedIntProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/UnsignedIntPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['unsignedLongProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/UnsignedLongPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['unsignedShortProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/UnsignedShortPropertyCharacteristic" );
       characteristicName = characteristicReference.substring( characteristicReference.lastIndexOf( "/" ) + 1 );
-      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['" + characteristicName + "']['type']" ) ).isEqualTo( "integer" );
 
       characteristicReference = context.<String>read( "$['properties']['yearMonthDurationProperty']['allOf'][0]['$ref']" );
       assertThat( characteristicReference ).isEqualTo( "#/components/schemas/YearMonthDurationPropertyCharacteristic" );
@@ -538,7 +538,7 @@ class AspectModelJsonSchemaGeneratorTest {
       assertThat( context.<Integer>read( "$['components']['schemas']['TestLengthConstraintWithCollection']['minItems']" ) )
             .isEqualTo( 1 );
       assertThat( context.<String>read( "$['components']['schemas']['TestLengthConstraintWithCollection']['items']['type']" ) )
-            .isEqualTo( "number" );
+            .isEqualTo( "integer" );
 
       final ObjectNode payload = JsonNodeFactory.instance.objectNode();
       final ArrayNode array = JsonNodeFactory.instance.arrayNode();
@@ -577,7 +577,7 @@ class AspectModelJsonSchemaGeneratorTest {
             .isEqualTo( "#/components/schemas/TestRangeConstraint" );
       assertThat( context.<String>read( "$['components']['schemas']['TestRangeConstraint']['description']" ) )
             .isEqualTo( "This is a test range constraint." );
-      assertThat( context.<String>read( "$['components']['schemas']['TestRangeConstraint']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['TestRangeConstraint']['type']" ) ).isEqualTo( "integer" );
       assertThat(
             context.<String>read(
                   "$['components']['schemas']['TestRangeConstraint']['" + AspectModelJsonSchemaGenerator.SAMM_EXTENSION + "']" ) )
@@ -645,7 +645,7 @@ class AspectModelJsonSchemaGeneratorTest {
       assertThat(
             context.<String>read( "$['components']['schemas']['IntegerRange']['" + AspectModelJsonSchemaGenerator.SAMM_EXTENSION + "']" ) )
                   .isEqualTo( TestModel.TEST_NAMESPACE + "IntegerRange" );
-      assertThat( context.<String>read( "$['components']['schemas']['IntegerRange']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['IntegerRange']['type']" ) ).isEqualTo( "integer" );
       assertThat( context.<Integer>read( "$['components']['schemas']['IntegerRange']['minimum']" ) ).isEqualTo( 12 );
       assertThat( context.<Integer>read( "$['components']['schemas']['IntegerRange']['maximum']" ) ).isEqualTo( 23 );
       assertThat( context.<Boolean>read( "$['components']['schemas']['IntegerRange']['exclusiveMaximum']" ) ).isTrue();
@@ -656,7 +656,7 @@ class AspectModelJsonSchemaGeneratorTest {
       assertThat(
             context.<String>read( "$['components']['schemas']['IntRange']['" + AspectModelJsonSchemaGenerator.SAMM_EXTENSION + "']" ) )
                   .isEqualTo( TestModel.TEST_NAMESPACE + "IntRange" );
-      assertThat( context.<String>read( "$['components']['schemas']['IntRange']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['IntRange']['type']" ) ).isEqualTo( "integer" );
       assertThat( context.<Integer>read( "$['components']['schemas']['IntRange']['minimum']" ) ).isEqualTo( 12 );
       assertThat( context.<Integer>read( "$['components']['schemas']['IntRange']['maximum']" ) ).isEqualTo( 23 );
       assertThat( context.<Boolean>read( "$['components']['schemas']['IntRange']['exclusiveMaximum']" ) ).isTrue();
@@ -798,7 +798,7 @@ class AspectModelJsonSchemaGeneratorTest {
             .isEqualTo( "#/components/schemas/TestEnumeration" );
       assertThat( context.<String>read( "$['components']['schemas']['TestEnumeration']['description']" ) )
             .isEqualTo( "This is a test for enumeration." );
-      assertThat( context.<String>read( "$['components']['schemas']['TestEnumeration']['type']" ) ).isEqualTo( "number" );
+      assertThat( context.<String>read( "$['components']['schemas']['TestEnumeration']['type']" ) ).isEqualTo( "integer" );
       assertThat(
             context.<String>read(
                   "$['components']['schemas']['TestEnumeration']['" + AspectModelJsonSchemaGenerator.SAMM_EXTENSION + "']" ) )


### PR DESCRIPTION
## Description

This PR fixes `aspect to openapi` and `aspect to schema` to map the integral types to `integer` rather than `number`, avoiding unintended truncation or validation errors.

Fixes #1011

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas

  - No comments were added as the changes are simple and straightforward

- [ ] I have made corresponding changes to the documentation

  - As far as I can see, there is no documentation on the data conversion rules of OAS and JSON schema generation, while [Java](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/java-code-generation.html#type-mapping) and [SQL](https://eclipse-esmf.github.io/esmf-developer-guide/tooling-guide/java-code-generation.html#databricks-type-mapping) generation have them.

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional notes:

In addition to updating the existing tests, I've manually made sure the revised OAS document and JSON Schema are valid against their specification, as follows:

```
$ java -jar tools/samm-cli/target/samm-cli-DEV-SNAPSHOT.jar aspect core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithSimpleProperties.ttl to openapi -b http://example.com -o /tmp/AspectWithSimpleProperties.yaml
$ grep -C1 integer /tmp/AspectWithSimpleProperties.yaml 
    Int:
      type: integer
      minimum: -2147483648
$ openapi-generator-cli validate -i /tmp/AspectWithSimpleProperties.yaml 
Validating spec (/tmp/AspectWithSimpleProperties.yaml)
No validation issues detected.
```

```
$ java -jar tools/samm-cli/target/samm-cli-DEV-SNAPSHOT.jar aspect core/esmf-test-aspect-models/src/main/resources/valid/org.eclipse.esmf.test/1.0.0/AspectWithSimpleProperties.ttl to schema -o /tmp/AspectWithSimpleProperties.schema.json
$ grep -C1 integer /tmp/AspectWithSimpleProperties.schema.json 
      "Int" : {
        "type" : "integer",
        "maximum" : 2147483647,
$ check-jsonschema --check-metaschema /tmp/AspectWithSimpleProperties.schema.json
ok -- validation done
```