### PR TITLE
Use deterministic default timestamp and add --current-timestamp option for JSON generation

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
@@ -53,7 +53,8 @@ public record JsonPayloadGenerationConfig(
          } catch ( final IllegalArgumentException e ) {
             throw new IllegalArgumentException(
                   "Invalid timestamp format: '" + timestamp
-                        + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).", e );
+                        + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).",
+                  e );
          }
          if ( cal.getYear() == DatatypeConstants.FIELD_UNDEFINED
                || cal.getMonth() == DatatypeConstants.FIELD_UNDEFINED

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
@@ -14,9 +14,6 @@
 package org.eclipse.esmf.aspectmodel.generator.json;
 
 import java.util.Random;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerationConfig;
@@ -31,44 +28,19 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  *        for inherited entities
  * @param failOnInvalidRegularExpressions if a sample value for a regex can not be generated, fail
  *        instead of creating a fallback
- * @param timestamp custom timestamp in XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z)
- *        to use when no example value is defined. Must be a full dateTime; partial timestamps are
- *        not supported.
+ * @param currentTimestamp if set to true, generates current timestamp dynamically using
+ *        LocalDateTime.now() instead of the fixed default timestamp (start of Unix epoch).
  */
 @RecordBuilder
 public record JsonPayloadGenerationConfig(
       Random randomStrategy,
       boolean addTypeAttributeForEntityInheritance,
       boolean failOnInvalidRegularExpressions,
-      String timestamp
+      boolean currentTimestamp
 ) implements JsonGenerationConfig {
    public JsonPayloadGenerationConfig {
       if ( randomStrategy == null ) {
          randomStrategy = new Random();
-      }
-      if ( timestamp != null && !timestamp.isBlank() ) {
-         final XMLGregorianCalendar cal = parseTimestamp( timestamp );
-         if ( cal.getYear() == DatatypeConstants.FIELD_UNDEFINED
-               || cal.getMonth() == DatatypeConstants.FIELD_UNDEFINED
-               || cal.getDay() == DatatypeConstants.FIELD_UNDEFINED
-               || cal.getHour() == DatatypeConstants.FIELD_UNDEFINED
-               || cal.getMinute() == DatatypeConstants.FIELD_UNDEFINED
-               || cal.getSecond() == DatatypeConstants.FIELD_UNDEFINED ) {
-            throw new IllegalArgumentException(
-                  "Timestamp must be a full XML Schema dateTime (e.g. 2025-06-15T10:30:00.000Z). "
-                        + "Partial timestamps are not supported: '" + timestamp + "'." );
-         }
-      }
-   }
-
-   private static XMLGregorianCalendar parseTimestamp( final String timestamp ) {
-      try {
-         return DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( timestamp );
-      } catch ( final IllegalArgumentException e ) {
-         throw new IllegalArgumentException(
-               "Invalid timestamp format: '" + timestamp
-                     + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).",
-               e );
       }
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
@@ -47,15 +47,7 @@ public record JsonPayloadGenerationConfig(
          randomStrategy = new Random();
       }
       if ( timestamp != null && !timestamp.isBlank() ) {
-         final XMLGregorianCalendar cal;
-         try {
-            cal = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( timestamp );
-         } catch ( final IllegalArgumentException e ) {
-            throw new IllegalArgumentException(
-                  "Invalid timestamp format: '" + timestamp
-                        + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).",
-                  e );
-         }
+         final XMLGregorianCalendar cal = parseTimestamp( timestamp );
          if ( cal.getYear() == DatatypeConstants.FIELD_UNDEFINED
                || cal.getMonth() == DatatypeConstants.FIELD_UNDEFINED
                || cal.getDay() == DatatypeConstants.FIELD_UNDEFINED
@@ -66,6 +58,17 @@ public record JsonPayloadGenerationConfig(
                   "Timestamp must be a full XML Schema dateTime (e.g. 2025-06-15T10:30:00.000Z). "
                         + "Partial timestamps are not supported: '" + timestamp + "'." );
          }
+      }
+   }
+
+   private static XMLGregorianCalendar parseTimestamp( final String timestamp ) {
+      try {
+         return DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( timestamp );
+      } catch ( final IllegalArgumentException e ) {
+         throw new IllegalArgumentException(
+               "Invalid timestamp format: '" + timestamp
+                     + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).",
+               e );
       }
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerationConfig.java
@@ -14,6 +14,9 @@
 package org.eclipse.esmf.aspectmodel.generator.json;
 
 import java.util.Random;
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.esmf.aspectmodel.generator.GenerationConfig;
 import org.eclipse.esmf.aspectmodel.generator.JsonGenerationConfig;
