### PR TITLE
Add a new option to `aspect usage` for specifying the output format

### DIFF
--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -249,9 +249,10 @@ of model resolution] for more information.
                                      changes in the report .                                                                 |
                                    | _--force_ : When a new file is to be created but it already exists in the file system,
                                      the operation will be cancelled, unless `--force` is used.                              |
-.1+| [[aspect-usage]] aspect <model> usage | Shows where model elements are used in an Aspect. `model` can be an Aspect Model
+.2+| [[aspect-usage]] aspect <model> usage | Shows where model elements are used in an Aspect. `model` can be an Aspect Model
                                      file or an element URN. If `model` is a URN, at least one `--models-root` must also be
                                      specified.                                                                              | `samm aspect AspectModelFile.ttl usage`
+                                   | _--format, -f_ : Specifies the output format. Valid values are `table` (default) and `csv`. | `samm aspect AspectModelFile.ttl usage --format csv`
 .3+| [[aas-to-aspect]] aas <aas file> to aspect | Translate Asset Administration Shell (AAS) Submodel Templates to
                                      Aspect Models                                                                           | `samm aas AssetAdminShell.aasx to aspect`
                                    | _--output-directory, -d_ : output directory to write files to (default:

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectUsageCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectUsageCommand.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.esmf.AbstractCommand;
 import org.eclipse.esmf.InputHandler;
 import org.eclipse.esmf.LoggingMixin;
@@ -163,22 +164,11 @@ public class AspectUsageCommand extends AbstractCommand {
       // Print data rows
       references.stream().sorted( Comparator.comparing( reference -> reference.pointer().toString() ) ).forEach( reference -> {
          // Escape CSV fields that contain commas or quotes
-         final String element = escapeCsvField( reference.pointer().toString() );
-         final String inFile = escapeCsvField( reference.pointerSource().toString() );
-         final String pointsTo = escapeCsvField( reference.pointee().toString() );
-         final String pointsToFile = escapeCsvField( reference.pointeeSource().toString() );
+         final String element = StringEscapeUtils.escapeCsv( reference.pointer().toString() );
+         final String inFile = StringEscapeUtils.escapeCsv( reference.pointerSource().toString() );
+         final String pointsTo = StringEscapeUtils.escapeCsv( reference.pointee().toString() );
+         final String pointsToFile = StringEscapeUtils.escapeCsv( reference.pointeeSource().toString() );
          System.out.printf( "%s,%s,%s,%s%n", element, inFile, pointsTo, pointsToFile );
       } );
-   }
-
-   private String escapeCsvField( final String field ) {
-      // If field contains comma, quote, or newline, escape it
-      if ( field.contains( "," ) || field.contains( "\"" ) || field.contains( "\n" ) ) {
-         // Escape quotes by doubling them
-         final String escaped = field.replace( "\"", "\"\"" );
-         // Wrap in quotes
-         return "\"" + escaped + "\"";
-      }
-      return field;
    }
 }

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectUsageCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/AspectUsageCommand.java
@@ -44,6 +44,30 @@ import picocli.CommandLine;
 public class AspectUsageCommand extends AbstractCommand {
    public static final String COMMAND_NAME = "usage";
 
+   /**
+    * The list of supported aspect usage output formats
+    */
+   private enum AspectUsageFormat {
+      TABLE, CSV;
+
+      @Override
+      public String toString() {
+         return switch ( this ) {
+            case TABLE -> "table";
+            case CSV -> "csv";
+         };
+      }
+
+      /**
+       * Returns a formatted list of the valid formats
+       *
+       * @return the list of formats
+       */
+      public static String allValues() {
+         return String.join( ", ", java.util.stream.Stream.of( values() ).map( AspectUsageFormat::toString ).toList() );
+      }
+   }
+
    @CommandLine.ParentCommand
    public AspectCommand parentCommand;
 
@@ -52,6 +76,11 @@ public class AspectUsageCommand extends AbstractCommand {
       names = { "--details" },
       description = "Print detailed reports on errors" )
    private boolean details = false;
+
+   @CommandLine.Option(
+      names = { "--format", "-f" },
+      description = "Output format. Valid options are ${COMPLETION-CANDIDATES}. Default is ${DEFAULT-VALUE}." )
+   private AspectUsageFormat format = AspectUsageFormat.TABLE;
 
    @CommandLine.Mixin
    private LoggingMixin loggingMixin;
@@ -92,6 +121,16 @@ public class AspectUsageCommand extends AbstractCommand {
          System.exit( 0 );
       }
 
+      if ( AspectUsageFormat.CSV == format ) {
+         printCsvOutput( references );
+      } else if ( AspectUsageFormat.TABLE == format ) {
+         printTableOutput( references );
+      } else {
+         throw new CommandException( "Invalid format: " + format + ". Valid formats are " + AspectUsageFormat.allValues() );
+      }
+   }
+
+   private void printTableOutput( final List<Reference> references ) {
       final String[] headerParts = new String[] { "Element", "in file", "Points to", "in file" };
       final int[] columnWidth = Arrays.stream( headerParts ).mapToInt( String::length ).toArray();
       for ( final Reference reference : references ) {
@@ -115,5 +154,31 @@ public class AspectUsageCommand extends AbstractCommand {
                reference.pointee(),
                reference.pointeeSource() );
       } );
