### PR TITLE
feat: load external RdfBasedValidator for AspectModelValidator

### DIFF
--- a/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/validation/RdfBasedValidator.java
+++ b/core/esmf-aspect-meta-model-interface/src/main/java/org/eclipse/esmf/aspectmodel/validation/RdfBasedValidator.java
@@ -15,11 +15,14 @@ package org.eclipse.esmf.aspectmodel.validation;
 
 import org.apache.jena.rdf.model.Model;
 
+import org.eclipse.esmf.annotations.InterfaceVersion;
+
 import org.eclipse.esmf.aspectmodel.ViolationReport;
 
 /**
  * Generic validator for Aspect Models on the raw RDF input
  */
+@InterfaceVersion( version = 1 )
 public interface RdfBasedValidator {
    /**
     * Validates a complete RDF input (i.e., this model is expected to contain all necessary

--- a/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/service/ExtensionService.java
+++ b/core/esmf-aspect-meta-model-java/src/main/java/org/eclipse/esmf/aspectmodel/service/ExtensionService.java
@@ -22,6 +22,7 @@ import org.eclipse.esmf.annotations.InterfaceVersion;
 import org.eclipse.esmf.annotations.RequiredInterfaceVersion;
 import org.eclipse.esmf.aspectmodel.resolver.ResolutionStrategy;
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
+import org.eclipse.esmf.aspectmodel.validation.RdfBasedValidator;
 
 import net.harawata.appdirs.AppDirsFactory;
 import org.slf4j.Logger;
@@ -42,11 +43,16 @@ public class ExtensionService {
          Path.of( AppDirsFactory.getInstance().getUserDataDir( "esmf", "1", "esmf" ) ).resolve( "plugins" );
    private static final ClassLoader PLUGIN_CLASS_LOADER = createPluginClassLoader( PLUGIN_DIRECTORY );
    private static final List<ResolutionStrategy> RESOLUTION_STRATEGIES = loadServiceProviders( ResolutionStrategy.class );
+   private static final List<RdfBasedValidator> RDF_BASED_VALIDATORS = loadServiceProviders( RdfBasedValidator.class );
 
    private ExtensionService() {}
 
    public static List<ResolutionStrategy> getResolutionStrategies() {
       return RESOLUTION_STRATEGIES;
+   }
+
+   public static List<RdfBasedValidator> getRdfBasedValidators() {
+      return RDF_BASED_VALIDATORS;
    }
 
    /**

--- a/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/AspectModelValidator.java
+++ b/core/esmf-aspect-model-validator/src/main/java/org/eclipse/esmf/aspectmodel/validation/services/AspectModelValidator.java
@@ -42,6 +42,7 @@ import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ModelResolutionException;
 import org.eclipse.esmf.aspectmodel.resolver.exceptions.ParserException;
 import org.eclipse.esmf.aspectmodel.resolver.modelfile.MetaModelFile;
+import org.eclipse.esmf.aspectmodel.service.ExtensionService;
 import org.eclipse.esmf.aspectmodel.shacl.ShaclValidator;
 import org.eclipse.esmf.aspectmodel.validation.InvalidLexicalValueViolationBuilder;
 import org.eclipse.esmf.aspectmodel.validation.InvalidSyntaxViolation;
@@ -235,11 +236,15 @@ public class AspectModelValidator implements Validator {
     */
    @Override
    public ViolationReport validateModel( final Model model ) {
-      return Stream.<Supplier<RdfBasedValidator>>of(
+      final Stream<Supplier<RdfBasedValidator>> builtInValidators = Stream.of(
             () -> shaclValidator,
             ModelCycleDetector::new,
             RegularExpressionExampleValueValidator::new
-      )
+      );
+      final Stream<Supplier<RdfBasedValidator>> extensionValidators =
+            ExtensionService.getRdfBasedValidators().stream()
+                  .map( validator -> () -> validator );
+      return Stream.concat( builtInValidators, extensionValidators )
             .map( validator -> validator.get().validateModel( model ) )
             .filter( result -> !result.isEmpty() )
             .findFirst()


### PR DESCRIPTION
## Description
Addition to #1017. Enable ESMF-SDK to also load externally provided RdfBasedValidators

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