@@ -28,16 +31,40 @@ import io.soabase.recordbuilder.core.RecordBuilder;
  *        for inherited entities
  * @param failOnInvalidRegularExpressions if a sample value for a regex can not be generated, fail
  *        instead of creating a fallback
+ * @param timestamp custom timestamp in XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z)
+ *        to use when no example value is defined. Must be a full dateTime; partial timestamps are
+ *        not supported.
  */
 @RecordBuilder
 public record JsonPayloadGenerationConfig(
       Random randomStrategy,
       boolean addTypeAttributeForEntityInheritance,
-      boolean failOnInvalidRegularExpressions
+      boolean failOnInvalidRegularExpressions,
+      String timestamp
 ) implements JsonGenerationConfig {
    public JsonPayloadGenerationConfig {
       if ( randomStrategy == null ) {
          randomStrategy = new Random();
+      }
+      if ( timestamp != null && !timestamp.isBlank() ) {
+         final XMLGregorianCalendar cal;
+         try {
+            cal = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( timestamp );
+         } catch ( final IllegalArgumentException e ) {
+            throw new IllegalArgumentException(
+                  "Invalid timestamp format: '" + timestamp
+                        + "'. Expected XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z).", e );
+         }
+         if ( cal.getYear() == DatatypeConstants.FIELD_UNDEFINED
+               || cal.getMonth() == DatatypeConstants.FIELD_UNDEFINED
+               || cal.getDay() == DatatypeConstants.FIELD_UNDEFINED
+               || cal.getHour() == DatatypeConstants.FIELD_UNDEFINED
+               || cal.getMinute() == DatatypeConstants.FIELD_UNDEFINED
+               || cal.getSecond() == DatatypeConstants.FIELD_UNDEFINED ) {
+            throw new IllegalArgumentException(
+                  "Timestamp must be a full XML Schema dateTime (e.g. 2025-06-15T10:30:00.000Z). "
+                        + "Partial timestamps are not supported: '" + timestamp + "'." );
+         }
       }
    }
 }

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
@@ -94,6 +94,17 @@ public class JsonPayloadGenerator<S extends StructureElement>
       this( element, DEFAULT_CONFIG );
    }
 