+   }
+
+   private void printCsvOutput( final List<Reference> references ) {
+      // Print CSV header
+      System.out.println( "Element,in file,Points to,in file" );
+
+      // Print data rows
+      references.stream().sorted( Comparator.comparing( reference -> reference.pointer().toString() ) ).forEach( reference -> {
+         // Escape CSV fields that contain commas or quotes
+         final String element = escapeCsvField( reference.pointer().toString() );
+         final String inFile = escapeCsvField( reference.pointerSource().toString() );
+         final String pointsTo = escapeCsvField( reference.pointee().toString() );
+         final String pointsToFile = escapeCsvField( reference.pointeeSource().toString() );
+         System.out.printf( "%s,%s,%s,%s%n", element, inFile, pointsTo, pointsToFile );
+      } );
+   }
+
+   private String escapeCsvField( final String field ) {
+      // If field contains comma, quote, or newline, escape it
+      if ( field.contains( "," ) || field.contains( "\"" ) || field.contains( "\n" ) ) {
+         // Escape quotes by doubling them
+         final String escaped = field.replace( "\"", "\"\"" );
+         // Wrap in quotes
+         return "\"" + escaped + "\"";
+      }
+      return field;
    }
 }

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -1513,6 +1513,47 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
+   void testAspectUsageWithCsvFormat() {
+      final ExecutionResult result =
+            sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "usage", "--format", "csv" );
+      assertThat( result.stderr() ).isEmpty();
+      // CSV output should start with header line
+      assertThat( result.stdout() ).startsWith( "Element,in file,Points to,in file" );
+      // Should contain some data rows in CSV format (with commas, not pipes)
+      assertThat( result.stdout() ).contains( "," );
+      assertThat( result.stdout() ).doesNotContain( "|" );
+   }
+
+   @Test
+   void testAspectUsageWithCsvFormatShortOption() {
+      final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "usage", "-f", "csv" );
+      assertThat( result.stderr() ).isEmpty();
+      // CSV output should start with header line
+      assertThat( result.stdout() ).startsWith( "Element,in file,Points to,in file" );
+      // Should contain some data rows in CSV format (with commas, not pipes)
+      assertThat( result.stdout() ).contains( "," );
+      assertThat( result.stdout() ).doesNotContain( "|" );
+   }
+
+   @Test
+   void testAspectUsageDefaultFormatIsTable() {
+      final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "usage" );
+      assertThat( result.stderr() ).isEmpty();
+      // Default table output should contain pipe characters
+      assertThat( result.stdout() ).contains( "|" );
+      // Should not contain commas in the header
+      assertThat( result.stdout() ).doesNotStartWith( "Element,in file,Points to,in file" );
+   }
+
+   @Test
+   void testAspectUsageInvalidFormat() {
+      final ExecutionResult result = sammCli.apply( "--disable-color", "aspect", defaultInputFile, "usage", "--format", "invalid" );
+      assertThat( result.exitStatus() ).isEqualTo( 2 );
+      assertThat( result.stdout() ).isEmpty();
+      assertThat( result.stderr() ).contains( "Invalid value for option '--format'" );
+   }
+
+   @Test
    void testPackageWithoutSubcommand() {
       final ExecutionResult result = sammCli.apply( "--disable-color", "package" );
       assertThat( result.exitStatus() ).isEqualTo( 2 );


### PR DESCRIPTION
## Description

This PR adds a new option to `aspect usage` so that users can output the results in the CSV format in addition to the current tabular format.

Fixes #1013

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
