### PR TITLE
fix: use external reference for Operation semanticId in aas

### DIFF
--- a/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
+++ b/core/esmf-aspect-model-aas-generator/src/main/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasVisitor.java
@@ -451,10 +451,10 @@ public class AspectModelAasVisitor implements AspectVisitor<Environment, Context
 
    private Reference buildReferenceToOperation( final org.eclipse.esmf.metamodel.Operation operation ) {
       final Key key = new DefaultKey.Builder()
-            .type( KeyTypes.OPERATION )
+            .type( KeyTypes.GLOBAL_REFERENCE )
             .value( DEFAULT_MAPPER.determineIdentifierFor( operation ) )
             .build();
-      return new DefaultReference.Builder().type( ReferenceTypes.MODEL_REFERENCE ).keys( key ).build();
+      return new DefaultReference.Builder().type( ReferenceTypes.EXTERNAL_REFERENCE ).keys( key ).build();
    }
 
    private OperationVariable mapOperationVariable( final Property property, final Context context ) {

--- a/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
+++ b/core/esmf-aspect-model-aas-generator/src/test/java/org/eclipse/esmf/aspectmodel/aas/AspectModelAasGeneratorTest.java
@@ -408,6 +408,11 @@ class AspectModelAasGeneratorTest {
       final List<SubmodelElement> operations = environment.getSubmodels().getFirst().getSubmodelElements();
       final DefaultOperation operation1 = (DefaultOperation) operations.getFirst();
       assertThat( operation1.getSemanticId() ).isNotNull();
+      assertThat( operation1.getSemanticId().getType() ).isEqualTo( ReferenceTypes.EXTERNAL_REFERENCE );
+      assertThat( operation1.getSemanticId().getKeys() ).singleElement().satisfies( key -> {
+         assertThat( key.getType() ).isEqualTo( KeyTypes.GLOBAL_REFERENCE );
+         assertThat( key.getValue() ).isEqualTo( "urn:samm:org.eclipse.esmf.test:1.0.0#" + operation1.getIdShort() );
+      } );
       assertThat(
             environment.getConceptDescriptions().stream().filter( cd -> cd.getIdShort().equals( operation1.getIdShort() ) ) ).isNotNull();
 


### PR DESCRIPTION
## Description

`Operation` submodel elements generated by the AAS generator carried an invalid `semanticId`: a `ModelReference` whose first (and only) key had type `Operation`. This violates two constraints of the AAS metamodel specification (IDTA-01001):

- **AASd-121**: for `References`, `Key/type` of the first key must be one of `GloballyIdentifiables`; `Operation` is not.
- **AASd-123**: for model references, `Key/type` of the first key must be one of `AasIdentifiables` (`AssetAdministrationShell`, `ConceptDescription`, `Identifiable`, `Submodel`); `Operation` is not. Fragment keys such as `Operation` may only appear in *subsequent* keys (AASd-125/126/127).

This also made `Operation` inconsistent with every other submodel element generated from a SAMM model element (`Property`, `Aspect`, `ReferenceElement`, ...), all of which already emit an `ExternalReference` with a single `GlobalReference` key.

Fixes #998

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
