### PR TITLE
Add esmf-sdk-bom module

### DIFF
--- a/core/esmf-sdk-bom/pom.xml
+++ b/core/esmf-sdk-bom/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+  ~
+  ~ See the AUTHORS file(s) distributed with this work for additional
+  ~ information regarding authorship.
+  ~
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  ~
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.eclipse.esmf</groupId>
+      <artifactId>esmf-sdk-parent</artifactId>
+      <version>DEV-SNAPSHOT</version>
+      <relativePath>../../pom.xml</relativePath>
+   </parent>
+
+   <artifactId>esmf-sdk-bom</artifactId>
+   <name>ESMF SDK Bill of Materials</name>
+   <packaging>pom</packaging>
+
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-interface</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-meta-model-java</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-aas-generator</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-document-generators</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-generator</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-github-resolver</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-importers</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-jackson</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-java-core</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-java-generator</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-urn</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-model-validator</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-aspect-static-meta-model-java</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-test-aspect-models</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-test-resources</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-tree-sitter-turtle</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-turtle-language-server</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.eclipse.esmf</groupId>
+            <artifactId>esmf-util</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>${flatten-maven-plugin.version}</version>
+            <configuration>
+               <flattenMode>bom</flattenMode>
+               <pomElements>
+                  <properties>remove</properties>
+               </pomElements>
+            </configuration>
+            <executions>
+               <execution>
+                  <id>flatten</id>
+                  <goals>
+                     <goal>flatten</goal>
+                  </goals>
+                  <phase>process-resources</phase>
+               </execution>
+               <execution>
+                  <id>flatten.clean</id>
+                  <goals>
+                     <goal>clean</goal>
+                  </goals>
+                  <phase>clean</phase>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/documentation/developer-guide/modules/ROOT/partials/esmf-bom.adoc
+++ b/documentation/developer-guide/modules/ROOT/partials/esmf-bom.adoc
@@ -4,7 +4,7 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.esmf</groupId>
-      <artifactId>esmf-sdk-parent</artifactId>
+      <artifactId>esmf-sdk-bom</artifactId>
       <version>{esmf-sdk-version}</version>
       <type>pom</type>
       <scope>import</scope>

--- a/documentation/developer-guide/modules/tooling-guide/pages/java-aspect-tooling.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/java-aspect-tooling.adoc
@@ -12,7 +12,7 @@ respective subsection), _or_ you can use the `esmf-aspect-model-starter` artifac
 
 include::esmf-developer-guide:ROOT:partial$esmf-aspect-model-starter-artifact.adoc[]
 
-Alternatively, you can use the `esmf-sdk-parent` artifact as a
+Alternatively, you can use the `esmf-sdk-bom` artifact as a
 https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs[Maven
 BOM] (Bill of Materials) to enable declaring dependencies to specific modules without an explicit
 version. Add the following section to the Maven pom.xml in your project:

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
       <module>core/esmf-aspect-model-urn</module>
       <module>core/esmf-aspect-model-validator</module>
       <module>core/esmf-aspect-static-meta-model-java</module>
+      <module>core/esmf-sdk-bom</module>
       <module>core/esmf-tree-sitter-turtle</module>
       <module>core/esmf-turtle-language-server</module>
       <module>core/esmf-test-aspect-models</module>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
       <module>core/esmf-aspect-model-urn</module>
       <module>core/esmf-aspect-model-validator</module>
       <module>core/esmf-aspect-static-meta-model-java</module>
-      <module>core/esmf-sdk-bom</module>
       <module>core/esmf-tree-sitter-turtle</module>
       <module>core/esmf-turtle-language-server</module>
       <module>core/esmf-test-aspect-models</module>
@@ -72,6 +71,7 @@
       <module>tools/esmf-aspect-model-maven-plugin</module>
       <module>tools/samm-cli</module>
       <module>documentation</module>
+      <module>core/esmf-sdk-bom</module>
    </modules>
 
    <properties>


### PR DESCRIPTION
## Description

Add `esmf-sdk-bom` module that is usable with a different parent (e.g. spring-boot-starter) without overriding its dependency versions. See also #428.

Fixes #1022. Fixes #996.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- ~~[ ]I have added tests that prove my fix is effective or that my feature works~~

## Additional notes:

Verified correct behaviour using MRE https://github.com/MelleD/esmf-bom-test
and the following command: `mvn help:effective-pom | grep -A3 jackson-core` (before and after the change).
