### PR TITLE
Implement parser lifecycle management and enhance concurrency safety

### DIFF
--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TreeSitterTurtleParserService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TreeSitterTurtleParserService.java
@@ -16,6 +16,7 @@ package org.eclipse.esmf.turtle.languageserver.lsp.text;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.function.Function;
 
@@ -36,10 +37,11 @@ import org.treesitter.TSTree;
  * Service for parsing Turtle documents using Tree-sitter and maintaining their syntax trees.
  * Supports incremental parsing for efficient updates when documents change.
  */
-public class TreeSitterTurtleParserService implements Function<Document, ParsedDocument> {
+public class TreeSitterTurtleParserService implements Function<Document, ParsedDocument>, AutoCloseable {
    private final TSParser parser;
    private final Map<Document, TSTree> syntaxTrees = new HashMap<>();
    private final Map<Document, Rope> previousDocumentStates = new WeakHashMap<>();
+   private boolean closed;
 
    public TreeSitterTurtleParserService() {
       TurtleLoader.init();
@@ -49,8 +51,24 @@ public class TreeSitterTurtleParserService implements Function<Document, ParsedD
    }
 
    @Override
-   public ParsedDocument apply( final Document document ) {
+   public synchronized ParsedDocument apply( final Document document ) {
+      ensureOpen();
       return new ParsedDocument( document, syntaxTrees.computeIfAbsent( document, this::parseDocument ) );
+   }
+
+   public synchronized <T> T withParsedDocument( final Document document,
+         final Function<ParsedDocument, T> operation ) {
+      return operation.apply( apply( document ) );
+   }
+
+   public synchronized <T> Optional<T> withExistingParsedDocument( final Document document,
+         final Function<ParsedDocument, T> operation ) {
+      ensureOpen();
+      final TSTree tree = syntaxTrees.get( document );
+      if ( tree == null ) {
+         return Optional.empty();
+      }
+      return Optional.of( operation.apply( new ParsedDocument( document, tree ) ) );
    }
 
    private TSTree parseDocument( final Document document ) {
@@ -112,32 +130,70 @@ public class TreeSitterTurtleParserService implements Function<Document, ParsedD
       }
    }
 
-   public void onOpen( final Document document ) {
-      syntaxTrees.put( document, parseDocument( document ) );
+   public synchronized void onOpen( final Document document ) {
+      ensureOpen();
+      replaceTree( document, parseDocument( document ) );
    }
 
-   public void onChange( final Document document, final TextDocumentContentChangeEvent changeEvent ) {
+   public synchronized void onChange( final Document document, final TextDocumentContentChangeEvent changeEvent ) {
+      ensureOpen();
       final TSTree oldTree = syntaxTrees.get( document );
       if ( oldTree == null ) {
-         syntaxTrees.put( document, parseDocument( document ) );
+         replaceTree( document, parseDocument( document ) );
          return;
       }
 
       final Rope oldRope = previousDocumentStates.get( document );
       if ( oldRope == null ) {
-         syntaxTrees.put( document, parseDocument( document ) );
+         replaceTree( document, parseDocument( document ) );
          return;
       }
 
       final TSInputEdit edit = treeChangeFromLspChange( oldRope, changeEvent );
       if ( edit == null ) {
-         syntaxTrees.put( document, parseDocument( document ) );
+         replaceTree( document, parseDocument( document ) );
          return;
       }
 
       oldTree.edit( edit );
       final TSTree newTree = parser.parseString( oldTree, document.content() );
-      syntaxTrees.put( document, newTree );
+      replaceTree( document, newTree );
       previousDocumentStates.put( document, document.rope() );
+   }
+
+   public synchronized void remove( final Document document ) {
+      closeTree( syntaxTrees.remove( document ) );
+      previousDocumentStates.remove( document );
+   }
+
+   @Override
+   public synchronized void close() {
+      if ( closed ) {
+         return;
+      }
+      closed = true;
+      syntaxTrees.values().forEach( TreeSitterTurtleParserService::closeTree );
+      syntaxTrees.clear();
+      previousDocumentStates.clear();
+      parser.close();
+   }
+
+   private void replaceTree( final Document document, final TSTree newTree ) {
+      final TSTree replacedTree = syntaxTrees.put( document, newTree );
+      if ( replacedTree != newTree ) {
+         closeTree( replacedTree );
+      }
+   }
+
+   private static void closeTree( final @Nullable TSTree tree ) {
+      if ( tree != null ) {
+         tree.close();
+      }
+   }
+
+   private void ensureOpen() {
+      if ( closed ) {
+         throw new IllegalStateException( "Parser service is closed" );
+      }
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentService.java
@@ -22,19 +22,22 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.esmf.aspectmodel.ViolationReport;
 import org.eclipse.esmf.turtle.languageserver.aspect.navigation.AspectCrossFileDefinitionService;
 import org.eclipse.esmf.turtle.languageserver.lsp.ResolutionStrategyService;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.DiagnosticMapper;
-import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.ViolationProvider;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.ResolutionStrategyAwareViolationProvider;
+import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.ViolationProvider;
 import org.eclipse.esmf.turtle.languageserver.structure.DocumentSymbolService;
 import org.eclipse.esmf.turtle.languageserver.structure.TurtleTokenService;
 import org.eclipse.esmf.turtle.languageserver.turtle.TurtleCompletionService;
 import org.eclipse.esmf.turtle.languageserver.turtle.ValidationCoordinator;
 import org.eclipse.esmf.turtle.languageserver.turtle.navigation.TurtleDefinitionService;
 
+import com.google.common.collect.Streams;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
@@ -57,8 +60,6 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Streams;
-
 public class TurtleTextDocumentService implements TextDocumentService {
    private static final Logger LOG = LoggerFactory.getLogger( TurtleTextDocumentService.class );
 
@@ -78,6 +79,7 @@ public class TurtleTextDocumentService implements TextDocumentService {
             t.setDaemon( true );
             return t;
          } );
+   private final AtomicBoolean closed = new AtomicBoolean();
 
    public TurtleTextDocumentService() {
       clientNotifier = new TextDocumentClientNotifier( new DiagnosticMapper() );
@@ -94,7 +96,7 @@ public class TurtleTextDocumentService implements TextDocumentService {
             aware.setResolutionStrategyService( resolutionStrategyService );
          }
       } );
-      validationCoordinator = new ValidationCoordinator( violationProviders, clientNotifier::publishDiagnostics );
+      validationCoordinator = new ValidationCoordinator( violationProviders, clientNotifier::publishDiagnostics, turtleParserService );
    }
 
    public void connect( final LanguageClient client ) {
@@ -106,8 +108,20 @@ public class TurtleTextDocumentService implements TextDocumentService {
    }
 
    public void shutdown() {
+      if ( !closed.compareAndSet( false, true ) ) {
+         return;
+      }
       validationCoordinator.close();
-      asyncExecutor.shutdown();
+      asyncExecutor.shutdownNow();
+      try {
+         if ( !asyncExecutor.awaitTermination( 5, TimeUnit.SECONDS ) ) {
+            LOG.warn( "Timed out waiting for language-server request workers to stop" );
+         }
+      } catch ( final InterruptedException exception ) {
+         Thread.currentThread().interrupt();
+      }
+      documents.clear();
+      turtleParserService.close();
    }
 
    public CompletableFuture<ViolationReport> validateDocument( final String uri ) {
@@ -155,6 +169,7 @@ public class TurtleTextDocumentService implements TextDocumentService {
       final Document document = documents.remove( uri );
       if ( document != null ) {
          validationCoordinator.onDocumentClosed( document );
+         turtleParserService.remove( document );
       }
    }
 
@@ -181,8 +196,8 @@ public class TurtleTextDocumentService implements TextDocumentService {
       if ( document == null ) {
          return CompletableFuture.completedFuture( new SemanticTokens( List.of() ) );
       }
-      final ParsedDocument parsedDocument = turtleParserService.apply( document );
-      return CompletableFuture.supplyAsync( () -> tokenService.buildSemanticTokens( parsedDocument ), asyncExecutor );
+      return CompletableFuture.supplyAsync(
+            () -> turtleParserService.withParsedDocument( document, tokenService::buildSemanticTokens ), asyncExecutor );
    }
 
    @Override
@@ -194,17 +209,18 @@ public class TurtleTextDocumentService implements TextDocumentService {
       }
 
       return CompletableFuture.supplyAsync( () -> {
-         final ParsedDocument parsedDocument = turtleParserService.apply( document );
-         Optional<Location> declaration = turtleDefinitionService.findDefinition( parsedDocument, params.getPosition() );
+         return turtleParserService.withParsedDocument( document, parsedDocument -> {
+            Optional<Location> declaration = turtleDefinitionService.findDefinition( parsedDocument, params.getPosition() );
 
-         if ( declaration.isEmpty() && aspectCrossFileDefinitionService != null ) {
-            declaration = aspectCrossFileDefinitionService.findDefinition( parsedDocument, params.getPosition() );
-         }
+            if ( declaration.isEmpty() && aspectCrossFileDefinitionService != null ) {
+               declaration = aspectCrossFileDefinitionService.findDefinition( parsedDocument, params.getPosition() );
+            }
 
-         return declaration
-               .<Either<List<? extends Location>, List<? extends LocationLink>>>map(
-                     location -> Either.forLeft( List.of( location ) ) )
-               .orElseGet( () -> Either.forLeft( List.of() ) );
+            return declaration
+                  .<Either<List<? extends Location>, List<? extends LocationLink>>>map(
+                        location -> Either.forLeft( List.of( location ) ) )
+                  .orElseGet( () -> Either.forLeft( List.of() ) );
+         } );
       }, asyncExecutor );
    }
 
@@ -216,8 +232,9 @@ public class TurtleTextDocumentService implements TextDocumentService {
       if ( document == null ) {
          return CompletableFuture.completedFuture( List.of() );
       }
-      return CompletableFuture.supplyAsync( () -> documentSymbolService.symbols( document ).stream()
-            .map( Either::<SymbolInformation, DocumentSymbol>forRight ).toList(),
+      return CompletableFuture.supplyAsync( () -> turtleParserService.withParsedDocument( document,
+            parsedDocument -> documentSymbolService.symbols( parsedDocument ).stream()
+                  .map( Either::<SymbolInformation, DocumentSymbol>forRight ).toList() ),
             asyncExecutor );
    }
 
@@ -229,8 +246,8 @@ public class TurtleTextDocumentService implements TextDocumentService {
          return CompletableFuture.completedFuture( Either.forLeft( List.of() ) );
       }
       return CompletableFuture.supplyAsync( () -> {
-         final ParsedDocument parsedDocument = turtleParserService.apply( document );
-         return Either.forLeft( turtleCompletionService.complete( parsedDocument, position ) );
+         return turtleParserService.withParsedDocument( document,
+               parsedDocument -> Either.forLeft( turtleCompletionService.complete( parsedDocument, position ) ) );
       }, asyncExecutor );
    }
 }

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/DocumentSymbolService.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/structure/DocumentSymbolService.java
@@ -39,7 +39,10 @@ public class DocumentSymbolService extends TurtleService {
    }
 
    public List<DocumentSymbol> symbols( final Document document ) {
-      final ParsedDocument parsedDocument = parserService.apply( document );
+      return parserService.withParsedDocument( document, this::symbols );
+   }
+
+   public List<DocumentSymbol> symbols( final ParsedDocument parsedDocument ) {
       final TurtleSyntaxTree turtleSyntaxTree = parsedDocument.turtleSyntaxTree();
       final List<DocumentSymbol> symbols = new ArrayList<>();
 

--- a/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/ValidationCoordinator.java
+++ b/core/esmf-turtle-language-server/src/main/java/org/eclipse/esmf/turtle/languageserver/turtle/ValidationCoordinator.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
@@ -33,6 +34,7 @@ import org.eclipse.esmf.aspectmodel.validation.ProcessingViolationBuilder;
 import org.eclipse.esmf.turtle.languageserver.lsp.diagnostic.ViolationProvider;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.Document;
 import org.eclipse.esmf.turtle.languageserver.lsp.text.ParsedDocument;
+import org.eclipse.esmf.turtle.languageserver.lsp.text.TreeSitterTurtleParserService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +47,9 @@ public class ValidationCoordinator implements AutoCloseable {
    private final BiConsumer<Document, ViolationReport> onValidationComplete;
    private final ExecutorService executorService;
    private final ScheduledExecutorService scheduler;
+   private final Object parserLock;
+   private final TreeSitterTurtleParserService parserService;
+   private final AtomicBoolean closed = new AtomicBoolean();
 
    private final Map<Document, CompletableFuture<?>> runningValidations = new ConcurrentHashMap<>();
    private final Map<Document, ScheduledFuture<?>> scheduledValidations = new ConcurrentHashMap<>();
@@ -54,14 +59,33 @@ public class ValidationCoordinator implements AutoCloseable {
    public ValidationCoordinator(
          final List<ViolationProvider> violationProviders,
          final BiConsumer<Document, ViolationReport> onValidationComplete ) {
+      this( violationProviders, onValidationComplete, null );
+   }
+
+   public ValidationCoordinator(
+         final List<ViolationProvider> violationProviders,
+         final BiConsumer<Document, ViolationReport> onValidationComplete,
+         final TreeSitterTurtleParserService parserService ) {
       this.violationProviders = violationProviders;
       this.onValidationComplete = onValidationComplete;
+      this.parserService = parserService;
+      parserLock = parserService == null ? new Object() : parserService;
       executorService = Executors.newSingleThreadExecutor( Thread.ofPlatform().name( "semantic-models-validation-", 0 ).factory() );
       scheduler = Executors.newSingleThreadScheduledExecutor(
             Thread.ofPlatform().name( "semantic-models-validation-debounce-", 0 ).factory() );
    }
 
    private ViolationReport validateFast( final ParsedDocument parsedDocument ) {
+      if ( parserService != null ) {
+         return parserService.withExistingParsedDocument( parsedDocument.sourceDocument(), this::validateFastForCurrentDocument )
+               .orElse( ViolationReport.EMPTY );
+      }
+      synchronized ( parserLock ) {
+         return validateFastForCurrentDocument( parsedDocument );
+      }
+   }
+
+   private ViolationReport validateFastForCurrentDocument( final ParsedDocument parsedDocument ) {
       final ViolationReport result = violationProviders.stream()
             .filter( provider -> provider.type().equals( ViolationProvider.Type.FAST ) )
             .map( provider -> executeViolationProvider( provider, parsedDocument ) )
@@ -96,14 +120,20 @@ public class ValidationCoordinator implements AutoCloseable {
       cancelScheduledValidation( document );
       cancelRunningValidation( document );
       generations.remove( document );
+      fastValidationResults.remove( document );
    }
 
    @Override
    public void close() {
+      if ( !closed.compareAndSet( false, true ) ) {
+         return;
+      }
       scheduledValidations.values().forEach( f -> f.cancel( false ) );
       scheduledValidations.clear();
       runningValidations.values().forEach( f -> f.cancel( true ) );
       runningValidations.clear();
+      generations.clear();
+      fastValidationResults.clear();
       scheduler.shutdownNow();
       executorService.shutdownNow();
    }
@@ -183,6 +213,16 @@ public class ValidationCoordinator implements AutoCloseable {
    }
 
    private ViolationReport validateDelayed( final ParsedDocument parsedDocument ) {
+      if ( parserService != null ) {
+         return parserService.withExistingParsedDocument( parsedDocument.sourceDocument(), this::validateDelayedForCurrentDocument )
+               .orElse( ViolationReport.EMPTY );
+      }
+      synchronized ( parserLock ) {
+         return validateDelayedForCurrentDocument( parsedDocument );
+      }
+   }
+
+   private ViolationReport validateDelayedForCurrentDocument( final ParsedDocument parsedDocument ) {
       return violationProviders.stream()
             .filter( provider -> provider.type().equals( ViolationProvider.Type.DELAYED ) )
             .map( provider -> executeViolationProvider( provider, parsedDocument ) )

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleParserServiceTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleParserServiceTest.java
@@ -352,6 +352,7 @@ class TurtleParserServiceTest {
       final String initialContent = "ex:subject ex:predicate ex:object.";
       final Document document = new Document( "test.ttl", initialContent );
       final TSTree oldTree = parserService.apply( document ).concreteSyntaxTree();
+      final String oldTreeRepresentation = oldTree.getRootNode().toString();
       final Range range = new Range( pos( 0, 33 ), pos( 0, 33 ) );
       final TextDocumentContentChangeEvent change = new TextDocumentContentChangeEvent( range, " " );
       document.update( range, " " );
@@ -360,7 +361,7 @@ class TurtleParserServiceTest {
       final TSTree tree = parserService.apply( document ).concreteSyntaxTree();
       assertThat( tree.getRootNode().hasError() ).isFalse();
       assertThat( document.content() ).endsWith( "object ." );
-      assertThat( oldTree.getRootNode().toString() ).isEqualTo( tree.getRootNode().toString() );
+      assertThat( oldTreeRepresentation ).isEqualTo( tree.getRootNode().toString() );
    }
 
    void printDocumentAndTree( final Document document, final TSTree tree ) {

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentServiceLifecycleTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentServiceLifecycleTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package org.eclipse.esmf.turtle.languageserver.lsp.text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.esmf.turtle.languageserver.turtle.ValidationCoordinator;
+
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.jupiter.api.Test;
+
+class TurtleTextDocumentServiceLifecycleTest {
+   private static final int OPEN_CLOSE_CYCLES = 25;
+   private static final String URI = "file:///tmp/lifecycle-test.ttl";
+   private static final String CONTENT = """
+      @prefix ex: <http://example.org/> .
+
+      ex:subject ex:predicate ex:object .
+      """;
+
+   @Test
+   void repeatedOpenCloseReturnsAllDocumentOwnedStateToBaseline() throws ReflectiveOperationException {
+      final TurtleTextDocumentService service = new TurtleTextDocumentService();
+      try {
+         for ( int cycle = 1; cycle <= OPEN_CLOSE_CYCLES; cycle++ ) {
+            service.didOpen( new DidOpenTextDocumentParams( new TextDocumentItem( URI, "turtle", cycle, CONTENT ) ) );
+            service.didClose( new DidCloseTextDocumentParams( new TextDocumentIdentifier( URI ) ) );
+         }
+
+         final TreeSitterTurtleParserService parserService = field( service, "turtleParserService" );
+         final ValidationCoordinator validationCoordinator = field( service, "validationCoordinator" );
+         final List<Integer> retainedStateSizes = List.of(
+               mapField( service, "documents" ).size(),
+               mapField( parserService, "syntaxTrees" ).size(),
+               mapField( parserService, "previousDocumentStates" ).size(),
+               mapField( validationCoordinator, "fastValidationResults" ).size(),
+               mapField( validationCoordinator, "generations" ).size(),
+               mapField( validationCoordinator, "scheduledValidations" ).size(),
+               mapField( validationCoordinator, "runningValidations" ).size() );
+
+         assertThat( retainedStateSizes )
+               .as( "retained [documents, syntax trees, ropes, fast reports, generations, scheduled, running] after %s cycles",
+                     OPEN_CLOSE_CYCLES )
+               .containsExactly( 0, 0, 0, 0, 0, 0, 0 );
+      } finally {
+         service.shutdown();
+      }
+   }
+
+   @Test
+   void concurrentParserChangesPreserveAValidTree() throws Exception {
+      final TreeSitterTurtleParserService parserService = new TreeSitterTurtleParserService();
+      final Document document = new Document( URI, CONTENT );
+      parserService.onOpen( document );
+      final ExecutorService workers = Executors.newFixedThreadPool( 2 );
+      try {
+         for ( int iteration = 0; iteration < 100; iteration++ ) {
+            final CyclicBarrier barrier = new CyclicBarrier( 2 );
+            final Future<?> first = workers.submit( () -> changeAtBarrier( parserService, document, barrier ) );
+            final Future<?> second = workers.submit( () -> changeAtBarrier( parserService, document, barrier ) );
+            first.get( 5, TimeUnit.SECONDS );
+            second.get( 5, TimeUnit.SECONDS );
+            assertThat( parserService.apply( document ).concreteSyntaxTree().getRootNode().hasError() ).isFalse();
+         }
+      } finally {
+         workers.shutdownNow();
+      }
+   }
+
+   @Test
+   void ownedServiceShutdownReleasesAllDocumentResources() throws ReflectiveOperationException {
+      final TurtleTextDocumentService service = new TurtleTextDocumentService();
+      service.didOpen( new DidOpenTextDocumentParams( new TextDocumentItem( URI, "turtle", 1, CONTENT ) ) );
+      service.shutdown();
+
+      final TreeSitterTurtleParserService parserService = field( service, "turtleParserService" );
+      final ValidationCoordinator validationCoordinator = field( service, "validationCoordinator" );
+      assertThat( List.of(
+            mapField( service, "documents" ).size(),
+            mapField( parserService, "syntaxTrees" ).size(),
+            mapField( parserService, "previousDocumentStates" ).size(),
+            mapField( validationCoordinator, "fastValidationResults" ).size() ) )
+                  .as( "retained [documents, syntax trees, ropes, fast reports] after owned service shutdown" )
+                  .containsExactly( 0, 0, 0, 0 );
+   }
+
+   private static void changeAtBarrier( final TreeSitterTurtleParserService parserService, final Document document,
+         final CyclicBarrier barrier ) {
+      try {
+         barrier.await( 5, TimeUnit.SECONDS );
+         parserService.onChange( document, new TextDocumentContentChangeEvent( CONTENT ) );
+      } catch ( final Exception exception ) {
+         throw new IllegalStateException( exception );
+      }
+   }
+
+   @SuppressWarnings( "unchecked" )
+   private static Map<Object, Object> mapField( final Object target, final String name ) throws ReflectiveOperationException {
+      return (Map<Object, Object>) field( target, name );
+   }
+
+   @SuppressWarnings( "unchecked" )
+   private static <T> T field( final Object target, final String name ) throws ReflectiveOperationException {
+      final Field field = target.getClass().getDeclaredField( name );
+      field.setAccessible( true );
+      return (T) field.get( target );
+   }
+}

--- a/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentServiceLifecycleTest.java
+++ b/core/esmf-turtle-language-server/src/test/java/org/eclipse/esmf/turtle/languageserver/lsp/text/TurtleTextDocumentServiceLifecycleTest.java
@@ -72,7 +72,7 @@ class TurtleTextDocumentServiceLifecycleTest {
    }
 
    @Test
-   void concurrentParserChangesPreserveAValidTree() throws Exception {
+   void concurrentParserChangesPreserveValidTree() throws Exception {
       final TreeSitterTurtleParserService parserService = new TreeSitterTurtleParserService();
       final Document document = new Document( URI, CONTENT );
       parserService.onOpen( document );

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/LoggingMixin.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/LoggingMixin.java
@@ -66,6 +66,16 @@ public class LoggingMixin {
 
    public void configureLoggers() {
       final Level level = getTopLevelCommandLoggingMixin( mixee ).calcLogLevel();
+      configureLoggers( level );
+   }
+
+   public void ensureLspDiagnostics() {
+      if ( getTopLevelCommandLoggingMixin( mixee ).calcLogLevel() == Level.OFF ) {
+         configureLoggers( Level.ERROR );
+      }
+   }
+
+   private void configureLoggers( final Level level ) {
       final LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
       final Logger root = loggerContext.getLogger( Logger.ROOT_LOGGER_NAME );
       root.detachAndStopAllAppenders();

--- a/tools/samm-cli/src/main/java/org/eclipse/esmf/lsp/LspCommand.java
+++ b/tools/samm-cli/src/main/java/org/eclipse/esmf/lsp/LspCommand.java
@@ -47,6 +47,7 @@ public class LspCommand extends AbstractCommand {
 
    @Override
    public void run() {
+      loggingMixin.ensureLspDiagnostics();
       if ( useStdio ) {
          TurtleLanguageServer.launchForStdio();
          return;


### PR DESCRIPTION
## Description

Fixes stability issues in the Turtle/SAMM Language Server caused by unsafe native Tree-sitter lifecycle handling.

Changes include:

- Serialize access to shared native `TSParser`/`TSTree` state used by asynchronous LSP requests.
- Release parser, syntax-tree, rope, and validation state when documents are closed or the service shuts down.
- Make document-service and validation cleanup idempotent.
- Add default ERROR-level diagnostics for `samm lsp` without enabling verbose logging for unrelated CLI commands.
- Add lifecycle and concurrency regression tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
