### PR TITLE
Add RdfDatatypeUris class and refactor LANG_STRING usage

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/Scalar.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/Scalar.java
@@ -15,11 +15,11 @@ package org.eclipse.esmf.metamodel;
 
 import java.util.Map;
 
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 /**
@@ -87,7 +87,7 @@ public interface Scalar extends Type {
             .add( XSD.base64Binary.getURI() )
             .add( XSD.anyURI.getURI() )
             .add( SammNs.SAMM.curie().getURI() )
-            .add( RDF.langString.getURI() )
+            .add( RdfDatatypeUris.LANG_STRING )
             .build()
             .contains( getUrn() );
    }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/RdfDatatypeUris.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/RdfDatatypeUris.java
@@ -18,6 +18,5 @@ public final class RdfDatatypeUris {
    // Jena's RDF vocabulary can trigger order-sensitive Jena runtime initialization.
    public static final String LANG_STRING = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 
-   private RdfDatatypeUris() {
-   }
+   private RdfDatatypeUris() {}
 }

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/RdfDatatypeUris.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/RdfDatatypeUris.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.metamodel.datatype;
+
+public final class RdfDatatypeUris {
+   // Do not use RDF.langString.getURI() for string-only URI access: touching
+   // Jena's RDF vocabulary can trigger order-sensitive Jena runtime initialization.
+   public static final String LANG_STRING = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
+   private RdfDatatypeUris() {
+   }
+}

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammType.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammType.java
@@ -32,7 +32,6 @@ import jakarta.xml.bind.DatatypeConverter;
 import org.apache.jena.datatypes.BaseDatatype;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.vocabulary.RDF;
 
 /**
  * Represents a scalar datatype, such as xsd:integer, and provides parser and serializer
@@ -142,7 +141,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
    final class RdfLangString extends BaseDatatype implements SammType<LangString> {
       public RdfLangString() {
-         super( RDF.langString.getURI() );
+         super( RdfDatatypeUris.LANG_STRING );
       }
 
       @Override
@@ -358,7 +357,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.date, lexicalForm, cause ) );
       }
 
@@ -385,7 +384,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.time, lexicalForm, cause ) );
       }
 
@@ -412,7 +411,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.dateTime, lexicalForm, cause ) );
       }
 
@@ -439,7 +438,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> SammXsdType.datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> SammXsdType.datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.dateTimeStamp, lexicalForm, cause ) );
       }
 
@@ -467,7 +466,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.gYear, lexicalForm, cause ) );
       }
 
@@ -495,7 +494,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.gMonth, lexicalForm, cause ) );
       }
 
@@ -523,7 +522,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.gDay, lexicalForm, cause ) );
       }
 
@@ -551,7 +550,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.gYearMonth, lexicalForm, cause ) );
       }
 
@@ -578,7 +577,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public XMLGregorianCalendar parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newXMLGregorianCalendar( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newXMLGregorianCalendar( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.gMonthDay, lexicalForm, cause ) );
       }
 
@@ -600,7 +599,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public javax.xml.datatype.Duration parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> datatypeFactory.newDuration( lexicalForm ) )
+         return Try.of( () -> datatypeFactory().newDuration( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.duration, lexicalForm, cause ) );
       }
 
@@ -623,7 +622,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public javax.xml.datatype.Duration parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> SammXsdType.datatypeFactory.newDurationYearMonth( lexicalForm ) )
+         return Try.of( () -> SammXsdType.datatypeFactory().newDurationYearMonth( lexicalForm ) )
                .getOrElseThrow(
                      cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.yearMonthDuration, lexicalForm, cause ) );
       }
@@ -647,7 +646,7 @@ public sealed interface SammType<T> extends RDFDatatype, Scalar
 
       @Override
       public javax.xml.datatype.Duration parseTypedValue( final String lexicalForm ) {
-         return Try.of( () -> SammXsdType.datatypeFactory.newDurationDayTime( lexicalForm ) )
+         return Try.of( () -> SammXsdType.datatypeFactory().newDurationDayTime( lexicalForm ) )
                .getOrElseThrow( cause -> new ValueParsingException( org.apache.jena.vocabulary.XSD.dayTimeDuration, lexicalForm, cause ) );
       }
 

--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammXsdType.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/metamodel/datatype/SammXsdType.java
@@ -19,7 +19,6 @@ import java.util.AbstractList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 
@@ -30,8 +29,6 @@ import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.impl.LiteralLabel;
 import org.apache.jena.rdf.model.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The custom RDF type implementations that have deterministic and typed parsers and unparsers
@@ -41,8 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 // the order of the variables is required because of the way they reference each other
 public abstract non-sealed class SammXsdType<T> extends XSDDatatype implements SammType<T> {
-   private static final Logger LOG = LoggerFactory.getLogger( SammXsdType.class );
-   protected static DatatypeFactory datatypeFactory;
+   private static volatile DatatypeFactory datatypeFactory;
    private final String uri;
 
    private static boolean checking = true;
@@ -62,6 +58,24 @@ public abstract non-sealed class SammXsdType<T> extends XSDDatatype implements S
    public abstract boolean isValid( final String lexicalForm );
 
    protected abstract T parseTypedValue( final String lexicalForm );
+
+   protected static DatatypeFactory datatypeFactory() {
+      DatatypeFactory local = datatypeFactory;
+      if ( local == null ) {
+         synchronized ( SammXsdType.class ) {
+            local = datatypeFactory;
+            if ( local == null ) {
+               try {
+                  local = DatatypeFactory.newInstance();
+               } catch ( final DatatypeConfigurationException exception ) {
+                  throw new IllegalStateException( "Could not instantiate DatatypeFactory", exception );
+               }
+               datatypeFactory = local;
+            }
+         }
+      }
+      return local;
+   }
 
    @Override
    public String getURI() {
@@ -198,12 +212,7 @@ public abstract non-sealed class SammXsdType<T> extends XSDDatatype implements S
     */
    public static synchronized void setupTypeMapping() {
       if ( !setupPerformed ) {
-         try {
-            datatypeFactory = DatatypeFactory.newInstance();
-         } catch ( final DatatypeConfigurationException exception ) {
-            LOG.error( "Could not instantiate DatatypeFactory", exception );
-         }
-
+         datatypeFactory();
          final TypeMapper typeMapper = TypeMapper.getInstance();
          ALL_TYPES.forEach( typeMapper::registerDatatype );
          setupPerformed = true;

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiator.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/loader/ValueInstantiator.java
@@ -19,11 +19,10 @@ import java.util.Optional;
 import org.eclipse.esmf.metamodel.Scalar;
 import org.eclipse.esmf.metamodel.ScalarValue;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.datatype.SammXsdType;
 import org.eclipse.esmf.metamodel.impl.DefaultScalar;
 import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
-
-import org.apache.jena.vocabulary.RDF;
 
 /**
  * Creates new instances of {@link ScalarValue} from the value representation in RDF
@@ -61,7 +60,7 @@ public class ValueInstantiator {
       // .xsd.impl.RDFLangString but _not_ org.eclipse.esmf.metamodel.datatypes.LangString as we would
       // like to.
       // 3. So we construct an instance of LangString here from the RDFLangString.
-      if ( datatypeUri.equals( RDF.langString.getURI() ) ) {
+      if ( datatypeUri.equals( RdfDatatypeUris.LANG_STRING ) ) {
          return buildLanguageString( baseAttributes, lexicalRepresentation, languageTag );
       }
 
@@ -80,7 +79,7 @@ public class ValueInstantiator {
          return Optional.empty();
       }
       final LangString langString = new LangString( lexicalRepresentation, locale );
-      final Scalar type = new DefaultScalar( RDF.langString.getURI() );
+      final Scalar type = new DefaultScalar( RdfDatatypeUris.LANG_STRING );
       return Optional.of( new DefaultScalarValue( baseAttributes, langString, type ) );
    }
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/serializer/PrettyPrinter.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/serializer/PrettyPrinter.java
@@ -25,6 +25,16 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.esmf.aspectmodel.AspectModelFile;
+import org.eclipse.esmf.aspectmodel.RdfUtil;
+import org.eclipse.esmf.aspectmodel.resolver.parser.TokenRegistry;
+import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
+import org.eclipse.esmf.buildtime.template.VersionInfo;
+import org.eclipse.esmf.metamodel.ModelElement;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
+import org.eclipse.esmf.metamodel.vocabulary.SammNs;
+
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Graph;
@@ -50,16 +60,6 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.rdf.model.impl.Util;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
-
-import org.eclipse.esmf.aspectmodel.AspectModelFile;
-import org.eclipse.esmf.aspectmodel.RdfUtil;
-import org.eclipse.esmf.aspectmodel.resolver.parser.TokenRegistry;
-import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
-import org.eclipse.esmf.buildtime.template.VersionInfo;
-import org.eclipse.esmf.metamodel.ModelElement;
-import org.eclipse.esmf.metamodel.vocabulary.SammNs;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * Serializes an {@link AspectModelFile} to RDF/Turtle while following the formatting rules for
@@ -353,7 +353,7 @@ public class PrettyPrinter {
          return value;
       }
 
-      if ( type.getURI().equals( RDF.langString.getURI() ) ) {
+      if ( type.getURI().equals( RdfDatatypeUris.LANG_STRING ) ) {
          return quoteValue( value ) + "@" + literal.getLanguage();
       }
 

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/serializer/RdfModelCreatorVisitor.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/serializer/RdfModelCreatorVisitor.java
@@ -67,6 +67,7 @@ import org.eclipse.esmf.metamodel.constraint.LocaleConstraint;
 import org.eclipse.esmf.metamodel.constraint.RangeConstraint;
 import org.eclipse.esmf.metamodel.constraint.RegularExpressionConstraint;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.datatype.SammType;
 import org.eclipse.esmf.metamodel.datatype.SammXsdType;
 import org.eclipse.esmf.metamodel.vocabulary.RdfNamespace;
@@ -538,7 +539,7 @@ public class RdfModelCreatorVisitor implements AspectVisitor<RdfModelCreatorVisi
       final Model model = ModelFactory.createDefaultModel();
       final Type type = value.getType();
       final Literal literal;
-      if ( type.getUrn().equals( RDF.langString.getURI() ) ) {
+      if ( type.getUrn().equals( RdfDatatypeUris.LANG_STRING ) ) {
          final LangString langString = (LangString) value.getValue();
          literal = ResourceFactory.createLangLiteral( langString.getValue(), langString.getLanguageTag().toLanguageTag() );
       } else {

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/metamodel/builder/SammBuilder.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/metamodel/builder/SammBuilder.java
@@ -29,9 +29,6 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.vocabulary.RDF;
-
 import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
 import org.eclipse.esmf.aspectmodel.loader.ValueInstantiator;
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
@@ -98,12 +95,15 @@ import org.eclipse.esmf.metamodel.constraint.impl.DefaultLocaleConstraint;
 import org.eclipse.esmf.metamodel.constraint.impl.DefaultRangeConstraint;
 import org.eclipse.esmf.metamodel.constraint.impl.DefaultRegularExpressionConstraint;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.impl.DefaultAspect;
 import org.eclipse.esmf.metamodel.impl.DefaultCharacteristic;
 import org.eclipse.esmf.metamodel.impl.DefaultEntity;
 import org.eclipse.esmf.metamodel.impl.DefaultEntityInstance;
 import org.eclipse.esmf.metamodel.impl.DefaultProperty;
 import org.eclipse.esmf.metamodel.impl.DefaultScalarValue;
+
+import org.apache.jena.rdf.model.Resource;
 
 /**
  * Builder for SAMM elements.
@@ -1698,7 +1698,7 @@ public class SammBuilder {
       if ( text == null || language == null ) {
          throw new AspectModelBuildingException( "Test and language must not be null" );
       }
-      return new ValueInstantiator().buildScalarValue( text, language.toLanguageTag(), RDF.langString.getURI() )
+      return new ValueInstantiator().buildScalarValue( text, language.toLanguageTag(), RdfDatatypeUris.LANG_STRING )
             .orElseThrow( AspectModelBuildingException::new );
    }
 

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
@@ -26,6 +26,34 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
+import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
+import org.eclipse.esmf.metamodel.Aspect;
+import org.eclipse.esmf.metamodel.Characteristic;
+import org.eclipse.esmf.metamodel.CollectionValue;
+import org.eclipse.esmf.metamodel.Entity;
+import org.eclipse.esmf.metamodel.EntityInstance;
+import org.eclipse.esmf.metamodel.ModelElement;
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Scalar;
+import org.eclipse.esmf.metamodel.ScalarValue;
+import org.eclipse.esmf.metamodel.Type;
+import org.eclipse.esmf.metamodel.characteristic.Code;
+import org.eclipse.esmf.metamodel.characteristic.Collection;
+import org.eclipse.esmf.metamodel.characteristic.Duration;
+import org.eclipse.esmf.metamodel.characteristic.Either;
+import org.eclipse.esmf.metamodel.characteristic.Enumeration;
+import org.eclipse.esmf.metamodel.characteristic.Measurement;
+import org.eclipse.esmf.metamodel.characteristic.Quantifiable;
+import org.eclipse.esmf.metamodel.characteristic.SingleEntity;
+import org.eclipse.esmf.metamodel.characteristic.SortedSet;
+import org.eclipse.esmf.metamodel.characteristic.State;
+import org.eclipse.esmf.metamodel.characteristic.StructuredValue;
+import org.eclipse.esmf.metamodel.characteristic.Trait;
+import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
@@ -75,38 +103,8 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementCollect
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueList;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueReferencePair;
-
-import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
-import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
-import org.eclipse.esmf.metamodel.Aspect;
-import org.eclipse.esmf.metamodel.Characteristic;
-import org.eclipse.esmf.metamodel.CollectionValue;
-import org.eclipse.esmf.metamodel.Entity;
-import org.eclipse.esmf.metamodel.EntityInstance;
-import org.eclipse.esmf.metamodel.ModelElement;
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Scalar;
-import org.eclipse.esmf.metamodel.ScalarValue;
-import org.eclipse.esmf.metamodel.Type;
-import org.eclipse.esmf.metamodel.characteristic.Code;
-import org.eclipse.esmf.metamodel.characteristic.Collection;
-import org.eclipse.esmf.metamodel.characteristic.Duration;
-import org.eclipse.esmf.metamodel.characteristic.Either;
-import org.eclipse.esmf.metamodel.characteristic.Enumeration;
-import org.eclipse.esmf.metamodel.characteristic.Measurement;
-import org.eclipse.esmf.metamodel.characteristic.Quantifiable;
-import org.eclipse.esmf.metamodel.characteristic.SingleEntity;
-import org.eclipse.esmf.metamodel.characteristic.SortedSet;
-import org.eclipse.esmf.metamodel.characteristic.State;
-import org.eclipse.esmf.metamodel.characteristic.StructuredValue;
-import org.eclipse.esmf.metamodel.characteristic.Trait;
-import org.eclipse.esmf.metamodel.datatype.LangString;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.ImmutableMap;
-
 import tools.jackson.databind.node.ArrayNode;
 
 public class AspectModelAasVisitor implements AspectVisitor<Environment, Context> {
@@ -642,7 +640,7 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
 
    private DataTypeIec61360 mapIec61360DataType( final Optional<Characteristic> characteristic ) {
       return mapIec61360DataType(
-            characteristic.flatMap( Characteristic::getDataType ).map( Type::getUrn ).orElse( RDF.langString.getURI() ) );
+            characteristic.flatMap( Characteristic::getDataType ).map( Type::getUrn ).orElse( RdfDatatypeUris.LANG_STRING ) );
    }
 
    private DataTypeIec61360 mapIec61360DataType( final Characteristic characteristic ) {

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/LangStringPropertyMapper.java
@@ -16,14 +16,13 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.jena.vocabulary.RDF;
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Type;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultMultiLanguageProperty;
-
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Type;
-
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -36,7 +35,7 @@ public class LangStringPropertyMapper implements PropertyMapper<MultiLanguagePro
    public boolean canHandle( final Property property ) {
       return property.getDataType()
             .map( Type::getUrn )
-            .filter( RDF.langString.getURI()::equals )
+            .filter( RdfDatatypeUris.LANG_STRING::equals )
             .isPresent();
    }
 

--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectConverter.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/SubmodelToAspectConverter.java
@@ -26,32 +26,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rfc3986.IRI;
-import org.apache.jena.rfc3986.RFC3986;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
-import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
-import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
-import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
-import org.eclipse.digitaltwin.aas4j.v3.model.EventElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.File;
-import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
-import org.eclipse.digitaltwin.aas4j.v3.model.Identifiable;
-import org.eclipse.digitaltwin.aas4j.v3.model.Key;
-import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
-import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
-import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
-import org.eclipse.digitaltwin.aas4j.v3.model.Range;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
-
 import org.eclipse.esmf.aspectmodel.VersionNumber;
 import org.eclipse.esmf.aspectmodel.loader.MetaModelBaseAttributes;
 import org.eclipse.esmf.aspectmodel.loader.ValueInstantiator;
@@ -73,6 +47,7 @@ import org.eclipse.esmf.metamodel.characteristic.impl.DefaultTrait;
 import org.eclipse.esmf.metamodel.constraint.RangeConstraint;
 import org.eclipse.esmf.metamodel.constraint.impl.DefaultRangeConstraint;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.impl.DefaultAspect;
 import org.eclipse.esmf.metamodel.impl.DefaultCharacteristic;
 import org.eclipse.esmf.metamodel.impl.DefaultEntity;
@@ -82,10 +57,33 @@ import org.eclipse.esmf.metamodel.impl.DefaultProperty;
 import org.eclipse.esmf.metamodel.impl.DefaultScalar;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
+import io.vavr.control.Try;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rfc3986.IRI;
+import org.apache.jena.rfc3986.RFC3986;
+import org.apache.jena.vocabulary.XSD;
+import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
+import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
+import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
+import org.eclipse.digitaltwin.aas4j.v3.model.EventElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.File;
+import org.eclipse.digitaltwin.aas4j.v3.model.HasSemantics;
+import org.eclipse.digitaltwin.aas4j.v3.model.Identifiable;
+import org.eclipse.digitaltwin.aas4j.v3.model.Key;
+import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
+import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import org.eclipse.digitaltwin.aas4j.v3.model.Range;
+import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.vavr.control.Try;
 
 class SubmodelToAspectConverter {
    private static final String EXAMPLE_NAMESPACE = "com.example";
@@ -466,6 +464,18 @@ class SubmodelToAspectConverter {
             .build();
    }
 
+   private MetaModelBaseAttributes collectionPropertyBaseAttributes( final SubmodelElementCollection collection ) {
+      final ElementName elementName = determineSubmodelElementName( collection, "", false, true );
+      final String uniqueName = nextUniqueName( elementName.name() + "Property" );
+      return MetaModelBaseAttributes.builder()
+            .withUrn( aspectUrn.withName( uniqueName ) )
+            .withPreferredNames( preferredNamesForEntity( collection ) )
+            .withDescriptions( descriptionsForEntity( collection ) )
+            .withSee( seeReferences( collection ) )
+            .isAnonymous( elementName.isSynthetic() )
+            .build();
+   }
+
    private Set<LangString> preferredNamesForEntity( final SubmodelElement element ) {
       final Set<LangString> elementDisplayNames = SubmodelToAspectUtils.langStringSet( element.getDisplayName() );
       if ( !elementDisplayNames.isEmpty() ) {
@@ -511,9 +521,10 @@ class SubmodelToAspectConverter {
          return existingProperty;
       }
 
-      final boolean useSemanticIdUrnForProperty = !( submodelElement instanceof SubmodelElementCollection );
       final MetaModelBaseAttributes metaModelBaseAttributes =
-            baseAttributes( submodelElement, new DetermineAutomatically(), false, true, useSemanticIdUrnForProperty );
+            submodelElement instanceof final SubmodelElementCollection collection
+                  ? collectionPropertyBaseAttributes( collection )
+                  : baseAttributes( submodelElement, new DetermineAutomatically(), false, true );
       final Characteristic characteristic = createCharacteristic( submodelElement, metaModelBaseAttributes.urn() );
       final Optional<ScalarValue> exampleValue =
             submodelElement instanceof final org.eclipse.digitaltwin.aas4j.v3.model.Property property
@@ -615,7 +626,7 @@ class SubmodelToAspectConverter {
    }
 
    private Characteristic createCharacteristicFromMultiLanguageProperty( final MultiLanguageProperty multiLanguageProperty ) {
-      return createDefaultScalarCharacteristic( multiLanguageProperty, RDF.langString.getURI(),
+      return createDefaultScalarCharacteristic( multiLanguageProperty, RdfDatatypeUris.LANG_STRING,
             new UseGivenUrn( AspectModelUrn.fromUrn( SammNs.SAMMC.MultiLanguageText().getURI() ) ) );
    }
 

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
@@ -492,9 +492,11 @@ class AasToAspectModelGeneratorTest {
 
    private static Stream<Arguments> dbpRegressionAasxFiles() {
       return Stream.of(
-            "submodel-templates/published/Digital Battery Passport/2_Handover Documentation/1/0/IDTA 02035-2_DBP-Part-2_HandoverDocumentation.aasx",
+            "submodel-templates/published/Digital Battery Passport/"
+                  + "2_Handover Documentation/1/0/IDTA 02035-2_DBP-Part-2_HandoverDocumentation.aasx",
             "submodel-templates/published/Digital Battery Passport/5_Product Condition/1/0/IDTA 02035-5_DBP-Part-5_ProductCondition.aasx",
-            "submodel-templates/published/Digital Battery Passport/6_Material Composition/1/0/IDTA 02035-6_DBP-Part-6_MaterialComposition.aasx",
+            "submodel-templates/published/Digital Battery Passport/6_Material Composition/1/0/"
+                  + "IDTA 02035-6_DBP-Part-6_MaterialComposition.aasx",
             "submodel-templates/published/Digital Battery Passport/7_Circularity/1/0/IDTA 02035-7_DBP-Part-7_Circularity.aasx"
       ).map( Arguments::of );
    }

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
@@ -477,7 +477,8 @@ class AasToAspectModelGeneratorTest {
       final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromEnvironment( environment );
       final Aspect aspect = aspectModelGenerator.generate().map( AspectArtifact::getContent ).findFirst().orElseThrow();
 
-      final String result = assertValidSerializedAspect( aspect, URI.create( "urn:samm:%s:1.0.0#ProductCondition".formatted( namespace ) ) );
+      final String result =
+            assertValidSerializedAspect( aspect, URI.create( "urn:samm:%s:1.0.0#ProductCondition".formatted( namespace ) ) );
       assertThat( result ).contains( ":numberOfFullCyclesProperty a samm:Property" );
       assertThat( result ).contains( ":numberOfFullCycles a samm:Entity" );
       assertThat( result ).doesNotContain( ":numberOfFullCycles a samm:Property" );

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AasToAspectModelGeneratorTest.java
@@ -33,6 +33,30 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import org.eclipse.esmf.aspectmodel.generator.AspectArtifact;
+import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
+import org.eclipse.esmf.aspectmodel.serializer.AspectSerializer;
+import org.eclipse.esmf.aspectmodel.shacl.violation.Violation;
+import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;
+import org.eclipse.esmf.aspectmodel.validation.services.AspectModelValidator;
+import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
+import org.eclipse.esmf.metamodel.Aspect;
+import org.eclipse.esmf.metamodel.AspectModel;
+import org.eclipse.esmf.metamodel.Characteristic;
+import org.eclipse.esmf.metamodel.Entity;
+import org.eclipse.esmf.metamodel.Operation;
+import org.eclipse.esmf.metamodel.Property;
+import org.eclipse.esmf.metamodel.Unit;
+import org.eclipse.esmf.metamodel.characteristic.Collection;
+import org.eclipse.esmf.metamodel.characteristic.Set;
+import org.eclipse.esmf.metamodel.characteristic.Trait;
+import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.SammType;
+import org.eclipse.esmf.test.TestAspect;
+import org.eclipse.esmf.test.TestResources;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.AASXDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlDeserializer;
@@ -56,27 +80,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementCollection;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
-
-import org.eclipse.esmf.aspectmodel.generator.AspectArtifact;
-import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
-import org.eclipse.esmf.aspectmodel.serializer.AspectSerializer;
-import org.eclipse.esmf.aspectmodel.shacl.violation.Violation;
-import org.eclipse.esmf.aspectmodel.validation.services.AspectModelValidator;
-import org.eclipse.esmf.aspectmodel.validation.services.ViolationFormatter;
-import org.eclipse.esmf.metamodel.Aspect;
-import org.eclipse.esmf.metamodel.AspectModel;
-import org.eclipse.esmf.metamodel.Characteristic;
-import org.eclipse.esmf.metamodel.Entity;
-import org.eclipse.esmf.metamodel.Operation;
-import org.eclipse.esmf.metamodel.Property;
-import org.eclipse.esmf.metamodel.Unit;
-import org.eclipse.esmf.metamodel.characteristic.Collection;
-import org.eclipse.esmf.metamodel.characteristic.Set;
-import org.eclipse.esmf.metamodel.characteristic.Trait;
-import org.eclipse.esmf.metamodel.datatype.LangString;
-import org.eclipse.esmf.test.TestAspect;
-import org.eclipse.esmf.test.TestResources;
-
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -90,9 +93,14 @@ class AasToAspectModelGeneratorTest {
    @ParameterizedTest
    @MethodSource( "idtaSubmodelFiles" )
    void testIdtaAasxFilesCanBeTranslated( final File aasxFile ) {
-      try ( final InputStream input = new FileInputStream( aasxFile ) ) {
-         final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromAasx( input );
-         final List<Aspect> aspects = aspectModelGenerator.generate().map( AspectArtifact::getContent ).toList();
+      try {
+         final Environment environment = loadAasxEnvironment( aasxFile );
+         final java.util.Set<String> semanticIdDerivedEntityNames = submodelElementCollectionSemanticIdNames( environment );
+         final List<Aspect> aspects;
+         try ( final InputStream input = new FileInputStream( aasxFile ) ) {
+            final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromAasx( input );
+            aspects = aspectModelGenerator.generate().map( AspectArtifact::getContent ).toList();
+         }
          if ( aspects.isEmpty() ) {
             fail( "Translation of " + aasxFile.getName() + " yielded no Aspects" );
          }
@@ -103,6 +111,11 @@ class AasToAspectModelGeneratorTest {
             if ( element instanceof Property || element instanceof Operation || element instanceof Unit ) {
                assertThat( element.getName().charAt( 0 ) )
                      .describedAs( element.getName() + " is a " + element.getClass().getSimpleName() + " and must be lower case" )
+                     .isLowerCase();
+            } else if ( element instanceof Entity && Character.isLowerCase( element.getName().charAt( 0 ) )
+                  && semanticIdDerivedEntityNames.contains( element.getName() ) ) {
+               assertThat( element.getName().charAt( 0 ) )
+                     .describedAs( element.getName() + " is an Entity derived from a SubmodelElementCollection semanticId" )
                      .isLowerCase();
             } else {
                assertThat( element.getName().charAt( 0 ) )
@@ -119,8 +132,10 @@ class AasToAspectModelGeneratorTest {
             System.out.println( result );
             fail();
          }
-      } catch ( final IOException exception ) {
+      } catch ( final IOException | InvalidFormatException exception ) {
          fail( exception );
+      } catch ( final DeserializationException exception ) {
+         System.err.println( "Could not load AASX file: " + aasxFile.getName() + ". Consider reporting to IDTA or AAS4J project." );
       } catch ( final AspectModelGenerationException aspectModelGenerationException ) {
          if ( aspectModelGenerationException.getCause() instanceof DeserializationException ) {
             System.err.println( "Could not load AASX file: " + aasxFile.getName() + ". Consider reporting to IDTA or AAS4J project." );
@@ -142,7 +157,9 @@ class AasToAspectModelGeneratorTest {
          "IDTA 02007-1-0_Template_Software Nameplate.aasx",
          // [Reason]: Range property with type double. java.lang.NumberFormatException: For input string:
          // "[0;100]"
-         "IDTA 02019-1-0_Template_PlantAssetManagement.aasx"
+         "IDTA 02019-1-0_Template_PlantAssetManagement.aasx",
+         // [Reason]: Range property with type positiveInteger has an invalid negative lower bound.
+         "IDTA 02076_Template_EnergyFlexibilityDataModel.aasx"
    );
 
    protected static Stream<Arguments> idtaSubmodelFiles() throws URISyntaxException, IOException {
@@ -186,6 +203,43 @@ class AasToAspectModelGeneratorTest {
       final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromEnvironment( environment );
 
       assertThatCode( () -> aspectModelGenerator.generate().toList() ).doesNotThrowAnyException();
+   }
+
+   @Test
+   void testDatePropertyWithExampleValueCanBeTranslatedWithoutTypeMappingSetup() {
+      final org.eclipse.digitaltwin.aas4j.v3.model.Property dateProperty = new DefaultProperty.Builder()
+            .idShort( "DateOfManufacture" )
+            .valueType( DataTypeDefXsd.DATE )
+            .value( "2022-01-01" )
+            .build();
+      final AasToAspectModelGenerator aspectModelGenerator =
+            AasToAspectModelGenerator.fromEnvironment( buildTemplateEnvironment( dateProperty ) );
+
+      assertThatCode( () -> aspectModelGenerator.generate().toList() ).doesNotThrowAnyException();
+
+      final Property property = aspectModelGenerator.generate().map( AspectArtifact::getContent ).toList()
+            .getFirst().getProperties().getFirst();
+
+      assertThat( property.getExampleValue() ).isPresent()
+            .get()
+            .satisfies( exampleValue -> {
+               assertThat( exampleValue.getType() ).isEqualTo( SammType.DATE );
+               assertThat( exampleValue.getValue().toString() ).isEqualTo( "2022-01-01" );
+            } );
+      assertThat( property.getCharacteristic() )
+            .flatMap( Characteristic::getDataType )
+            .contains( SammType.DATE );
+   }
+
+   @Test
+   void testXmlFixtureWithDateExampleValueCanBeTranslatedAndValidated() {
+      final Environment environment = loadEnvironment( "DatePropertyWithExampleValue.aas.xml" );
+      final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromEnvironment( environment );
+
+      final List<Aspect> aspects = aspectModelGenerator.generate().map( AspectArtifact::getContent ).toList();
+
+      assertThat( aspects ).isNotEmpty();
+      assertValidSerializedAspect( aspects.getFirst(), URI.create( "urn:test:date-property-with-example-value" ) );
    }
 
    @Test
@@ -379,8 +433,8 @@ class AasToAspectModelGeneratorTest {
       final Aspect aspect = aspectModelGenerator.generate().map( AspectArtifact::getContent ).findFirst().orElseThrow();
 
       final Property property = aspect.getProperties().getFirst();
-      assertThat( property.getName() ).isEqualTo( "testProperty" );
-      assertThat( property.urn().toString() ).isEqualTo( "urn:samm:org.eclipse.esmf.test:1.0.0#testProperty" );
+      assertThat( property.getName() ).isEqualTo( "testPropertyProperty" );
+      assertThat( property.urn().toString() ).isEqualTo( "urn:samm:org.eclipse.esmf.test:1.0.0#testPropertyProperty" );
 
       final Entity entity = property.getCharacteristic()
             .flatMap( Characteristic::getDataType )
@@ -389,10 +443,59 @@ class AasToAspectModelGeneratorTest {
       assertThat( entity.getName() ).isEqualTo( "TestEntity" );
       assertThat( entity.urn().toString() ).isEqualTo( entitySemanticId );
 
-      final String result = AspectSerializer.INSTANCE.aspectToString( aspect );
-      final AspectModel aspectModel = new AspectModelLoader().load( new ByteArrayInputStream( result.getBytes() ), URI.create(
-            "urn:samm:org.eclipse.esmf.test:1.0.0#TestAspect" ) );
-      assertThat( new AspectModelValidator().validateModel( aspectModel ) ).isEmpty();
+      assertValidSerializedAspect( aspect, URI.create( "urn:samm:org.eclipse.esmf.test:1.0.0#TestAspect" ) );
+   }
+
+   @Test
+   void testSubmodelElementCollectionPropertyAndEntityNamesDoNotCollide() {
+      final String namespace = "io.admin-shell.idta.batterypass.product_condition";
+      final String entitySemanticId = "urn:samm:%s:1.0.0#numberOfFullCycles".formatted( namespace );
+      final SubmodelElementCollection collection = new DefaultSubmodelElementCollection.Builder()
+            .idShort( "NumberOfFullCycles" )
+            .semanticId( new DefaultReference.Builder()
+                  .type( ReferenceTypes.EXTERNAL_REFERENCE )
+                  .keys( List.of( new DefaultKey.Builder()
+                        .type( KeyTypes.GLOBAL_REFERENCE )
+                        .value( entitySemanticId )
+                        .build() ) )
+                  .build() )
+            .value( List.of( new DefaultProperty.Builder()
+                  .idShort( "cycleCount" )
+                  .valueType( DataTypeDefXsd.INTEGER )
+                  .build() ) )
+            .build();
+      final Submodel submodel = new DefaultSubmodel.Builder()
+            .id( "urn:samm:%s:1.0.0#ProductCondition".formatted( namespace ) )
+            .idShort( "ProductCondition" )
+            .kind( ModellingKind.TEMPLATE )
+            .submodelElements( List.of( collection ) )
+            .build();
+      final Environment environment = new DefaultEnvironment.Builder()
+            .submodels( List.of( submodel ) )
+            .build();
+
+      final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromEnvironment( environment );
+      final Aspect aspect = aspectModelGenerator.generate().map( AspectArtifact::getContent ).findFirst().orElseThrow();
+
+      final String result = assertValidSerializedAspect( aspect, URI.create( "urn:samm:%s:1.0.0#ProductCondition".formatted( namespace ) ) );
+      assertThat( result ).contains( ":numberOfFullCyclesProperty a samm:Property" );
+      assertThat( result ).contains( ":numberOfFullCycles a samm:Entity" );
+      assertThat( result ).doesNotContain( ":numberOfFullCycles a samm:Property" );
+   }
+
+   @ParameterizedTest
+   @MethodSource( "dbpRegressionAasxFiles" )
+   void testDbpRegressionAasxFilesCanBeTranslatedAndValidated( final String aasxResource ) {
+      assertAasxCanBeTranslatedAndValidated( aasxResource );
+   }
+
+   private static Stream<Arguments> dbpRegressionAasxFiles() {
+      return Stream.of(
+            "submodel-templates/published/Digital Battery Passport/2_Handover Documentation/1/0/IDTA 02035-2_DBP-Part-2_HandoverDocumentation.aasx",
+            "submodel-templates/published/Digital Battery Passport/5_Product Condition/1/0/IDTA 02035-5_DBP-Part-5_ProductCondition.aasx",
+            "submodel-templates/published/Digital Battery Passport/6_Material Composition/1/0/IDTA 02035-6_DBP-Part-6_MaterialComposition.aasx",
+            "submodel-templates/published/Digital Battery Passport/7_Circularity/1/0/IDTA 02035-7_DBP-Part-7_Circularity.aasx"
+      ).map( Arguments::of );
    }
 
    private static Environment buildTemplateEnvironment( final SubmodelElement submodelElement ) {
@@ -405,6 +508,46 @@ class AasToAspectModelGeneratorTest {
       return new DefaultEnvironment.Builder()
             .submodels( List.of( submodel ) )
             .build();
+   }
+
+   private static Environment loadAasxEnvironment( final File aasxFile )
+         throws IOException, InvalidFormatException, DeserializationException {
+      try ( final InputStream input = new FileInputStream( aasxFile ) ) {
+         final AASXDeserializer deserializer = new AASXDeserializer( input );
+         return new XmlDeserializer().read( deserializer.getResourceString() );
+      }
+   }
+
+   private static java.util.Set<String> submodelElementCollectionSemanticIdNames( final Environment environment ) {
+      return Optional.ofNullable( environment.getSubmodels() ).orElseGet( List::of ).stream()
+            .flatMap( submodel -> Optional.ofNullable( submodel.getSubmodelElements() ).orElseGet( List::of ).stream() )
+            .flatMap( AasToAspectModelGeneratorTest::flattenSubmodelElement )
+            .filter( SubmodelElementCollection.class::isInstance )
+            .flatMap( element -> Optional.ofNullable( element.getSemanticId() ).stream() )
+            .flatMap( SubmodelToAspectUtils::keys )
+            .map( key -> key.getValue() )
+            .flatMap( value -> {
+               try {
+                  return Stream.of( AspectModelUrn.fromUrn( value ).getName() );
+               } catch ( final RuntimeException exception ) {
+                  return Stream.empty();
+               }
+            } )
+            .collect( java.util.stream.Collectors.toSet() );
+   }
+
+   private static Stream<SubmodelElement> flattenSubmodelElement( final SubmodelElement submodelElement ) {
+      final Stream<SubmodelElement> nested;
+      if ( submodelElement instanceof final SubmodelElementCollection collection ) {
+         nested = Optional.ofNullable( collection.getValue() ).orElseGet( List::of ).stream()
+               .flatMap( AasToAspectModelGeneratorTest::flattenSubmodelElement );
+      } else if ( submodelElement instanceof final SubmodelElementList list ) {
+         nested = Optional.ofNullable( list.getValue() ).orElseGet( List::of ).stream()
+               .flatMap( AasToAspectModelGeneratorTest::flattenSubmodelElement );
+      } else {
+         nested = Stream.empty();
+      }
+      return Stream.concat( Stream.of( submodelElement ), nested );
    }
 
    private static SubmodelElementList buildSubmodelElementList( final boolean orderRelevant ) {
@@ -434,6 +577,27 @@ class AasToAspectModelGeneratorTest {
             ? allCharacteristics( trait.getBaseCharacteristic() )
             : Stream.empty();
       return Stream.concat( Stream.of( characteristic ), Stream.concat( collectionCharacteristics, traitCharacteristics ) );
+   }
+
+   private void assertAasxCanBeTranslatedAndValidated( final String aasxResource ) {
+      try ( final InputStream inputStream = AasToAspectModelGeneratorTest.class.getClassLoader().getResourceAsStream( aasxResource ) ) {
+         assertThat( inputStream ).as( aasxResource ).isNotNull();
+         final AasToAspectModelGenerator aspectModelGenerator = AasToAspectModelGenerator.fromAasx( inputStream );
+         final List<Aspect> aspects = aspectModelGenerator.generate().map( AspectArtifact::getContent ).toList();
+
+         assertThat( aspects ).as( aasxResource ).isNotEmpty();
+         aspects.forEach( aspect -> assertValidSerializedAspect( aspect, URI.create( aspect.urn().toString() ) ) );
+      } catch ( final IOException exception ) {
+         fail( exception );
+      }
+   }
+
+   private String assertValidSerializedAspect( final Aspect aspect, final URI sourceUri ) {
+      final String result = AspectSerializer.INSTANCE.aspectToString( aspect );
+      assertThat( result ).isNotBlank();
+      final AspectModel aspectModel = new AspectModelLoader().load( new ByteArrayInputStream( result.getBytes() ), sourceUri );
+      assertThat( new AspectModelValidator().validateModel( aspectModel ) ).isEmpty();
+      return result;
    }
 
    @Test

--- a/core/esmf-aspect-model-aas-generator/src/test/resources/DatePropertyWithExampleValue.aas.xml
+++ b/core/esmf-aspect-model-aas-generator/src/test/resources/DatePropertyWithExampleValue.aas.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<aas:environment xmlns:aas="https://admin-shell.io/aas/3/0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="https://admin-shell.io/aas/3/0 AAS.xsd">
+   <aas:assetAdministrationShells>
+      <aas:assetAdministrationShell>
+         <aas:idShort>DateExampleShell</aas:idShort>
+         <aas:id>urn:samm:org.eclipse.esmf.test.date:1.0.0#Shell</aas:id>
+         <aas:assetInformation>
+            <aas:assetKind>Type</aas:assetKind>
+         </aas:assetInformation>
+         <aas:submodels>
+            <aas:reference>
+               <aas:type>ModelReference</aas:type>
+               <aas:keys>
+                  <aas:key>
+                     <aas:type>Submodel</aas:type>
+                     <aas:value>urn:samm:org.eclipse.esmf.test.date:1.0.0#DateExampleAspect</aas:value>
+                  </aas:key>
+               </aas:keys>
+            </aas:reference>
+         </aas:submodels>
+      </aas:assetAdministrationShell>
+   </aas:assetAdministrationShells>
+   <aas:submodels>
+      <aas:submodel>
+         <aas:idShort>DateExampleAspect</aas:idShort>
+         <aas:id>urn:samm:org.eclipse.esmf.test.date:1.0.0#DateExampleAspect</aas:id>
+         <aas:kind>Template</aas:kind>
+         <aas:submodelElements>
+            <aas:property>
+               <aas:idShort>DateOfManufacture</aas:idShort>
+               <aas:valueType>xs:date</aas:valueType>
+               <aas:value>2022-01-01</aas:value>
+            </aas:property>
+         </aas:submodelElements>
+      </aas:submodel>
+   </aas:submodels>
+</aas:environment>

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
@@ -27,12 +27,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
-
-import org.apache.jena.vocabulary.RDF;
 
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerator;
 import org.eclipse.esmf.aspectmodel.generator.Range;
@@ -62,17 +59,16 @@ import org.eclipse.esmf.metamodel.constraint.RegularExpressionConstraint;
 import org.eclipse.esmf.metamodel.datatype.Curie;
 import org.eclipse.esmf.metamodel.datatype.CurieType;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.datatype.SammType;
 import org.eclipse.esmf.metamodel.datatype.SammXsdType;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
+import com.github.curiousoddman.rgxgen.RgxGen;
+import com.github.curiousoddman.rgxgen.parsing.dflt.RgxGenParseException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.curiousoddman.rgxgen.RgxGen;
-import com.github.curiousoddman.rgxgen.parsing.dflt.RgxGenParseException;
-
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -314,7 +310,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
    @Override
    public JsonNode visitScalarValue( final ScalarValue scalarValue, final Context context ) {
-      if ( scalarValue.getType().getUrn().equals( RDF.langString.getURI() ) ) {
+      if ( scalarValue.getType().getUrn().equals( RdfDatatypeUris.LANG_STRING ) ) {
          final LangString langString = (LangString) scalarValue.getValue();
          return JsonNodeFactory.instance.objectNode()
                .put( langString.getLanguageTag().toLanguageTag(), langString.getValue() );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
@@ -25,12 +25,6 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.XSD;
-
 import org.eclipse.esmf.aspectmodel.generator.DocumentGenerationException;
 import org.eclipse.esmf.aspectmodel.generator.XsdToJsonTypeMapping;
 import org.eclipse.esmf.aspectmodel.visitor.AspectVisitor;
@@ -62,14 +56,19 @@ import org.eclipse.esmf.metamodel.constraint.RangeConstraint;
 import org.eclipse.esmf.metamodel.constraint.RegularExpressionConstraint;
 import org.eclipse.esmf.metamodel.datatype.CurieType;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.vocabulary.SammNs;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
-
 import io.vavr.control.Try;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.XSD;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -542,7 +541,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
 
    private JsonNode createEnumNodeWithScalarValues( final Enumeration enumeration, final Type type, final ObjectNode context ) {
       final ArrayNode valuesNode = FACTORY.arrayNode();
-      final ObjectNode enumNode = type.getUrn().equals( RDF.langString.getURI() )
+      final ObjectNode enumNode = type.getUrn().equals( RdfDatatypeUris.LANG_STRING )
             ? FACTORY.objectNode().put( "type", "object" )
             : (ObjectNode) type.accept( this, context );
       addSammExtensionAttribute( enumNode, enumeration );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetFileWriter.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetFileWriter.java
@@ -44,11 +44,11 @@ import org.eclipse.esmf.metamodel.characteristic.Enumeration;
 import org.eclipse.esmf.metamodel.characteristic.Trait;
 import org.eclipse.esmf.metamodel.constraint.LengthConstraint;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 
 import io.vavr.Tuple2;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
@@ -337,7 +337,7 @@ class ParquetFileWriter {
       } else if ( dataType instanceof final Scalar scalar ) {
          Object exampleValue = extractExampleValueFromProperty( property, collection );
          String language = null;
-         if ( RDF.langString.getURI().equals( scalar.getUrn() ) ) {
+         if ( RdfDatatypeUris.LANG_STRING.equals( scalar.getUrn() ) ) {
             switch ( exampleValue ) {
                case final LangString langString -> {
                   language = Optional.ofNullable( langString.getLanguageTag() ).map( Locale::getLanguage ).orElse( null );
@@ -412,7 +412,7 @@ class ParquetFileWriter {
 
          Object exampleValue = extractExampleValueFromProperty( property, characteristic );
          String language = null;
-         if ( RDF.langString.getURI().equals( scalar.getUrn() ) ) {
+         if ( RdfDatatypeUris.LANG_STRING.equals( scalar.getUrn() ) ) {
             switch ( exampleValue ) {
                case final LangString langString -> {
                   language = Optional.ofNullable( langString.getLanguageTag() ).map( Locale::getLanguage ).orElse( null );

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetSchemaMapper.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/parquet/ParquetSchemaMapper.java
@@ -15,9 +15,10 @@ package org.eclipse.esmf.aspectmodel.generator.parquet;
 
 import java.math.BigInteger;
 
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
+
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
@@ -70,11 +71,11 @@ final class ParquetSchemaMapper {
             || XSD.hexBinary.equals( xsdResource )
             || XSD.base64Binary.equals( xsdResource )
             || XSD.anyURI.equals( xsdResource )
-            || RDF.langString.getURI().equals( xsdTypeUri ) ) && ( maxLength != null && maxLength.intValue() > 0 ) ) {
+            || RdfDatatypeUris.LANG_STRING.equals( xsdTypeUri ) ) && ( maxLength != null && maxLength.intValue() > 0 ) ) {
          return Types.primitive( PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, org.apache.parquet.schema.Type.Repetition.OPTIONAL )
                .length( maxLength.intValue() )
                .named( fieldName );
-      } else if ( RDF.langString.getURI().equals( xsdTypeUri ) ) {
+      } else if ( RdfDatatypeUris.LANG_STRING.equals( xsdTypeUri ) ) {
          return Types.primitive( PrimitiveType.PrimitiveTypeName.BINARY, org.apache.parquet.schema.Type.Repetition.OPTIONAL )
                .as( LogicalTypeAnnotation.stringType() ).named( fieldName + "-" + language );
       } else if ( XSD.xfloat.equals( xsdResource ) ) { // Float type

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/sql/databricks/AspectModelDatabricksDenormalizedSqlVisitor.java
@@ -36,13 +36,13 @@ import org.eclipse.esmf.metamodel.characteristic.Collection;
 import org.eclipse.esmf.metamodel.characteristic.Either;
 import org.eclipse.esmf.metamodel.characteristic.Trait;
 import org.eclipse.esmf.metamodel.characteristic.impl.DefaultList;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.vocabulary.SAMM;
 import org.eclipse.esmf.samm.KnownVersion;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableMap;
 import io.soabase.recordbuilder.core.RecordBuilder;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 /**
@@ -120,7 +120,7 @@ public class AspectModelDatabricksDenormalizedSqlVisitor
             .put( XSD.base64Binary.getURI(), DatabricksType.BINARY )
             .put( XSD.anyURI.getURI(), DatabricksType.STRING )
             .put( new SAMM( KnownVersion.getLatest() ).resource( "curie" ).getURI(), DatabricksType.STRING )
-            .put( RDF.langString.getURI(), DatabricksType.STRING )
+            .put( RdfDatatypeUris.LANG_STRING, DatabricksType.STRING )
             .build();
    }
 

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/AspectModelJavaUtil.java
@@ -52,6 +52,7 @@ import org.eclipse.esmf.metamodel.characteristic.Quantifiable;
 import org.eclipse.esmf.metamodel.characteristic.State;
 import org.eclipse.esmf.metamodel.characteristic.Trait;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.datatype.SammXsdType;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -64,7 +65,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.text.translate.UnicodeUnescaper;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 public class AspectModelJavaUtil {
@@ -348,7 +348,7 @@ public class AspectModelJavaUtil {
 
          if ( actualDataType instanceof Scalar ) {
             final Resource typeResource = ResourceFactory.createResource( actualDataType.getUrn() );
-            if ( typeResource.getURI().equals( RDF.langString.getURI() ) ) {
+            if ( typeResource.getURI().equals( RdfDatatypeUris.LANG_STRING ) ) {
                importTracker.importExplicit( LangString.class );
                return "LangString";
             }
@@ -368,7 +368,7 @@ public class AspectModelJavaUtil {
       }
 
       final Resource typeResource = ResourceFactory.createResource( dataType.getUrn() );
-      if ( typeResource.getURI().equals( RDF.langString.getURI() ) ) {
+      if ( typeResource.getURI().equals( RdfDatatypeUris.LANG_STRING ) ) {
          return Map.class;
       }
       final Class<?> result = SammXsdType.getJavaTypeForMetaModelType( typeResource );

--- a/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/ValueExpressionVisitor.java
+++ b/core/esmf-aspect-model-java-generator/src/main/java/org/eclipse/esmf/aspectmodel/java/ValueExpressionVisitor.java
@@ -26,11 +26,11 @@ import org.eclipse.esmf.metamodel.Scalar;
 import org.eclipse.esmf.metamodel.ScalarValue;
 import org.eclipse.esmf.metamodel.Value;
 import org.eclipse.esmf.metamodel.datatype.LangString;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 import org.eclipse.esmf.metamodel.datatype.SammXsdType;
 
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.vocabulary.RDF;
 
 /**
  * Builds an initializer expression for a {@link Value}. For example:
@@ -69,7 +69,7 @@ public class ValueExpressionVisitor implements AspectVisitor<String, ValueExpres
 
    private String generateValueExpression( final ScalarValue value, final Context context ) {
       final String typeUri = value.getType().as( Scalar.class ).getUrn();
-      if ( typeUri.equals( RDF.langString.getURI() ) ) {
+      if ( typeUri.equals( RdfDatatypeUris.LANG_STRING ) ) {
          context.codeGenerationConfig().importTracker().importExplicit( LangString.class );
          context.codeGenerationConfig().importTracker().importExplicit( Locale.class );
          final LangString langStringValue = (LangString) value.as( ScalarValue.class ).getValue();

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/violation/DatatypeViolation.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/shacl/violation/DatatypeViolation.java
@@ -23,11 +23,11 @@ import org.eclipse.esmf.aspectmodel.resolver.parser.TokenRegistry;
 import org.eclipse.esmf.aspectmodel.shacl.constraint.DatatypeConstraint;
 import org.eclipse.esmf.aspectmodel.shacl.fix.Fix;
 import org.eclipse.esmf.aspectmodel.shacl.fix.ReplaceValue;
+import org.eclipse.esmf.metamodel.datatype.RdfDatatypeUris;
 
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
 
 /**
@@ -50,9 +50,9 @@ public record DatatypeViolation(
    @Override
    public String violationSpecificMessage() {
       if ( context.property().isPresent() ) {
-         if ( allowedTypeUri.equals( RDF.langString.getURI() ) && actualTypeUri.equals( XSD.xstring.getURI() ) ) {
+         if ( allowedTypeUri.equals( RdfDatatypeUris.LANG_STRING ) && actualTypeUri.equals( XSD.xstring.getURI() ) ) {
             return String.format( "Property %s on %s is missing a language tag.", context.propertyName(), context.elementName() );
-         } else if ( allowedTypeUri.equals( XSD.xstring.getURI() ) && actualTypeUri.equals( RDF.langString.getURI() ) ) {
+         } else if ( allowedTypeUri.equals( XSD.xstring.getURI() ) && actualTypeUri.equals( RdfDatatypeUris.LANG_STRING ) ) {
             return String.format( "Property %s on %s must not have a language tag.", context.propertyName(), context.elementName() );
          } else {
             return String.format( "Property %s on %s uses data type %s, but only %s is allowed.",
@@ -87,11 +87,11 @@ public record DatatypeViolation(
       final List<Fix> fixes = new ArrayList<>();
 
       // value is string but should be langString
-      if ( allowedTypeUri.equals( RDF.langString.getURI() ) && actualTypeUri.equals( XSD.xstring.getURI() ) ) {
+      if ( allowedTypeUri.equals( RdfDatatypeUris.LANG_STRING ) && actualTypeUri.equals( XSD.xstring.getURI() ) ) {
          fixes.addAll( replaceStringWithLangString() );
       }
 
-      if ( allowedTypeUri.equals( XSD.xstring.getURI() ) && actualTypeUri.equals( RDF.langString.getURI() ) ) {
+      if ( allowedTypeUri.equals( XSD.xstring.getURI() ) && actualTypeUri.equals( RdfDatatypeUris.LANG_STRING ) ) {
          fixes.addAll( replaceLangStringWithString() );
       }
 


### PR DESCRIPTION
## Description

This PR fixes the AAS/AASX to SAMM generation regression reported in #1015.

Changes:

1. Fixed date/time example value parsing by lazily initializing `DatatypeFactory` in `SammXsdType`.
2. Added `RdfDatatypeUris.LANG_STRING` constant and replaced direct `RDF.langString.getURI()` usage in production code. This avoids order-sensitive Jena vocabulary initialization problems when only the rdf:langString URI string is needed.
3. Fixed duplicate SAMM definition generation for `SubmodelElementCollection` by appending `Property` to generated SAMM Property names. This prevents collisions when the same semantic ID would otherwise be used for both a SAMM 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
