### PR TITLE
Fix highlighting for multi line strings

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammType.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammType.java
@@ -19,8 +19,14 @@ import java.net.URI;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.Optional;
+
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.apache.jena.datatypes.BaseDatatype;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.vocabulary.RDF;
 
 import org.eclipse.esmf.aspectmodel.AspectModelFile;
 import org.eclipse.esmf.aspectmodel.ValueParsingException;
@@ -29,10 +35,6 @@ import org.eclipse.esmf.metamodel.Scalar;
 
 import io.vavr.control.Try;
 import jakarta.xml.bind.DatatypeConverter;
-import org.apache.jena.datatypes.BaseDatatype;
-import org.apache.jena.datatypes.RDFDatatype;
-import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.vocabulary.RDF;
 
 /**
  * Represents a scalar datatype, such as xsd:integer, and provides parser and serializer
@@ -40,13 +42,14 @@ import org.apache.jena.vocabulary.RDF;
  * @param <T> the Java type corresponding to values of this type
  */
 public sealed interface SammType<T> extends RDFDatatype, Scalar
-      permits CurieType, SammType.IntegerType, SammType.RdfLangString, SammType.XsdAnyUri, SammType.XsdBase64Binary, SammType.XsdBoolean,
-      SammType.XsdByte, SammType.XsdDate, SammType.XsdDateTime, SammType.XsdDateTimeStamp, SammType.XsdDayTimeDuration, SammType.XsdDecimal,
-      SammType.XsdDouble, SammType.XsdDuration, SammType.XsdFloat, SammType.XsdGDay, SammType.XsdGMonth, SammType.XsdGYear,
-      SammType.XsdGYearMonth, SammType.XsdHexBinary, SammType.XsdInt, SammType.XsdInteger, SammType.XsdLong, SammType.XsdMonthDay,
-      SammType.XsdNegativeInteger, SammType.XsdNonNegativeInteger, SammType.XsdNonPositiveInteger, SammType.XsdPositiveInteger,
-      SammType.XsdShort, SammType.XsdString, SammType.XsdTime, SammType.XsdUnsignedByte, SammType.XsdUnsignedInt, SammType.XsdUnsignedLong,
-      SammType.XsdUnsignedShort, SammType.XsdYearMonthDuration, SammXsdType, SammXsdType.SammExtendedXsdType {
+      permits CurieType, SammType.NumericType, SammType.IntegerType, SammType.RdfLangString, SammType.XsdAnyUri, SammType.XsdBase64Binary,
+      SammType.XsdBoolean, SammType.XsdByte, SammType.XsdDate, SammType.XsdDateTime, SammType.XsdDateTimeStamp, SammType.XsdDayTimeDuration,
+      SammType.XsdDecimal, SammType.XsdDouble, SammType.XsdDuration, SammType.XsdFloat, SammType.XsdGDay, SammType.XsdGMonth,
+      SammType.XsdGYear, SammType.XsdGYearMonth, SammType.XsdHexBinary, SammType.XsdInt, SammType.XsdInteger, SammType.XsdLong,
+      SammType.XsdMonthDay, SammType.XsdNegativeInteger, SammType.XsdNonNegativeInteger, SammType.XsdNonPositiveInteger,
+      SammType.XsdPositiveInteger, SammType.XsdShort, SammType.XsdString, SammType.XsdTime, SammType.XsdUnsignedByte,
+      SammType.XsdUnsignedInt, SammType.XsdUnsignedLong, SammType.XsdUnsignedShort, SammType.XsdYearMonthDuration, SammXsdType,
+      SammXsdType.SammExtendedXsdType {
    /**
     * Parses a lexical representation of a value of the type
     *
@@ -118,13 +121,27 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
    SammType<Curie> CURIE = CurieType.INSTANCE;
 
    /**
+    * Returns the SAMM type object that corresponds to the given URI
+    *
+    * @param typeUri the type URI
+    * @return the SAMM type object
+    */
+   static Optional<SammType<?>> forUri( final String typeUri ) {
+      return SammXsdType.ALL_TYPES.stream().filter( xsdType -> xsdType.getURI().equals( typeUri ) ).findAny();
+   }
+
+   sealed interface NumericType<T> extends SammType<T> permits IntegerType, XsdDouble, XsdFloat, XsdDecimal {
+
+   }
+
+   /**
     * Numeric types with integer numbers
     *
     * @param <T> the Java type corresponding to values of this type
     */
-   sealed interface IntegerType<T> extends SammType<T> permits XsdInteger, XsdByte, XsdShort, XsdInt, XsdLong,
+   sealed interface IntegerType<T> extends SammType<T>, NumericType<T> permits XsdInteger, XsdByte, XsdShort, XsdInt, XsdLong,
          XsdUnsignedByte, XsdUnsignedShort, XsdUnsignedInt, XsdUnsignedLong, XsdPositiveInteger, XsdNonNegativeInteger,
-         XsdNonPositiveInteger, XsdNegativeInteger {
+         XsdNonPositiveInteger, XsdNegativeInteger, XsdDecimal {
       /**
        * The minimum value for this type
        *
@@ -219,7 +236,8 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
       }
    }
 
-   final class XsdDecimal extends SammXsdType<BigDecimal> implements SammType<BigDecimal> {
+   final class XsdDecimal extends SammXsdType<BigDecimal>
+         implements SammType<BigDecimal>, IntegerType<BigDecimal>, NumericType<BigDecimal> {
       private XsdDecimal() {
          super( org.apache.jena.vocabulary.XSD.decimal, BigDecimal.class );
       }
@@ -238,6 +256,16 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
       @Override
       public <T, C> T accept( final AspectVisitor<T, C> visitor, final C context ) {
          return visitor.visitXsdDecimal( this, context );
+      }
+
+      @Override
+      public Optional<BigInteger> lowerBound() {
+         return Optional.empty();
+      }
+
+      @Override
+      public Optional<BigInteger> upperBound() {
+         return Optional.empty();
       }
    }
 
@@ -273,7 +301,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
       }
    }
 
-   final class XsdDouble extends SammXsdType<Double> implements SammType<Double> {
+   final class XsdDouble extends SammXsdType<Double> implements SammType<Double>, NumericType<Double> {
       private XsdDouble() {
          super( org.apache.jena.vocabulary.XSD.xdouble, Double.class );
       }
@@ -307,7 +335,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
       }
    }
 
-   final class XsdFloat extends SammXsdType<Float> implements SammType<Float> {
+   final class XsdFloat extends SammXsdType<Float> implements SammType<Float>, NumericType<Float> {
       private XsdFloat() {
          super( org.apache.jena.vocabulary.XSD.xfloat, Float.class );
       }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammXsdType.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammXsdType.java
@@ -85,8 +85,7 @@ public abstract non-sealed class SammXsdType<T> extends XSDDatatype implements S
                      SammType.BYTE, SammType.SHORT, SammType.INT, SammType.LONG, SammType.UNSIGNED_BYTE, SammType.UNSIGNED_SHORT,
                      SammType.UNSIGNED_INT, SammType.UNSIGNED_LONG, SammType.POSITIVE_INTEGER, SammType.NON_NEGATIVE_INTEGER,
                      SammType.NEGATIVE_INTEGER, SammType.NON_POSITIVE_INTEGER, SammType.HEX_BINARY, SammType.BASE64_BINARY,
-                     SammType.ANY_URI,
-                     SammType.LANG_STRING, SammType.CURIE
+                     SammType.ANY_URI, SammType.LANG_STRING, SammType.CURIE
                );
                allTypesCache = local;
             }
@@ -213,16 +212,27 @@ public abstract non-sealed class SammXsdType<T> extends XSDDatatype implements S
    /**
     * Returns the Java class corresponding to a XSD type in a given meta model version.
     *
+    * @param typeUri the datatype URI
+    * @return the java class
+    */
+   public static Class<?> getJavaTypeForMetaModelType( final String typeUri ) {
+      return ALL_TYPES
+            .stream()
+            .filter( xsdType -> xsdType.getURI().equals( typeUri ) )
+            .map( RDFDatatype::getJavaClass )
+            .findAny()
+            .orElseThrow( () -> new IllegalStateException( "Invalid data type " + typeUri + " found in model." ) );
+
+   }
+
+   /**
+    * Returns the Java class corresponding to a XSD type in a given meta model version.
+    *
     * @param type the resource of the data type
     * @return the java class
     */
    public static Class<?> getJavaTypeForMetaModelType( final Resource type ) {
-      return ALL_TYPES
-            .stream()
-            .filter( xsdType -> xsdType.getURI().equals( type.getURI() ) )
-            .map( RDFDatatype::getJavaClass )
-            .findAny()
-            .orElseThrow( () -> new IllegalStateException( "Invalid data type " + type + " found in model." ) );
+      return getJavaTypeForMetaModelType( type.getURI() );
    }
 
    @Override

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/RdfUtil.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/RdfUtil.java
@@ -329,4 +329,21 @@ public class RdfUtil {
             .findFirst()
             .orElse( uri );
    }
+
+   /**
+    * Expand a CURIE for a "well-known" namespace to the corresponding full URI.
+    * For example, the result for "xsd:float" is "http://w3.org/2001/XMLSchema#float".
+    * For URIs from other/unknown namespaces, the CURIE is returned as-is.
+    *
+    * @param curie the CURIE
+    * @return the corresponding URI
+    */
+   @SuppressWarnings( "JavadocLinkAsPlainText" )
+   public static String fullUri( final String curie ) {
+      return SammNs.wellKnownNamespaces()
+            .filter( ns -> curie.startsWith( ns.getShortForm() + ":" ) )
+            .map( ns -> curie.replace( ns.getShortForm() + ":", ns.getNamespace() ) )
+            .findFirst()
+            .orElse( curie );
+   }
 }

--- a/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
+++ b/core/esmf-tree-sitter-turtle/src/main/java/org/eclipse/esmf/treesitterturtle/TurtleSyntaxTree.java
@@ -76,7 +76,7 @@ public class TurtleSyntaxTree {
     * Represents one node in the concrete syntax tree in the source document
     *
     * @param type the type of token, expected to be one of the constants in {@link ParserTokenType}
-    * @param content the actual content of the token
+    * @param contentSupplier supplier for the actual content of the token
     * @param location the location in the source document
     * @param children children of the node
     */

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.eclipse.esmf.turtle.languageserver.aspect.navigation.AspectCrossFileDefinitionService;
 import org.eclipse.esmf.turtle.languageserver.lsp.ResolutionStrategyService;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticMapper;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticReport;
@@ -31,7 +32,6 @@ import org.eclipse.esmf.turtle.languageserver.structure.DocumentSymbolService;
 import org.eclipse.esmf.turtle.languageserver.structure.TurtleTokenService;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleCompletionService;
 import org.eclipse.esmf.turtle.languageserver.turtle.ValidationCoordinator;
-import org.eclipse.esmf.turtle.languageserver.aspect.navigation.AspectCrossFileDefinitionService;
 import org.eclipse.esmf.turtle.languageserver.turtle.navigation.TurtleDefinitionService;
 
 import org.eclipse.lsp4j.CompletionItem;
@@ -83,13 +83,13 @@ public class TurtleTextDocumentService implements TextDocumentService {
       turtleDefinitionService = new TurtleDefinitionService();
       turtleCompletionService = new TurtleCompletionService();
       turtleParserService = new TreeSitterTurtleParserService();
-      tokenService = new TurtleTokenService( turtleParserService );
+      tokenService = new TurtleTokenService();
       aspectCrossFileDefinitionService = new AspectCrossFileDefinitionService( turtleParserService, documents, resolutionStrategyService );
       documentSymbolService = new DocumentSymbolService( turtleParserService );
       final List<DiagnosticsProvider> diagnosticsProviders =
             Streams.stream( ServiceLoader.load( DiagnosticsProvider.class ).iterator() ).toList();
       diagnosticsProviders.forEach( provider -> {
-         if ( provider instanceof ResolutionStrategyAwareDiagnosticsProvider aware ) {
+         if ( provider instanceof final ResolutionStrategyAwareDiagnosticsProvider aware ) {
             aware.setResolutionStrategyService( resolutionStrategyService );
          }
       } );
@@ -176,11 +176,12 @@ public class TurtleTextDocumentService implements TextDocumentService {
    public CompletableFuture<SemanticTokens> semanticTokensFull( final SemanticTokensParams params ) {
       final String uri = params.getTextDocument().getUri();
       final Document document = documents.get( uri );
+      final ParsedDocument parsedDocument = turtleParserService.apply( document );
       LOG.info( "[semanticTokensFull] URI={}", uri );
       if ( document == null ) {
          return CompletableFuture.completedFuture( new SemanticTokens( List.of() ) );
       }
-      return CompletableFuture.supplyAsync( () -> tokenService.buildSemanticTokens( document ), asyncExecutor );
+      return CompletableFuture.supplyAsync( () -> tokenService.buildSemanticTokens( parsedDocument ), asyncExecutor );
    }
 
    @Override

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
@@ -176,11 +176,11 @@ public class TurtleTextDocumentService implements TextDocumentService {
    public CompletableFuture<SemanticTokens> semanticTokensFull( final SemanticTokensParams params ) {
       final String uri = params.getTextDocument().getUri();
       final Document document = documents.get( uri );
-      final ParsedDocument parsedDocument = turtleParserService.apply( document );
       LOG.info( "[semanticTokensFull] URI={}", uri );
       if ( document == null ) {
          return CompletableFuture.completedFuture( new SemanticTokens( List.of() ) );
       }
+      final ParsedDocument parsedDocument = turtleParserService.apply( document );
       return CompletableFuture.supplyAsync( () -> tokenService.buildSemanticTokens( parsedDocument ), asyncExecutor );
    }
 

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenService.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.eclipse.esmf.Location;
+import org.eclipse.esmf.aspectmodel.RdfUtil;
+import org.eclipse.esmf.metamodel.datatype.SammType;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
 import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
@@ -204,6 +206,25 @@ public class TurtleTokenService {
          case ParserTokenType.SYMBOL_DOUBLE_CARET -> SemanticTokenTypes.Decorator;
          case ParserTokenType.SYMBOL_FULL_STOP -> SemanticTokenTypes.Decorator;
          case ParserTokenType.SYMBOL_SEMICOLON -> SemanticTokenTypes.Decorator;
+         case ParserTokenType.RDF_LITERAL -> {
+            if ( node.childWithType( ParserTokenType.SYMBOL_DOUBLE_CARET ).isPresent() ) {
+               // Typed literal
+               yield node.childWithType( ParserTokenType.PREFIXED_NAME )
+                     .map( TurtleSyntaxTree.Node::content )
+                     .map( RdfUtil::fullUri )
+                     .map( typeUri -> SammType.forUri( typeUri )
+                           .filter( sammType -> sammType instanceof SammType.NumericType<?> )
+                           .map( _ -> SemanticTokenTypes.Number )
+                           .orElse( SemanticTokenTypes.String ) )
+                     .orElse( "" );
+            } else if ( node.childWithType( ParserTokenType.LANG_TAG ).isPresent() ) {
+               // rdf:langString
+               yield SemanticTokenTypes.String;
+            } else {
+               // plain string
+               yield SemanticTokenTypes.String;
+            }
+         }
          default -> "";
       };
       if ( semanticToken.isEmpty() ) {

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenService.java
@@ -20,13 +20,16 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.eclipse.esmf.Location;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 import org.eclipse.esmf.treesitterturtle.ParserTokenType;
+import org.eclipse.esmf.treesitterturtle.TurtleSyntaxTree;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
-import org.eclipse.esmf.turtle.languageserver.lsp.text.TreeSitterTurtleParserService;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
 
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
@@ -34,10 +37,6 @@ import org.eclipse.lsp4j.SemanticTokens;
 import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.treesitter.TSNode;
-import org.treesitter.TSTree;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Service that maps parser tokens to LSP semantic tokens
@@ -62,27 +61,6 @@ public class TurtleTokenService {
          )
    );
 
-   private static final Map<String, String> PARSER_TOKEN_TO_SEMANTIC_TOKEN = ImmutableMap.<String, String>builder()
-         .put( ParserTokenType.COMMENT, SemanticTokenTypes.Comment )
-         .put( ParserTokenType.AT_BASE, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.AT_PREFIX, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.SPARQL_BASE, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.SPARQL_PREFIX, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.A, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.STRING, SemanticTokenTypes.String )
-         .put( ParserTokenType.INTEGER, SemanticTokenTypes.Number )
-         .put( ParserTokenType.DECIMAL, SemanticTokenTypes.Number )
-         .put( ParserTokenType.DOUBLE, SemanticTokenTypes.Number )
-         .put( ParserTokenType.BOOLEAN_LITERAL, SemanticTokenTypes.Keyword )
-         .put( ParserTokenType.LANG_TAG, SemanticTokenTypes.Decorator )
-         .put( ParserTokenType.PN_PREFIX, SemanticTokenTypes.Function )
-         .put( ParserTokenType.PN_LOCAL, SemanticTokenTypes.Property )
-         .put( ParserTokenType.SYMBOL_DOUBLE_CARET, SemanticTokenTypes.Decorator )
-         .put( ParserTokenType.SYMBOL_FULL_STOP, SemanticTokenTypes.Decorator )
-         .put( ParserTokenType.SYMBOL_SEMICOLON, SemanticTokenTypes.Decorator )
-         .build();
-   private final TreeSitterTurtleParserService parserService;
-
    private final Map<String, Integer> tokenTypeIds = IntStream.range( 0, SUPPORTED_TOKEN_TYPES.getTokenTypes().size() )
          .boxed()
          .collect( Collectors.toMap( i -> SUPPORTED_TOKEN_TYPES.getTokenTypes().get( i ), Function.identity() ) );
@@ -90,23 +68,18 @@ public class TurtleTokenService {
          .boxed()
          .collect( Collectors.toMap( i -> SUPPORTED_TOKEN_TYPES.getTokenModifiers().get( i ), Function.identity() ) );
 
-   public TurtleTokenService( final TreeSitterTurtleParserService parserService ) {
-      this.parserService = parserService;
-   }
+   public TurtleTokenService() {}
 
    /**
     * Represents a single token over a given range
     *
-    * @param line the line where the token appears
-    * @param column the column in the line
-    * @param length the length of the token in characters
+    * @param location the location of the token
     * @param tokenType the token type
     * @param tokenModifiers the token modifiers bit set
     */
    private record TokenRange(
-         int line,
-         int column,
-         int length,
+         Location location,
+         String content,
          int tokenType,
          int tokenModifiers
    ) {}
@@ -116,30 +89,54 @@ public class TurtleTokenService {
     *
     * @param document the document
     */
-   public SemanticTokens buildSemanticTokens( final Document document ) {
+   public SemanticTokens buildSemanticTokens( final ParsedDocument document ) {
       final List<TokenRange> tokenRanges = new ArrayList<>();
-      final TSTree concreteSyntaxTree = parserService.apply( document ).concreteSyntaxTree();
-      final Deque<TSNode> nodes = new ArrayDeque<>();
-      TSNode node;
-      nodes.push( concreteSyntaxTree.getRootNode() );
+      final Deque<TurtleSyntaxTree.Node> nodes = new ArrayDeque<>();
+      TurtleSyntaxTree.Node node;
+      nodes.push( document.turtleSyntaxTree().rootNode() );
       while ( !nodes.isEmpty() ) {
          node = nodes.pop();
-         for ( int i = 0; i < node.getChildCount(); i++ ) {
-            nodes.push( node.getChild( i ) );
-         }
+         node.children().forEach( nodes::push );
 
          final int tokenId = tokenIdForNode( node );
          if ( tokenId == -1 ) {
             continue;
          }
 
-         final int line = node.getStartPoint().getRow();
-         final int column = node.getStartPoint().getColumn();
-         final int length = node.getEndByte() - node.getStartByte();
-         tokenRanges.add( new TokenRange( line, column, length, tokenId, tokenModifierBitSetForNode( node, document ) ) );
+         final Location location = node.location();
+         final TokenRange tokenRange = new TokenRange( location,
+               document.sourceDocument().subSequence( location.fromLine(), location.fromColumn(), location.toLine(), location.toColumn() ),
+               tokenId, tokenModifierBitSetForNode( node ) );
+         tokenRanges.addAll( splitIntoSingleLineTokens( tokenRange ) );
       }
 
-      return buildSemanticTokens( tokenRanges );
+      return buildSemanticTokens( tokenRanges, document.sourceDocument() );
+   }
+
+   private List<TokenRange> splitIntoSingleLineTokens( final TokenRange tokenRange ) {
+      if ( !tokenRange.content().contains( "\n" ) ) {
+         return List.of( tokenRange );
+      }
+
+      final List<TokenRange> result = new ArrayList<>();
+      final String[] lines = tokenRange.content().split( "\n", -1 );
+      int currentLine = tokenRange.location().fromLine();
+      int currentColumn = tokenRange.location().fromColumn();
+
+      for ( int i = 0; i < lines.length; i++ ) {
+         final String lineContent = lines[i];
+         if ( i == lines.length - 1 && lineContent.isEmpty() ) {
+            // Skip the last empty line if content ends with \n
+            break;
+         }
+
+         final Location lineLocation = new Location( currentLine, currentColumn, currentLine, currentColumn + lineContent.length() );
+         result.add( new TokenRange( lineLocation, lineContent, tokenRange.tokenType(), tokenRange.tokenModifiers() ) );
+         currentLine++;
+         currentColumn = 0;
+      }
+
+      return result;
    }
 
    /**
@@ -152,14 +149,16 @@ public class TurtleTokenService {
     *      Tokens at LSP specification</a>
     * @return the SemanticTokens representation
     */
-   private SemanticTokens buildSemanticTokens( final List<TokenRange> tokenRanges ) {
-      tokenRanges.sort( Comparator.comparingInt( TokenRange::line ).thenComparingInt( TokenRange::column ) );
+   private SemanticTokens buildSemanticTokens( final List<TokenRange> tokenRanges, final Document document ) {
+      final ToIntFunction<TokenRange> lineExtractor = tokenRange -> tokenRange.location().fromLine();
+      final ToIntFunction<TokenRange> columnExtractor = tokenRange -> tokenRange.location().fromColumn();
+      tokenRanges.sort( Comparator.comparingInt( lineExtractor ).thenComparingInt( columnExtractor ) );
       final List<Integer> data = new ArrayList<>();
       int lastLine = -1;
       int lastColumn = -1;
       for ( final TokenRange tokenRange : tokenRanges ) {
-         final int line = tokenRange.line();
-         final int column = tokenRange.column();
+         final int line = tokenRange.location().fromLine();
+         final int column = tokenRange.location().fromColumn();
          if ( lastLine == -1 ) {
             data.add( line );
             data.add( column );
@@ -167,7 +166,9 @@ public class TurtleTokenService {
             data.add( line - lastLine );
             data.add( lastLine == line ? column - lastColumn : column );
          }
-         data.add( tokenRange.length() );
+         final int length = document.subSequence( tokenRange.location().fromLine(), tokenRange.location().fromColumn(),
+               tokenRange.location().toLine(), tokenRange.location().toColumn() ).length();
+         data.add( length );
          data.add( tokenRange.tokenType() );
          data.add( tokenRange.tokenModifiers() );
          lastLine = line;
@@ -184,9 +185,28 @@ public class TurtleTokenService {
     * @see TurtleTokenService#SUPPORTED_TOKEN_TYPES
     * @return the corresponding tokenId
     */
-   private int tokenIdForNode( final TSNode node ) {
-      final String semanticToken = PARSER_TOKEN_TO_SEMANTIC_TOKEN.get( node.getGrammarType() );
-      if ( semanticToken == null ) {
+   private int tokenIdForNode( final TurtleSyntaxTree.Node node ) {
+      final String semanticToken = switch ( node.type() ) {
+         case ParserTokenType.COMMENT -> SemanticTokenTypes.Comment;
+         case ParserTokenType.AT_BASE -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.AT_PREFIX -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.SPARQL_BASE -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.SPARQL_PREFIX -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.A -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.STRING -> SemanticTokenTypes.String;
+         case ParserTokenType.INTEGER -> SemanticTokenTypes.Number;
+         case ParserTokenType.DECIMAL -> SemanticTokenTypes.Number;
+         case ParserTokenType.DOUBLE -> SemanticTokenTypes.Number;
+         case ParserTokenType.BOOLEAN_LITERAL -> SemanticTokenTypes.Keyword;
+         case ParserTokenType.LANG_TAG -> SemanticTokenTypes.Decorator;
+         case ParserTokenType.PN_PREFIX -> SemanticTokenTypes.Function;
+         case ParserTokenType.PN_LOCAL -> SemanticTokenTypes.Property;
+         case ParserTokenType.SYMBOL_DOUBLE_CARET -> SemanticTokenTypes.Decorator;
+         case ParserTokenType.SYMBOL_FULL_STOP -> SemanticTokenTypes.Decorator;
+         case ParserTokenType.SYMBOL_SEMICOLON -> SemanticTokenTypes.Decorator;
+         default -> "";
+      };
+      if ( semanticToken.isEmpty() ) {
          return -1;
       }
 
@@ -198,11 +218,10 @@ public class TurtleTokenService {
       return semanticTokenId;
    }
 
-   private int tokenModifierBitSetForNode( final TSNode node, final Document document ) {
+   private int tokenModifierBitSetForNode( final TurtleSyntaxTree.Node node ) {
       int bitSet = 0;
-      if ( node.getGrammarType().equals( ParserTokenType.PN_PREFIX ) ) {
-         final String token = document.subSequence( node.getStartPoint().getRow(), node.getStartPoint().getColumn(),
-               node.getEndPoint().getRow(), node.getEndPoint().getColumn() );
+      if ( node.type().equals( ParserTokenType.PN_PREFIX ) ) {
+         final String token = node.content();
          if ( token.equals( SammNs.SAMM.getShortForm() ) || token.equals( SammNs.SAMMC.getShortForm() ) ) {
             bitSet = bitSet | ( 1 << tokenModifierTypeIds.get( SemanticTokenModifiers.DefaultLibrary ) );
          }

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/structure/TurtleTokenServiceTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.turtle.languageserver.structure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.TreeSitterTurtleParserService;
+
+import org.eclipse.lsp4j.SemanticTokens;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TurtleTokenServiceTest {
+   private TurtleTokenService tokenService;
+   private TreeSitterTurtleParserService parserService;
+
+   @BeforeEach
+   void setUp() {
+      tokenService = new TurtleTokenService();
+      parserService = new TreeSitterTurtleParserService();
+   }
+
+   @Test
+   void testBasicSemanticTokens() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject ex:predicate ex:object .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+      // Each token is represented by 5 integers: deltaLine, deltaColumn, length, tokenType,
+      // tokenModifiers
+      assertThat( tokens.getData().size() % 5 ).isEqualTo( 0 );
+   }
+
+   @Test
+   void testMultiLineStringLiteral() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject ex:description \"\"\"This is a
+         multi-line
+         string literal.\"\"\" .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+
+      // Verify tokens are split correctly - each token should be on a single line
+      // The data format is [deltaLine, deltaColumn, length, tokenType, tokenModifiers]
+      // We iterate through the tokens and verify no length exceeds what could fit on a single line
+      for ( int i = 0; i < tokens.getData().size(); i += 5 ) {
+         final int length = tokens.getData().get( i + 2 );
+         // Multi-line content should be split, so each token length should be reasonable for a single line
+         assertThat( length ).isGreaterThan( 0 );
+      }
+   }
+
+   @Test
+   void testMultiLineCommentToken() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         # This is a comment
+         # on multiple lines
+         ex:subject ex:predicate ex:object .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+   }
+
+   @Test
+   void testSingleQuoteMultiLineString() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject ex:note '''This is
+         another multi-line
+         string with single quotes.''' .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+   }
+
+   @Test
+   void testComplexDocumentWithMultiLineStrings() {
+      final Document document = new Document( "test.ttl", """
+         @prefix : <urn:samm:org.eclipse.esmf.test:1.0.0#> .
+         @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+         @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+         :TestAspect a samm:Aspect ;
+            samm:preferredName "Test Aspect"@en ;
+            samm:description \"\"\"This is a test aspect
+            with a multi-line description
+            that spans several lines.\"\"\"@en ;
+            samm:properties ( :property1 :property2 ) .
+
+         :property1 a samm:Property ;
+            samm:preferredName "Property 1"@en ;
+            samm:description "Single line description"@en ;
+            samm:characteristic samm-c:Text .
+
+         :property2 a samm:Property ;
+            samm:preferredName "Property 2"@en ;
+            samm:description '''Another multi-line
+            description using
+            single quotes.'''@en ;
+            samm:characteristic samm-c:Text .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+
+      // Verify the data is well-formed
+      assertThat( tokens.getData().size() % 5 ).isEqualTo( 0 );
+
+      // Check that all deltaLine values are non-negative
+      for ( int i = 0; i < tokens.getData().size(); i += 5 ) {
+         final int deltaLine = tokens.getData().get( i );
+         assertThat( deltaLine ).isGreaterThanOrEqualTo( 0 );
+      }
+   }
+
+   @Test
+   void testTokenTypesAreValid() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+         ex:subject
+            ex:stringProp "test string" ;
+            ex:numberProp 42 ;
+            ex:decimalProp 3.14 ;
+            ex:boolProp true ;
+            ex:langString "test"@en ;
+            ex:typedLiteral "123"^^xsd:integer ;
+            a ex:Class .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+
+      // Verify all token types are within valid range
+      final int maxTokenType = TurtleTokenService.SUPPORTED_TOKEN_TYPES.getTokenTypes().size() - 1;
+      for ( int i = 0; i < tokens.getData().size(); i += 5 ) {
+         final int tokenType = tokens.getData().get( i + 3 );
+         assertThat( tokenType ).isBetween( 0, maxTokenType );
+      }
+   }
+
+   @Test
+   void testEmptyDocument() {
+      final Document document = new Document( "test.ttl", "" );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      // Empty document should produce empty token list
+      assertThat( tokens.getData() ).isEmpty();
+   }
+
+   @Test
+   void testOnlyWhitespace() {
+      final Document document = new Document( "test.ttl", "   \n\n   \n" );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      // Whitespace-only document should produce empty token list
+      assertThat( tokens.getData() ).isEmpty();
+   }
+
+   @Test
+   void testMultiLineStringWithEscapes() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject ex:text \"\"\"Line 1
+         Line 2 with \\"quotes\\"
+         Line 3 with \\n escape
+         Line 4\"\"\" .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+   }
+
+   @Test
+   void testTokenOrdering() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject1 ex:predicate1 ex:object1 .
+         ex:subject2 ex:predicate2 ex:object2 .
+         """ );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+
+      // Verify tokens are properly ordered (deltaLine should increase or stay same)
+      int currentLine = 0;
+      int currentColumn = 0;
+      for ( int i = 0; i < tokens.getData().size(); i += 5 ) {
+         final int deltaLine = tokens.getData().get( i );
+         final int deltaColumn = tokens.getData().get( i + 1 );
+
+         currentLine += deltaLine;
+         if ( deltaLine == 0 ) {
+            currentColumn += deltaColumn;
+         } else {
+            currentColumn = deltaColumn;
+         }
+
+         // All positions should be non-negative
+         assertThat( currentLine ).isGreaterThanOrEqualTo( 0 );
+         assertThat( currentColumn ).isGreaterThanOrEqualTo( 0 );
+      }
+   }
+
+   @Test
+   void testMultiLineStringAtEndOfFile() {
+      final Document document = new Document( "test.ttl", """
+         @prefix ex: <http://example.org/> .
+
+         ex:subject ex:description \"\"\"Multi-line
+         string at
+         end of file.\"\"\" .""" );
+
+      final SemanticTokens tokens = tokenService.buildSemanticTokens( parserService.apply( document ) );
+
+      assertThat( tokens ).isNotNull();
+      assertThat( tokens.getData() ).isNotEmpty();
+   }
+}


### PR DESCRIPTION
## Description

LSP: Fixes syntax highlighting for multi-line string literals.

Fixes #1018 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