+   private LocalDateTime getReferenceDateTime() {
+      if ( config.timestamp() == null || config.timestamp().isBlank() ) {
+         return LocalDateTime.now();
+      }
+      final XMLGregorianCalendar cal = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( config.timestamp() );
+      return LocalDateTime.of(
+            cal.getYear(), cal.getMonth(), cal.getDay(),
+            cal.getHour(), cal.getMinute(), cal.getSecond()
+      );
+   }
+
    @Override
    public Stream<JsonPayloadArtifact> generate() {
       final StructureElement element = structureElement();
@@ -402,9 +413,9 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
    @Override
    public JsonNode visitXsdDate( final SammType.XsdDate date, final Context context ) {
-      final LocalDateTime now = LocalDateTime.now();
+      final LocalDateTime reference = getReferenceDateTime();
       final XMLGregorianCalendar calendar = DatatypeFactory.newDefaultInstance()
-            .newXMLGregorianCalendar( now.getYear(), now.getMonthValue(), now.getDayOfMonth(),
+            .newXMLGregorianCalendar( reference.getYear(), reference.getMonthValue(), reference.getDayOfMonth(),
                   DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED,
                   DatatypeConstants.FIELD_UNDEFINED, 0 );
       return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
@@ -412,20 +423,20 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
    @Override
    public JsonNode visitXsdTime( final SammType.XsdTime time, final Context context ) {
-      final LocalDateTime now = LocalDateTime.now();
+      final LocalDateTime reference = getReferenceDateTime();
       final XMLGregorianCalendar calendar = DatatypeFactory.newDefaultInstance()
             .newXMLGregorianCalendar( DatatypeConstants.FIELD_UNDEFINED, DatatypeConstants.FIELD_UNDEFINED,
                   DatatypeConstants.FIELD_UNDEFINED,
-                  now.getHour(), now.getMinute(), now.getSecond(), 0, 0 );
+                  reference.getHour(), reference.getMinute(), reference.getSecond(), 0, 0 );
       return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
    }
 
    @Override
    public JsonNode visitXsdDateTime( final SammType.@Nullable XsdDateTime dateTime, final Context context ) {
-      final LocalDateTime now = LocalDateTime.now();
+      final LocalDateTime reference = getReferenceDateTime();
       final XMLGregorianCalendar calendar = DatatypeFactory.newDefaultInstance()
-            .newXMLGregorianCalendar( now.getYear(), now.getMonthValue(), now.getDayOfMonth(),
-                  now.getHour(), now.getMinute(), now.getSecond(), 0, 0 );
+            .newXMLGregorianCalendar( reference.getYear(), reference.getMonthValue(), reference.getDayOfMonth(),
+                  reference.getHour(), reference.getMinute(), reference.getSecond(), 0, 0 );
       return JsonNodeFactory.instance.stringNode( calendar.toXMLFormat() );
    }
 
@@ -436,29 +447,29 @@ public class JsonPayloadGenerator<S extends StructureElement>
 
    @Override
    public JsonNode visitXsdGYear( final SammType.XsdGYear gYear, final Context context ) {
-      return JsonNodeFactory.instance.stringNode( "" + LocalDateTime.now().getYear() );
+      return JsonNodeFactory.instance.stringNode( "" + getReferenceDateTime().getYear() );
    }
 
    @Override
    public JsonNode visitXsdGMonth( final SammType.XsdGMonth gMonth, final Context context ) {
-      return JsonNodeFactory.instance.stringNode( "--%02d".formatted( LocalDateTime.now().getMonthValue() ) );
+      return JsonNodeFactory.instance.stringNode( "--%02d".formatted( getReferenceDateTime().getMonthValue() ) );
    }
 
    @Override
    public JsonNode visitXsdGDay( final SammType.XsdGDay gDay, final Context context ) {
-      return JsonNodeFactory.instance.stringNode( "---%02d".formatted( LocalDateTime.now().getDayOfMonth() ) );
+      return JsonNodeFactory.instance.stringNode( "---%02d".formatted( getReferenceDateTime().getDayOfMonth() ) );
    }
 
    @Override
    public JsonNode visitXsdGYearMonth( final SammType.XsdGYearMonth gYearMonth, final Context context ) {
-      final LocalDateTime now = LocalDateTime.now();
-      return JsonNodeFactory.instance.stringNode( "%04d-%02d".formatted( now.getYear(), now.getMonthValue() ) );
+      final LocalDateTime reference = getReferenceDateTime();
+      return JsonNodeFactory.instance.stringNode( "%04d-%02d".formatted( reference.getYear(), reference.getMonthValue() ) );
    }
 
    @Override
    public JsonNode visitXsdGMonthDay( final SammType.XsdMonthDay monthDay, final Context context ) {
-      final LocalDateTime now = LocalDateTime.now();
-      return JsonNodeFactory.instance.stringNode( "--%02d-%02d".formatted( now.getMonthValue(), now.getDayOfMonth() ) );
+      final LocalDateTime reference = getReferenceDateTime();
+      return JsonNodeFactory.instance.stringNode( "--%02d-%02d".formatted( reference.getMonthValue(), reference.getDayOfMonth() ) );
    }
 
    @Override

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/json/JsonPayloadGenerator.java
@@ -84,6 +84,7 @@ public class JsonPayloadGenerator<S extends StructureElement>
       extends JsonGenerator<S, JsonPayloadGenerationConfig, JsonNode, JsonPayloadArtifact>
       implements AspectVisitor<JsonNode, JsonPayloadGenerator.Context> {
    private static final Logger LOG = LoggerFactory.getLogger( JsonPayloadGenerator.class );
+   public static final LocalDateTime DEFAULT_TIMESTAMP = LocalDateTime.of( 1970, 1, 1, 0, 0, 0 );
    public static final JsonPayloadGenerationConfig DEFAULT_CONFIG = JsonPayloadGenerationConfigBuilder.builder().build();
 
    public JsonPayloadGenerator( final S element, final JsonPayloadGenerationConfig config ) {
@@ -95,14 +96,10 @@ public class JsonPayloadGenerator<S extends StructureElement>
    }
 
    private LocalDateTime getReferenceDateTime() {
-      if ( config.timestamp() == null || config.timestamp().isBlank() ) {
+      if ( config.currentTimestamp() ) {
          return LocalDateTime.now();
       }
-      final XMLGregorianCalendar cal = DatatypeFactory.newDefaultInstance().newXMLGregorianCalendar( config.timestamp() );
-      return LocalDateTime.of(
-            cal.getYear(), cal.getMonth(), cal.getDay(),
-            cal.getHour(), cal.getMinute(), cal.getSecond()
-      );
+      return DEFAULT_TIMESTAMP;
    }
 
    @Override

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -653,6 +653,48 @@ class AspectModelJsonPayloadGeneratorTest {
       assertThat( StringUtils.countMatches( generatedJson, "entity property example" ) ).isEqualTo( 2 );
    }
 
+   @Test
+   void testGenerateJsonWithDefaultTimestamp() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).aspect();
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect ).generateJson();
+
+      final AspectWithSimpleProperties parsed = parseJson( generatedJson, AspectWithSimpleProperties.class );
+
+      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isNotNull();
+   }
+
+   @Test
+   void testGenerateJsonWithCustomTimestamp() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).aspect();
+      final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
+            .timestamp( "2025-06-15T10:30:00.000Z" )
+            .build();
+
+      final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
+      final AspectWithSimpleProperties parsed = parseJson( generatedJson, AspectWithSimpleProperties.class );
+
+      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "2025-06-15T10:30:00.000Z" ) );
+   }
+
+   @Test
+   void testGenerateJsonWithInvalidTimestampThrowsException() {
+      assertThatCode( () -> JsonPayloadGenerationConfigBuilder.builder()
+            .timestamp( "not-a-timestamp" )
+            .build()
+      ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "Invalid timestamp format" );
+   }
+
+   @Test
+   void testGenerateJsonWithPartialTimestampThrowsException() {
+      assertThatCode( () -> JsonPayloadGenerationConfigBuilder.builder()
+            .timestamp( "2025-06" )
+            .build()
+      ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "Partial timestamps are not supported" );
+   }
+
    private String generateJsonForModel( final Aspect aspect ) {
       final AspectModelJsonPayloadGenerator jsonGenerator = new AspectModelJsonPayloadGenerator( aspect );
       return jsonGenerator.generateJson();

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -660,39 +660,22 @@ class AspectModelJsonPayloadGeneratorTest {
 
       final AspectWithSimpleProperties parsed = parseJson( generatedJson, AspectWithSimpleProperties.class );
 
-      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isNotNull();
+      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isEqualTo(
+            datatypeFactory.newXMLGregorianCalendar( "1970-01-01T00:00:00.000Z" ) );
    }
 
    @Test
-   void testGenerateJsonWithCustomTimestamp() {
+   void testGenerateJsonWithCurrentTimestamp() {
       final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).aspect();
       final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
-            .timestamp( "2025-06-15T10:30:00.000Z" )
+            .currentTimestamp( true )
             .build();
 
       final String generatedJson = new AspectModelJsonPayloadGenerator( aspect, config ).generateJson();
       final AspectWithSimpleProperties parsed = parseJson( generatedJson, AspectWithSimpleProperties.class );
 
-      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isEqualTo(
-            datatypeFactory.newXMLGregorianCalendar( "2025-06-15T10:30:00.000Z" ) );
-   }
-
-   @Test
-   void testGenerateJsonWithInvalidTimestampThrowsException() {
-      assertThatCode( () -> JsonPayloadGenerationConfigBuilder.builder()
-            .timestamp( "not-a-timestamp" )
-            .build()
-      ).isInstanceOf( IllegalArgumentException.class )
-            .hasMessageContaining( "Invalid timestamp format" );
-   }
-
-   @Test
-   void testGenerateJsonWithPartialTimestampThrowsException() {
-      assertThatCode( () -> JsonPayloadGenerationConfigBuilder.builder()
-            .timestamp( "2025-06" )
-            .build()
-      ).isInstanceOf( IllegalArgumentException.class )
-            .hasMessageContaining( "Partial timestamps are not supported" );
+      assertThat( parsed.getTestLocalDateTimeWithoutExample() ).isNotNull();
+      assertThat( parsed.getTestLocalDateTimeWithoutExample().getYear() ).isGreaterThanOrEqualTo( 2024 );
    }
 
    private String generateJsonForModel( final Aspect aspect ) {

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -179,10 +179,11 @@ of model resolution] for more information.
                                        be generated (default: en)                                                            | `samm aspect AspectModel.ttl to asyncapi -l de`
                                    | _--separate-files, -sf_ : Create separate files for each schema                         |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
-.4+| [[aspect-to-json]] aspect <model> to json | Generate example JSON payload data for an Aspect Model                      | `samm aspect AspectModel.ttl to json`
+.5+| [[aspect-to-json]] aspect <model> to json | Generate example JSON payload data for an Aspect Model                      | `samm aspect AspectModel.ttl to json`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--add-type-attribute_, _-ta_ : Add `@type` attribute for inherited Entities            |
+                                   | _--timestamp_ : Specifies a fixed timestamp in XML Schema dateTime format (e.g. `2025-06-15T10:30:00.000Z`) to use when no example value is defined (default: current timestamp). Partial timestamps are not supported. | `samm aspect AspectModel.ttl to json --timestamp 2025-06-15T10:30:00.000Z`
 .4+| [[aspect-to-parquet]] aspect <model> to parquet | Generate example Apache Parquet payload data for an Aspect Model      | `samm aspect AspectModel.ttl to parquet`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |

--- a/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
+++ b/documentation/developer-guide/modules/tooling-guide/pages/samm-cli.adoc
@@ -183,7 +183,7 @@ of model resolution] for more information.
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |
                                    | _--add-type-attribute_, _-ta_ : Add `@type` attribute for inherited Entities            |
