### PR TITLE
Add a new feature to generate a random JSON payload ignoring example values

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
@@ -28,12 +28,15 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  *        for inherited entities
  * @param failOnInvalidRegularExpressions if a sample value for a regex can not be generated, fail
  *        instead of creating a fallback
+ * @param ignoreExampleValue if a random value is generated for each property,
+ *        even if an example value is defined in the Aspect Model
  */
 @RecordBuilder
 public record JsonPayloadGenerationConfig(
       Random randomStrategy,
       boolean addTypeAttributeForEntityInheritance,
-      boolean failOnInvalidRegularExpressions
+      boolean failOnInvalidRegularExpressions,
+      boolean ignoreExampleValue
 ) implements JsonGenerationConfig {
    public JsonPayloadGenerationConfig {
       if ( randomStrategy == null ) {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
@@ -97,7 +97,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
    @Override
    public Stream<JsonPayloadArtifact> generate() {
       final StructureElement element = structureElement();
-      final JsonNode json = element.accept( this, new Context() );
+      final JsonNode json = element.accept( this, new Context().doIgnoreExampleValue( config.ignoreExampleValue() ) );
       return Stream.of( new JsonPayloadArtifact( element.getName() + ".json", json ) );
    }
 
@@ -199,7 +199,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
       if ( context.ignoreExampleValue() ) {
          return property.getCharacteristic()
-               .map( c -> c.accept( this, context.doIgnoreExampleValue( false ) ) )
+               .map( c -> c.accept( this, context.doIgnoreExampleValue( config.ignoreExampleValue() ) ) )
                .orElse( null );
       } else {
          return property.getExampleValue()
@@ -245,7 +245,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
       }
       final ArrayNode result = JsonNodeFactory.instance.arrayNode( numberOfElements );
       final Context contextForSubsequentElements = context.withConstraints( List.of() );
-      final Context contextForFirstElement = contextForSubsequentElements.doIgnoreExampleValue( false );
+      final Context contextForFirstElement = contextForSubsequentElements.doIgnoreExampleValue( config.ignoreExampleValue() );
       result.add( collectionElementType.accept( this, contextForFirstElement ) );
       for ( int i = 1; i < numberOfElements; i++ ) {
          result.add( collectionElementType.accept( this, contextForSubsequentElements ) );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -231,6 +232,80 @@ class AspectModelJsonPayloadGeneratorTest {
       final TestEntityWithSimpleTypes testEntityWithSimpleTypes = aspectWithEntityCollection.getTestList().getFirst();
       assertThat( generatedJson ).contains( "[" ).contains( "]" );
       assertTestEntityWithSimpleTypes( testEntityWithSimpleTypes );
+   }
+
+   @Test
+   void testIgnoreExampleValuesInSimpleProperties() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).aspect();
+      final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
+            .randomStrategy( new Random( 0 ) )
+            .ignoreExampleValue( true )
+            .build();
+
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
+      final AspectWithSimpleProperties generatedAspect = parseJson( generatedJson, AspectWithSimpleProperties.class );
+
+      assertThat( generatedAspect.getTestString() ).isNotEqualTo( "Example Value Test" );
+      assertThat( generatedAspect.getTestInt() ).isNotEqualTo( 3 );
+      assertThat( generatedAspect.getTestFloat() ).isNotEqualTo( 2.25f );
+      assertThat( generatedAspect.getTestLocalDateTime() ).isNotEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "2018-02-28T14:23:32.918" ) );
+   }
+
+   @Test
+   void testUseExampleValuesInSimpleProperties() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).aspect();
+      final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
+            .randomStrategy( new Random( 0 ) )
+            .ignoreExampleValue( false )
+            .build();
+
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
+      final AspectWithSimpleProperties generatedAspect = parseJson( generatedJson, AspectWithSimpleProperties.class );
+
+      assertThat( generatedAspect.getTestString() ).isEqualTo( "Example Value Test" );
+      assertThat( generatedAspect.getTestInt() ).isEqualTo( 3 );
+      assertThat( generatedAspect.getTestFloat() ).isEqualTo( 2.25f );
+      assertThat( generatedAspect.getTestLocalDateTime() ).isEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "2018-02-28T14:23:32.918" ) );
+   }
+
+   @Test
+   void testIgnoreExampleValuesInNestedEntityCollection() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_ENTITY_LIST ).aspect();
+      final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
+            .randomStrategy( new Random( 0 ) )
+            .ignoreExampleValue( true )
+            .build();
+
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
+      final AspectWithEntityCollection generatedAspect = parseJson( generatedJson, AspectWithEntityCollection.class );
+      final TestEntityWithSimpleTypes generatedEntity = generatedAspect.getTestList().getFirst();
+
+      assertThat( generatedEntity.getTestString() ).isNotEqualTo( "Example Value Test" );
+      assertThat( generatedEntity.getTestInt() ).isNotEqualTo( 3 );
+      assertThat( generatedEntity.getTestFloat() ).isNotEqualTo( 2.25f );
+      assertThat( generatedEntity.getTestLocalDateTime() ).isNotEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "2018-02-28T14:23:32.918Z" ) );
+   }
+
+   @Test
+   void testUseExampleValuesInNestedEntityCollection() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_ENTITY_LIST ).aspect();
+      final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
+            .randomStrategy( new Random( 0 ) )
+            .ignoreExampleValue( false )
+            .build();
+
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
+      final AspectWithEntityCollection generatedAspect = parseJson( generatedJson, AspectWithEntityCollection.class );
+      final TestEntityWithSimpleTypes generatedEntity = generatedAspect.getTestList().getFirst();
+
+      assertThat( generatedEntity.getTestString() ).isEqualTo( "Example Value Test" );
+      assertThat( generatedEntity.getTestInt() ).isEqualTo( 3 );
+      assertThat( generatedEntity.getTestFloat() ).isEqualTo( 2.25f );
+      assertThat( generatedEntity.getTestLocalDateTime() ).isEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "2018-02-28T14:23:32.918Z" ) );
    }
 
    @Test

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -179,10 +179,12 @@ of model resolution] for more information.
                                        be generated (default: en)                                                            | `samm aspect AspectModel.ttl to asyncapi -l de`
                                    | _--separate-files, -sf_ : Create separate files for each schema                         |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
