### PR TITLE
Add example values to OpenAPI generator (#708)

### DIFF
--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/jsonschema/AspectModelJsonSchemaVisitor.java
@@ -267,6 +267,7 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
    public JsonNode visitProperty( final Property property, final ObjectNode context ) {
       final ObjectNode propertyNode = addDescription( FACTORY.objectNode(), property, config.locale() );
       addSammExtensionAttribute( propertyNode, property );
+      addExampleValue( propertyNode, property );
       final Characteristic characteristic = determineCharacteristic( property );
       final String referenceNodeName = getSchemaNameForModelElement( characteristic, property );
       if ( processedProperties.contains( property ) ) {
@@ -656,6 +657,21 @@ public class AspectModelJsonSchemaVisitor implements AspectVisitor<JsonNode, Obj
       if ( !describedElement.isAnonymous() ) {
          node.put( AspectModelJsonSchemaGenerator.SAMM_EXTENSION, describedElement.urn().toString() );
       }
+   }
+
+   private void addExampleValue( final ObjectNode node, final Property property ) {
+      if ( !config.generateForOpenApi() ) {
+         return;
+      }
+      property.getExampleValue().ifPresent( exampleValue -> {
+         final JsonNode exampleNode = exampleValue.accept( this, node );
+         final boolean isCollection = property.getEffectiveCharacteristic()
+               .map( c -> c.is( Collection.class ) )
+               .orElse( false );
+         node.set( "example", isCollection
+               ? FACTORY.arrayNode().add( exampleNode )
+               : exampleNode );
+      } );
    }
 
    private ObjectNode generateRefOrWrappedRef( final ObjectNode propertyNode, final String referenceNodeName ) {

--- a/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
+++ b/core/esmf-aspect-model-document-generators/src/main/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGenerator.java
@@ -109,6 +109,7 @@ public class AspectModelOpenApiGenerator extends JsonGenerator<Aspect, OpenApiSc
    private static final AspectModelJsonSchemaVisitor SCHEMA_VISITOR = new AspectModelJsonSchemaVisitor(
          JsonSchemaGenerationConfigBuilder.builder()
                .useExtendedTypes( false )
+               .generateForOpenApi( true )
                .build() );
    private static final AspectModelPagingGenerator PAGING_GENERATOR = new AspectModelPagingGenerator();
    private static final Logger LOG = LoggerFactory.getLogger( AspectModelOpenApiGenerator.class );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/asyncapi/AspectModelAsyncApiGeneratorTest.java
@@ -141,6 +141,7 @@ class AspectModelAsyncApiGeneratorTest {
                                           "testProperty" : {
                                             "description" : "This is a test property.",
                                             "x-samm-aspect-model-urn" : "urn:samm:org.eclipse.esmf.test:1.0.0#testProperty",
+                                            "example" : "Example Value",
                                             "allOf" : [ {
                                               "$ref" : "#/components/schemas/Text"
                                             } ]

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -1096,7 +1096,8 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( property ).isNotNull();
       assertThat( property.getExample() ).isEqualTo( "Example Value Test" );
 
-      final JsonNode propertyNode = json.get( "components" ).get( "schemas" ).get( aspect.getName() ).get( "properties" ).get( "testString" );
+      final JsonNode propertyNode = json.get( "components" ).get( "schemas" )
+            .get( aspect.getName() ).get( "properties" ).get( "testString" );
       assertThat( propertyNode.has( "example" ) ).isTrue();
       assertThat( propertyNode.get( "example" ).asString() ).isEqualTo( "Example Value Test" );
    }
@@ -1104,22 +1105,22 @@ class AspectModelOpenApiGeneratorTest {
    @Test
    void testPropertyWithCollectionExampleValue_ShouldBeArray() {
       final String ttl = """
-            @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
-            @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
-            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-            @prefix : <urn:samm:org.example.test:1.0.0#> .
+         @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+         @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+         @prefix : <urn:samm:org.example.test:1.0.0#> .
 
-            :AspectWithCollectionExample a samm:Aspect ;
-               samm:properties ( :numberList ) ;
-               samm:operations ( ) .
+         :AspectWithCollectionExample a samm:Aspect ;
+            samm:properties ( :numberList ) ;
+            samm:operations ( ) .
 
-            :numberList a samm:Property ;
-               samm:characteristic :Numbers ;
-               samm:exampleValue "42"^^xsd:int .
+         :numberList a samm:Property ;
+            samm:characteristic :Numbers ;
+            samm:exampleValue "42"^^xsd:int .
 
-            :Numbers a samm-c:List ;
-               samm:dataType xsd:int .
-            """;
+         :Numbers a samm-c:List ;
+            samm:dataType xsd:int .
+         """;
       final AspectModel aspectModel = new AspectModelLoader().load(
             new ByteArrayInputStream( ttl.getBytes( StandardCharsets.UTF_8 ) ),
             URI.create( "test:AspectWithCollectionExample.ttl" ) );
@@ -1142,7 +1143,8 @@ class AspectModelOpenApiGeneratorTest {
       assertThat( property ).isNotNull();
       assertThat( property.getExample() ).hasToString( "[42]" );
 
-      final JsonNode propertyNode = json.get( "components" ).get( "schemas" ).get( aspect.getName() ).get( "properties" ).get( "numberList" );
+      final JsonNode propertyNode = json.get( "components" ).get( "schemas" )
+            .get( aspect.getName() ).get( "properties" ).get( "numberList" );
       assertThat( propertyNode.has( "example" ) ).isTrue();
       assertThat( propertyNode.get( "example" ).isArray() ).isTrue();
       assertThat( propertyNode.get( "example" ).get( 0 ).asInt() ).isEqualTo( 42 );

--- a/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
+++ b/core/esmf-aspect-model-document-generators/src/test/java/org/eclipse/esmf/aspectmodel/generator/openapi/AspectModelOpenApiGeneratorTest.java
@@ -17,8 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -28,7 +30,9 @@ import java.util.Map;
 
 import org.eclipse.esmf.aspectmodel.generator.AbstractSchemaArtifact;
 import org.eclipse.esmf.aspectmodel.generator.jsonschema.AspectModelJsonSchemaGenerator;
+import org.eclipse.esmf.aspectmodel.loader.AspectModelLoader;
 import org.eclipse.esmf.metamodel.Aspect;
+import org.eclipse.esmf.metamodel.AspectModel;
 import org.eclipse.esmf.metamodel.Property;
 import org.eclipse.esmf.test.TestAspect;
 import org.eclipse.esmf.test.TestResources;
@@ -1069,6 +1073,107 @@ class AspectModelOpenApiGeneratorTest {
                   .isEqualTo( "#/components/schemas/PagingSchema" );
 
       assertThat( openApi.getComponents().getSchemas() ).containsKey( "AspectWithProperty" );
+   }
+
+   @Test
+   void testPropertyWithExampleValue_ShouldContainExampleInPropertySchema() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_ENGLISH_DESCRIPTION ).aspect();
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .useSemanticVersion( true )
+            .baseUrl( TEST_BASE_URL )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .locale( Locale.ENGLISH )
+            .build();
+
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
+      final OpenAPI openApi = result.getOpenAPI();
+
+      final Schema<?> schema = openApi.getComponents().getSchemas().get( aspect.getName() );
+      assertThat( schema ).isNotNull();
+
+      final Schema<?> property = (Schema<?>) schema.getProperties().get( "testString" );
+      assertThat( property ).isNotNull();
+      assertThat( property.getExample() ).isEqualTo( "Example Value Test" );
+
+      final JsonNode propertyNode = json.get( "components" ).get( "schemas" ).get( aspect.getName() ).get( "properties" ).get( "testString" );
+      assertThat( propertyNode.has( "example" ) ).isTrue();
+      assertThat( propertyNode.get( "example" ).asString() ).isEqualTo( "Example Value Test" );
+   }
+
+   @Test
+   void testPropertyWithCollectionExampleValue_ShouldBeArray() {
+      final String ttl = """
+            @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+            @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            @prefix : <urn:samm:org.example.test:1.0.0#> .
+
+            :AspectWithCollectionExample a samm:Aspect ;
+               samm:properties ( :numberList ) ;
+               samm:operations ( ) .
+
+            :numberList a samm:Property ;
+               samm:characteristic :Numbers ;
+               samm:exampleValue "42"^^xsd:int .
+
+            :Numbers a samm-c:List ;
+               samm:dataType xsd:int .
+            """;
+      final AspectModel aspectModel = new AspectModelLoader().load(
+            new ByteArrayInputStream( ttl.getBytes( StandardCharsets.UTF_8 ) ),
+            URI.create( "test:AspectWithCollectionExample.ttl" ) );
+      final Aspect aspect = aspectModel.aspect();
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .useSemanticVersion( true )
+            .baseUrl( TEST_BASE_URL )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .locale( Locale.ENGLISH )
+            .build();
+
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final SwaggerParseResult result = new OpenAPIParser().readContents( json.toString(), null, null );
+      final OpenAPI openApi = result.getOpenAPI();
+
+      final Schema<?> schema = openApi.getComponents().getSchemas().get( aspect.getName() );
+      assertThat( schema ).isNotNull();
+
+      final Schema<?> property = (Schema<?>) schema.getProperties().get( "numberList" );
+      assertThat( property ).isNotNull();
+      assertThat( property.getExample() ).hasToString( "[42]" );
+
+      final JsonNode propertyNode = json.get( "components" ).get( "schemas" ).get( aspect.getName() ).get( "properties" ).get( "numberList" );
+      assertThat( propertyNode.has( "example" ) ).isTrue();
+      assertThat( propertyNode.get( "example" ).isArray() ).isTrue();
+      assertThat( propertyNode.get( "example" ).get( 0 ).asInt() ).isEqualTo( 42 );
+   }
+
+   @Test
+   void testOperationWithExampleValue_ShouldContainExampleInParams() {
+      final Aspect aspect = TestResources.load( TestAspect.ASPECT_WITH_SCRIPT_TAGS ).aspect();
+      final OpenApiSchemaGenerationConfig config = OpenApiSchemaGenerationConfigBuilder.builder()
+            .useSemanticVersion( true )
+            .baseUrl( TEST_BASE_URL )
+            .resourcePath( TEST_RESOURCE_PATH )
+            .locale( Locale.ENGLISH )
+            .build();
+
+      final JsonNode json = new AspectModelOpenApiGenerator( aspect, config ).getContent();
+      final JsonNode paramsProperties = json.get( "components" )
+            .get( "schemas" )
+            .get( "Operation" )
+            .get( "allOf" )
+            .get( 1 )
+            .get( "properties" )
+            .get( "params" )
+            .get( "properties" );
+      assertThat( paramsProperties ).isNotNull();
+
+      final JsonNode inputProp = paramsProperties.get( "operationInput" );
+      assertThat( inputProp ).isNotNull();
+      assertThat( inputProp.has( "example" ) ).isTrue();
+      assertThat( inputProp.get( "example" ).asString() )
+            .isEqualTo( "Example operation input <script>alert('Should not be alerted');</script>" );
    }
 
    private void assertSpecificationIsValid( final JsonNode jsonNode, final String json, final Aspect aspect ) throws IOException {


### PR DESCRIPTION
## Description

Add support for `samm:exampleValue` in OpenAPI and AsyncAPI property schemas.

Fixes #708 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works