-                                   | _--timestamp_ : Specifies a fixed timestamp in XML Schema dateTime format (e.g. `2025-06-15T10:30:00.000Z`) to use when no example value is defined (default: current timestamp). Partial timestamps are not supported. | `samm aspect AspectModel.ttl to json --timestamp 2025-06-15T10:30:00.000Z`
+                                   | _--current-timestamp_ : Generate current timestamp dynamically instead of using the fixed default timestamp (Unix epoch `1970-01-01T00:00:00.000Z`). | `samm aspect AspectModel.ttl to json --current-timestamp`
 .4+| [[aspect-to-parquet]] aspect <model> to parquet | Generate example Apache Parquet payload data for an Aspect Model      | `samm aspect AspectModel.ttl to parquet`
                                    | _--output, -o_ : output file path (default: stdout)                                     |
                                    | _--custom-resolver_ : use an external resolver for the resolution of the model elements |

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
@@ -39,6 +39,9 @@ public class GenerateJsonPayload extends AspectModelMojo {
    @Parameter( defaultValue = "false" )
    private boolean addTypeAttribute;
 
+   @Parameter
+   private String timestamp;
+
    @Override
    public void executeGeneration() throws MojoExecutionException, MojoFailureException {
       validateParameters();
@@ -47,6 +50,7 @@ public class GenerateJsonPayload extends AspectModelMojo {
       for ( final Aspect context : aspects ) {
          final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
                .addTypeAttributeForEntityInheritance( addTypeAttribute )
+               .timestamp( timestamp )
                .build();
          final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator( context, config );
          for ( final JsonPayloadArtifact artifact : generator.generate().toList() ) {

--- a/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
+++ b/tools/esmf-aspect-model-maven-plugin/src/main/java/org/eclipse/esmf/aspectmodel/GenerateJsonPayload.java
@@ -39,8 +39,8 @@ public class GenerateJsonPayload extends AspectModelMojo {
    @Parameter( defaultValue = "false" )
    private boolean addTypeAttribute;
 
-   @Parameter
-   private String timestamp;
+   @Parameter( defaultValue = "false" )
+   private boolean currentTimestamp;
 
    @Override
    public void executeGeneration() throws MojoExecutionException, MojoFailureException {
@@ -50,7 +50,7 @@ public class GenerateJsonPayload extends AspectModelMojo {
       for ( final Aspect context : aspects ) {
          final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
                .addTypeAttributeForEntityInheritance( addTypeAttribute )
-               .timestamp( timestamp )
+               .currentTimestamp( currentTimestamp )
                .build();
          final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator( context, config );
          for ( final JsonPayloadArtifact artifact : generator.generate().toList() ) {

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
@@ -58,10 +58,9 @@ public class AspectToJsonCommand extends AbstractCommand {
 
    @SuppressWarnings( "FieldCanBeLocal" )
    @CommandLine.Option(
-      names = { "--timestamp" },
-      description = "Specifies a fixed timestamp in XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z)"
-            + " to use when no example value is defined. Partial timestamps are not supported." )
-   private String timestamp;
+      names = { "--current-timestamp" },
+      description = "Generate current timestamp dynamically instead of using the fixed default timestamp." )
+   private boolean currentTimestamp = false;
 
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
@@ -80,7 +79,7 @@ public class AspectToJsonCommand extends AbstractCommand {
       final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
             .addTypeAttributeForEntityInheritance( addTypeAttribute )
             .failOnInvalidRegularExpressions( failOnEmptyExampleValue )
-            .timestamp( timestamp )
+            .currentTimestamp( currentTimestamp )
             .build();
 
       final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator(

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/aspect/to/AspectToJsonCommand.java
@@ -56,6 +56,13 @@ public class AspectToJsonCommand extends AbstractCommand {
             + "instead of returning an empty value." )
    private boolean failOnEmptyExampleValue = false;
 
+   @SuppressWarnings( "FieldCanBeLocal" )
+   @CommandLine.Option(
+      names = { "--timestamp" },
+      description = "Specifies a fixed timestamp in XML Schema dateTime format (e.g. 2025-06-15T10:30:00.000Z)"
+            + " to use when no example value is defined. Partial timestamps are not supported." )
+   private String timestamp;
+
    @CommandLine.ParentCommand
    private AspectToCommand parentCommand;
 
@@ -73,6 +80,7 @@ public class AspectToJsonCommand extends AbstractCommand {
       final JsonPayloadGenerationConfig config = JsonPayloadGenerationConfigBuilder.builder()
             .addTypeAttributeForEntityInheritance( addTypeAttribute )
             .failOnInvalidRegularExpressions( failOnEmptyExampleValue )
+            .timestamp( timestamp )
             .build();
 
       final AspectModelJsonPayloadGenerator generator = new AspectModelJsonPayloadGenerator(

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -751,6 +751,15 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
+   void testAspectToJsonWithCustomTimestamp() {
+      final String input = inputFile( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).getAbsolutePath();
+      final ExecutionResult result = sammCli.runAndExpectSuccess(
+            "--disable-color", "aspect", input, "to", "json", "--timestamp", "2024-05-15T10:30:00.000Z" );
+      assertThat( result.stdout() ).contains( "\"testLocalDateTimeWithoutExample\" : \"2024-05-15T10:30:00.000Z\"" );
+      assertThat( result.stderr() ).isEmpty();
+   }
+
+   @Test
    void testAspectToJsonLdToFile( @TempDir final Path outputDirectory ) {
       final File targetFile = outputFile( outputDirectory, "output.json" );
       final ExecutionResult result = sammCli.runAndExpectSuccess( "--disable-color", "aspect", defaultInputFile, "to", "jsonld", "-o",

--- a/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
+++ b/tools/samm-cli/src/test/java/org/eclipse/esmf/SammCliTest.java
@@ -751,11 +751,21 @@ class SammCliTest extends SammCliAbstractTest {
    }
 
    @Test
-   void testAspectToJsonWithCustomTimestamp() {
+   void testAspectToJsonWithDefaultTimestamp() {
       final String input = inputFile( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).getAbsolutePath();
       final ExecutionResult result = sammCli.runAndExpectSuccess(
-            "--disable-color", "aspect", input, "to", "json", "--timestamp", "2024-05-15T10:30:00.000Z" );
-      assertThat( result.stdout() ).contains( "\"testLocalDateTimeWithoutExample\" : \"2024-05-15T10:30:00.000Z\"" );
+            "--disable-color", "aspect", input, "to", "json" );
+      assertThat( result.stdout() ).contains( "\"testLocalDateTimeWithoutExample\" : \"1970-01-01T00:00:00.000Z\"" );
+      assertThat( result.stderr() ).isEmpty();
+   }
+
+   @Test
+   void testAspectToJsonWithCurrentTimestamp() {
+      final String input = inputFile( TestAspect.ASPECT_WITH_SIMPLE_PROPERTIES ).getAbsolutePath();
+      final ExecutionResult result = sammCli.runAndExpectSuccess(
+            "--disable-color", "aspect", input, "to", "json", "--current-timestamp" );
+      assertThat( result.stdout() ).contains( "\"testLocalDateTimeWithoutExample\" :" );
+      assertThat( result.stdout() ).doesNotContain( "\"testLocalDateTimeWithoutExample\" : \"1970-01-01T00:00:00.000Z\"" );
       assertThat( result.stderr() ).isEmpty();
    }
 


### PR DESCRIPTION
## Description

Makes JSON payload timestamp generation deterministic by default:
- **Default behavior**: When no `exampleValue` is defined in the model, date and time properties are generated using a fixed default timestamp (start of the Unix epoch: `1970-01-01T00:00:00.000Z`). This
ensures stable output across runs for automated tests and golden files.
- **Opt-in dynamic timestamp**: Adds a `--current-timestamp` flag (CLI, Maven plugin, and API config) to generate dynamic timestamps using `LocalDateTime.now()`.
- **Model priority**: An `exampleValue` defined in the Aspect Model always takes precedence over generated default values.


Default deterministic generation:
```bash
samm aspect AspectModel.ttl to json
```
Opt-in current timestamp:
```bash
samm aspect AspectModel.ttl to json --current-timestamp
```

Fixes #813 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