-.4+| [[aspect-to-json]] aspect <model> to json | Generate example JSON payload data for an Aspect Model                      | `samm aspect AspectModel.ttl to json`
+.5+| [[aspect-to-json]] aspect <model> to json | Generate example JSON payload data for an Aspect Model                      | `samm aspect AspectModel.ttl to json`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--add-type-attribute_, _-ta_ : Add `@type` attribute for inherited Entities            |
+                                   | _--ignore-example-value_ : Ignore example values defined in the Aspect Model and generate
+                                       random values for all Properties                                                      |
 .4+| [[aspect-to-parquet]] aspect <model> to parquet | Generate example Apache Parquet payload data for an Aspect Model      | `samm aspect AspectModel.ttl to parquet`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
@@ -39,6 +39,9 @@ public class GenerateJsonPayload extends AspectModelMojo {
    @Parameter( defaultValue = "false" )
    private boolean addTypeAttribute;
 
+   @Parameter( defaultValue = "false" )
+   private boolean ignoreExampleValue;
+
    @Override
    public void executeGeneration() throws MojoExecutionException, MojoFailureException {
       validateParameters();
@@ -47,6 +50,7 @@ public class GenerateJsonPayload extends AspectModelMojo {
       for ( final Aspect context : aspects ) {
          final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
                .addTypeAttributeForEntityInheritance( addTypeAttribute )
+               .ignoreExampleValue( ignoreExampleValue )
                .build();
          final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator( context, config );
          for ( final JsonPayloadArtifact artifact : generator.generate().toList() ) {

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
@@ -56,6 +56,11 @@ public class AspectToJsonCommand extends AbstractCommand {
             + "instead of returning an empty value." )
    private boolean failOnEmptyExampleValue = false;
 
+   @CommandLine.Option(
+      names = { "--ignore-example-value" },
+      description = "Ignore example values defined in the Aspect Model and always generate random values." )
+   private boolean ignoreExampleValue = false;
+
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
 
@@ -73,6 +78,7 @@ public class AspectToJsonCommand extends AbstractCommand {
       final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
             .addTypeAttributeForEntityInheritance( addTypeAttribute )
             .failOnInvalidRegularExpressions( failOnEmptyExampleValue )
+            .ignoreExampleValue( ignoreExampleValue )
             .build();
 
       final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator(

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -743,6 +743,25 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
+   void testAspectToJsonToStdoutIgnoringExampleValues() throws IOException {
+      final String input = inputFile( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).getAbsolutePath();
+
+      final ExecutionResult resultWithExampleValues = sammCli.runAndExpectSuccess(
+            "--disable-color", "aspect", input, "to", "json" );
+      final ExecutionResult resultIgnoringExampleValues = sammCli.runAndExpectSuccess(
+            "--disable-color", "aspect", input, "to", "json", "--ignore-example-value" );
+
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final JsonNode payloadWithExampleValues = objectMapper.readTree( resultWithExampleValues.stdout() );
+      final JsonNode payloadIgnoringExampleValues = objectMapper.readTree( resultIgnoringExampleValues.stdout() );
+
+      assertThat( payloadWithExampleValues.get( "testString" ).asText() ).isEqualTo( "Example Value Test" );
+      assertThat( payloadIgnoringExampleValues.get( "testString" ).asText() ).isNotEqualTo( "Example Value Test" );
+      assertThat( resultWithExampleValues.stderr() ).isEmpty();
+      assertThat( resultIgnoringExampleValues.stderr() ).isEmpty();
+   }
+
+   @Test
    void testAspectToJsonToStdoutWithCustomResolver() {
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "json",
             "--custom-resolver", resolverCommand() );


### PR DESCRIPTION
## Description

This PR adds a new option to `aspect to json` to generate a random payload forcefully ignoring the example values in Aspect Model, mainly for testing purpose.

Fixes #1034

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
